### PR TITLE
[zutils] F: Add requirements file parser and hello-zlib example

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,10 @@ python -m pytest tests/test_log.py::TestInfo::test_basic  # single test
 pip install -e .
 ```
 
+## Validation
+
+After making code changes, always validate by invoking the `/validate` skill. This runs the full test suite and pre-push checks (formatting + type checking) in a single step.
+
 ## Architecture
 
 ### Module Dependency Graph

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@
 name: Release
 
 on:
-    create:
     push:
         branches: ["release-*"]
     workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ examples/**/*.elf
 venv/
 .nanvix/venv/
 
-# Nanvix build artifacts (downloaded sysroot, cache, config)
+# Nanvix build artifacts (downloaded sysroot, buildroot, cache, config)
 **/.nanvix/sysroot/
+**/.nanvix/buildroot/
 **/.nanvix/cache/
 **/.nanvix/env.json
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ Then invoke via the bootstrap wrapper at the repo root:
 ./z test
 ```
 
-## Example
+## Examples
 
-See [`examples/hello-world/`](examples/hello-world/) for a complete runnable
-example that builds a trivial C project using `ZScript`.
+- [`examples/hello-world/`](examples/hello-world/) — builds a trivial C project
+  using `ZScript`.
+- [`examples/hello-zlib/`](examples/hello-zlib/) — downloads zlib via
+  `nanvix-requirements.txt` and cross-compiles a program that uses it.
 
 ## Developer Setup
 

--- a/examples/hello-world/.nanvix/nanvix-requirements.txt
+++ b/examples/hello-world/.nanvix/nanvix-requirements.txt
@@ -1,0 +1,2 @@
+# Nanvix sysroot
+nanvix@latest

--- a/examples/hello-world/.nanvix/z.py
+++ b/examples/hello-world/.nanvix/z.py
@@ -11,13 +11,11 @@ Demonstrates the full lifecycle with a real Nanvix build:
     ./z clean      # remove build artifacts
 """
 
-from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TAG, CFG_TOOLCHAIN, EXIT_MISSING_DEP, Sysroot, ZScript, log
+from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TOOLCHAIN, Sysroot, ZScript
 
 
 class HelloWorld(ZScript):
     """Build script for the hello-world C example."""
-
-    NANVIX_TAG = "latest"
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
@@ -41,15 +39,11 @@ class HelloWorld(ZScript):
 
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
-        tag = self.config.get(CFG_TAG, self.NANVIX_TAG)
-        if not tag:
-            log.fatal(f"{CFG_TAG} is not set.", code=EXIT_MISSING_DEP)
-
         sysroot = Sysroot.download(
             machine=self.config.machine,
             deployment_mode=self.config.deployment_mode,
             memory_size=self.config.memory_size,
-            tag=tag,
+            tag=self.requirements.sysroot_tag,
             gh_token=self.config.get(CFG_GH_TOKEN),
         )
         sysroot.verify(self.sysroot_required_files())

--- a/examples/hello-world/.nanvix/z.py
+++ b/examples/hello-world/.nanvix/z.py
@@ -52,7 +52,7 @@ class HelloWorld(ZScript):
             tag=tag,
             gh_token=self.config.get(CFG_GH_TOKEN),
         )
-        sysroot.verify(list(self.SYSROOT_REQUIRED_FILES))
+        sysroot.verify(self.sysroot_required_files())
         self.config.set(CFG_SYSROOT, str(sysroot.path))
         self.config.save()
 

--- a/examples/hello-zlib/.nanvix/nanvix-requirements.txt
+++ b/examples/hello-zlib/.nanvix/nanvix-requirements.txt
@@ -1,0 +1,5 @@
+# Nanvix sysroot
+nanvix@fa06b88
+
+# Build dependencies
+zlib@b7a6a3c

--- a/examples/hello-zlib/.nanvix/z.py
+++ b/examples/hello-zlib/.nanvix/z.py
@@ -1,0 +1,100 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Hello-zlib example — cross-compiles a C program that uses zlib for Nanvix.
+
+Demonstrates dependency downloading with nanvix-requirements.txt:
+
+    ./z setup      # download sysroot + zlib
+    ./z build      # cross-compile hello-zlib.c → hello-zlib.elf
+    ./z test       # run tests (smoke + integration + functional)
+    ./z clean      # remove build artifacts
+"""
+
+from nanvix_zutil import (
+    CFG_GH_TOKEN,
+    CFG_SYSROOT,
+    CFG_TOOLCHAIN,
+    Buildroot,
+    Sysroot,
+    ZScript,
+    load_requirements,
+    log,
+)
+
+
+class HelloZlib(ZScript):
+    """Build script for the hello-zlib C example."""
+
+    def _make_args(self, *targets: str) -> list[str]:
+        """Build the common make argument list."""
+        sysroot = self.config.get(CFG_SYSROOT, "")
+        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
+        buildroot_path = str(self.nanvix_dir / "buildroot")
+
+        args = [
+            "make",
+            "-f",
+            "Makefile.nanvix",
+            "CONFIG_NANVIX=y",
+            f"NANVIX_HOME={sysroot}",
+            f"NANVIX_TOOLCHAIN={toolchain}",
+            f"BUILDROOT={buildroot_path}",
+            f"PLATFORM={self.config.machine}",
+            f"PROCESS_MODE={self.config.deployment_mode}",
+            f"MEMORY_SIZE={self.config.memory_size}",
+        ]
+
+        args.extend(targets)
+        return args
+
+    def setup(self) -> None:
+        """Download the Nanvix sysroot and zlib dependency."""
+        reqs = load_requirements(self.repo_root / "nanvix-requirements.txt")
+
+        # Download sysroot.
+        sysroot = Sysroot.download(
+            machine=self.config.machine,
+            deployment_mode=self.config.deployment_mode,
+            memory_size=self.config.memory_size,
+            tag=reqs.sysroot_tag,
+            gh_token=self.config.get(CFG_GH_TOKEN),
+        )
+        sysroot.verify(self.sysroot_required_files())
+        self.config.set(CFG_SYSROOT, str(sysroot.path))
+
+        # Download build dependencies.
+        buildroot = Buildroot.create(self.nanvix_dir / "buildroot")
+        for dep in reqs.dependencies:
+            buildroot.install_dep(
+                dep=dep,
+                machine=self.config.machine,
+                deployment_mode=self.config.deployment_mode,
+                memory_size=self.config.memory_size,
+                gh_token=self.config.get(CFG_GH_TOKEN),
+            )
+        buildroot.verify(["libz.a"])
+
+        self.config.save()
+
+    def build(self) -> None:
+        """Cross-compile hello-zlib.c into hello-zlib.elf for Nanvix."""
+        self.run(*self._make_args("all"), cwd=self.repo_root)
+
+    def test(self) -> None:
+        """Run the test suite (smoke + integration + functional)."""
+        self.run(*self._make_args("test"), cwd=self.repo_root)
+
+    def clean(self) -> None:
+        """Remove build artifacts."""
+        self.run(
+            "make",
+            "-f",
+            "Makefile.nanvix",
+            "clean",
+            cwd=self.repo_root,
+        )
+
+
+if __name__ == "__main__":
+    HelloZlib.main()

--- a/examples/hello-zlib/Makefile.nanvix
+++ b/examples/hello-zlib/Makefile.nanvix
@@ -1,0 +1,169 @@
+# Makefile.nanvix - hello-zlib cross-compilation for Nanvix
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Targets:
+#   all              Build hello-zlib.elf
+#   test-smoke       Verify build artifact exists
+#   test-integration Verify ELF binary is valid
+#   test-functional  Run on nanvixd.elf (requires KVM)
+#   test             Run all test levels
+#   clean            Remove build artifacts
+
+# ===========================================================================
+# Toolchain Detection
+# ===========================================================================
+
+NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+
+ifdef CONFIG_NANVIX
+  NANVIX_TOOLCHAIN ?= /opt/nanvix
+  NANVIX_HOME ?= $(HOME)/nanvix
+  BUILDROOT ?= .nanvix/buildroot
+
+  ifndef CONFIG_NANVIX_DOCKER
+    ifeq ($(wildcard $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc),)
+      DOCKER_AVAILABLE := $(shell command -v docker 2>/dev/null)
+      ifdef DOCKER_AVAILABLE
+        DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
+        ifdef DOCKER_IMAGE_EXISTS
+          CONFIG_NANVIX_DOCKER := y
+          $(info [nanvix] Using Docker (native toolchain not found at $(NANVIX_TOOLCHAIN)))
+        else
+          $(error Docker image $(NANVIX_DOCKER_IMAGE) not found. Run: docker pull $(NANVIX_DOCKER_IMAGE))
+        endif
+      else
+        $(error Nanvix toolchain not found at $(NANVIX_TOOLCHAIN) and Docker not available)
+      endif
+    endif
+  else
+    DOCKER_AVAILABLE := $(shell command -v docker 2>/dev/null)
+    ifndef DOCKER_AVAILABLE
+      $(error CONFIG_NANVIX_DOCKER=y but Docker is not installed)
+    endif
+    DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
+    ifndef DOCKER_IMAGE_EXISTS
+      $(error Docker image $(NANVIX_DOCKER_IMAGE) not found. Run: docker pull $(NANVIX_DOCKER_IMAGE))
+    endif
+    $(info [nanvix] Using Docker (explicitly requested))
+  endif
+
+  EXE = .elf
+  SYSROOT_PATH := $(abspath $(NANVIX_HOME))
+  BUILDROOT_PATH := $(abspath $(BUILDROOT))
+
+  ifdef CONFIG_NANVIX_DOCKER
+    DOCKER_TOOLCHAIN_PATH := /opt/nanvix
+    DOCKER_SYSROOT_PATH := /mnt/sysroot
+    DOCKER_BUILDROOT_PATH := /mnt/buildroot
+    DOCKER_WORKSPACE_PATH := /mnt/workspace
+    DOCKER_UID := $(shell id -u)
+    DOCKER_GID := $(shell id -g)
+    DOCKER_RUN := docker run --rm --user $(DOCKER_UID):$(DOCKER_GID) \
+      -v $(CURDIR):$(DOCKER_WORKSPACE_PATH) \
+      -v $(SYSROOT_PATH):$(DOCKER_SYSROOT_PATH):ro \
+      -v $(BUILDROOT_PATH):$(DOCKER_BUILDROOT_PATH):ro \
+      -w $(DOCKER_WORKSPACE_PATH) \
+      -e HOME=/tmp \
+      $(NANVIX_DOCKER_IMAGE)
+    DOCKER_KVM_GID := $(shell stat -c '%g' /dev/kvm 2>/dev/null || echo 0)
+    DOCKER_RUN_FUNCTIONAL := docker run --rm --device /dev/kvm \
+      --user $(DOCKER_UID):$(DOCKER_GID) --group-add $(DOCKER_KVM_GID) \
+      -v $(CURDIR):$(DOCKER_WORKSPACE_PATH) \
+      -v $(SYSROOT_PATH):$(DOCKER_SYSROOT_PATH) \
+      -v $(BUILDROOT_PATH):$(DOCKER_BUILDROOT_PATH):ro \
+      -w $(DOCKER_SYSROOT_PATH) \
+      -e HOME=/tmp \
+      -e USER=$(shell whoami) \
+      $(NANVIX_DOCKER_IMAGE)
+    CC := $(DOCKER_RUN) $(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-gcc
+    NANVIX_CFLAGS := -I$(DOCKER_BUILDROOT_PATH)/include
+    NANVIX_LDFLAGS := -T$(DOCKER_SYSROOT_PATH)/lib/user.ld -static -Wl,-z,noexecstack
+    NANVIX_LIBS := -Wl,--start-group \
+      $(DOCKER_BUILDROOT_PATH)/lib/libz.a \
+      $(DOCKER_SYSROOT_PATH)/lib/libposix.a \
+      $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libc.a \
+      $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libm.a \
+      -Wl,--end-group
+  else
+    CC := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc
+    NANVIX_CFLAGS := -I$(BUILDROOT_PATH)/include
+    NANVIX_LDFLAGS := -T$(SYSROOT_PATH)/lib/user.ld -static -Wl,-z,noexecstack
+    NANVIX_LIBS := -Wl,--start-group \
+      $(BUILDROOT_PATH)/lib/libz.a \
+      $(SYSROOT_PATH)/lib/libposix.a \
+      $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a \
+      $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a \
+      -Wl,--end-group
+  endif
+else
+  ifneq ($(MAKECMDGOALS),clean)
+    $(error CONFIG_NANVIX must be set to 'y'. Usage: make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/sysroot)
+  endif
+  EXE = .elf
+endif
+
+# ===========================================================================
+# Build Configuration
+# ===========================================================================
+
+CFLAGS = -O2 -Wall -msse2 -mfpmath=sse $(NANVIX_CFLAGS)
+BINARY = hello-zlib$(EXE)
+
+# ===========================================================================
+# Build Targets
+# ===========================================================================
+
+all: $(BINARY)
+
+hello-zlib.o: src/hello-zlib.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(BINARY): hello-zlib.o
+	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ $< $(NANVIX_LIBS)
+
+# ===========================================================================
+# Test Targets
+# ===========================================================================
+
+test-smoke: $(BINARY)
+	@echo "=== hello-zlib smoke tests ==="
+	@test -f $(BINARY) || { echo "  FAIL: $(BINARY) not found"; exit 1; }
+	@size=$$(wc -c < $(BINARY)); \
+	  if [ "$$size" -lt 1000 ]; then echo "  FAIL: $(BINARY) too small ($$size bytes)"; exit 1; fi
+	@echo "  OK: $(BINARY) ($$(wc -c < $(BINARY)) bytes)"
+	@echo "  PASS: hello-zlib smoke tests"
+
+test-integration: $(BINARY)
+	@echo "=== hello-zlib integration tests ==="
+	@head -c 4 $(BINARY) | od -A n -t x1 | grep -q "7f 45 4c 46" || \
+	  { echo "  FAIL: $(BINARY) is not an ELF binary"; exit 1; }
+	@echo "  OK: $(BINARY) is a valid ELF binary"
+	@echo "  PASS: hello-zlib integration tests"
+
+test-functional: test-integration
+	@echo "=== hello-zlib functional tests ==="
+ifdef CONFIG_NANVIX_DOCKER
+	@echo "  Running hello-zlib$(EXE) via nanvixd.elf (Docker)..."
+	$(DOCKER_RUN_FUNCTIONAL) sh -c \
+	  'timeout --foreground 60 ./bin/nanvixd.elf -- $(DOCKER_WORKSPACE_PATH)/hello-zlib$(EXE)'
+	@echo "  PASS: hello-zlib ran successfully"
+else
+	@echo "  Running hello-zlib$(EXE) via nanvixd.elf..."
+	cd "$(SYSROOT_PATH)" && timeout --foreground 60 ./bin/nanvixd.elf -- $(abspath $(BINARY))
+	@echo "  PASS: hello-zlib ran successfully"
+endif
+	@echo "  PASS: hello-zlib functional tests"
+
+test: test-smoke test-integration test-functional
+	@echo "=== All hello-zlib tests PASSED ==="
+
+# ===========================================================================
+# Clean
+# ===========================================================================
+
+clean:
+	rm -f *.o $(BINARY)
+
+.PHONY: all clean test test-smoke test-integration test-functional

--- a/examples/hello-zlib/README.md
+++ b/examples/hello-zlib/README.md
@@ -1,0 +1,58 @@
+# hello-zlib — Nanvix Dependency Download Example
+
+A minimal C program that uses [zlib](https://github.com/nanvix/zlib) to
+compress and decompress a string, demonstrating how `nanvix-requirements.txt`
+manages build-time dependencies.
+
+## Structure
+
+```
+hello-zlib/
+├── .nanvix/
+│   └── z.py                    # HelloZlib(ZScript) — lifecycle hooks
+├── nanvix-requirements.txt     # Declarative dependencies
+├── Makefile.nanvix             # Cross-compilation rules
+├── src/
+│   └── hello-zlib.c            # Compress / decompress round-trip
+├── z                           # Bash bootstrap
+├── z.ps1                       # PowerShell bootstrap
+└── README.md
+```
+
+## Prerequisites
+
+- **Python 3.12+**
+- **Nanvix cross-compiler** — one of:
+  - Native install at `/opt/nanvix/` (or `$NANVIX_TOOLCHAIN`)
+  - Docker image `nanvix/toolchain:latest-minimal`
+- **KVM** (`/dev/kvm`) — for functional tests only
+
+## Usage
+
+```bash
+./z setup      # Download sysroot + zlib
+./z build      # Cross-compile hello-zlib.c → hello-zlib.elf
+./z test       # Run smoke, integration, and functional tests
+./z clean      # Remove build artifacts
+```
+
+## How It Works
+
+1. `./z setup` parses `nanvix-requirements.txt`, which declares:
+   - `nanvix@latest` — the Nanvix sysroot (downloaded via `Sysroot.download()`)
+   - `zlib@b7a6a3c-nanvix-fa06b88` — the zlib library (downloaded via `Buildroot.install_dep()`)
+
+2. `./z build` cross-compiles `src/hello-zlib.c` with `-I.nanvix/buildroot/include`
+   and links against `.nanvix/buildroot/lib/libz.a`.
+
+3. `./z test` runs the binary on the Nanvix microkernel via `nanvixd.elf`.
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NANVIX_MACHINE` | `hyperlight` | Target machine |
+| `NANVIX_DEPLOYMENT_MODE` | `multi-process` | Deployment mode |
+| `NANVIX_MEMORY_SIZE` | `128mb` | Memory size |
+| `NANVIX_TOOLCHAIN` | `/opt/nanvix` | Toolchain path |
+| `GH_TOKEN` | *(none)* | GitHub token for API rate limits |

--- a/examples/hello-zlib/nanvix-requirements.txt
+++ b/examples/hello-zlib/nanvix-requirements.txt
@@ -1,0 +1,5 @@
+# Nanvix sysroot
+nanvix@latest
+
+# Build dependencies
+zlib@b7a6a3c-nanvix-fa06b88

--- a/examples/hello-zlib/nanvix-requirements.txt
+++ b/examples/hello-zlib/nanvix-requirements.txt
@@ -1,5 +1,0 @@
-# Nanvix sysroot
-nanvix@latest
-
-# Build dependencies
-zlib@b7a6a3c-nanvix-fa06b88

--- a/examples/hello-zlib/src/hello-zlib.c
+++ b/examples/hello-zlib/src/hello-zlib.c
@@ -1,0 +1,44 @@
+/* Copyright(c) The Maintainers of Nanvix. */
+/* Licensed under the MIT License. */
+
+#include <stdio.h>
+#include <string.h>
+#include <zlib.h>
+
+int main(void)
+{
+    const char *original = "Hello from Nanvix with zlib!";
+    unsigned long src_len = (unsigned long)strlen(original) + 1;
+
+    /* Compress. */
+    unsigned long comp_len = compressBound(src_len);
+    unsigned char compressed[256];
+    int rc = compress(compressed, &comp_len, (const unsigned char *)original, src_len);
+    if (rc != Z_OK) {
+        printf("compress() failed: %d\n", rc);
+        return 1;
+    }
+
+    /* Decompress. */
+    unsigned char decompressed[256];
+    unsigned long decomp_len = sizeof(decompressed);
+    rc = uncompress(decompressed, &decomp_len, compressed, comp_len);
+    if (rc != Z_OK) {
+        printf("uncompress() failed: %d\n", rc);
+        return 1;
+    }
+
+    /* Verify round-trip. */
+    if (decomp_len != src_len || memcmp(original, decompressed, src_len) != 0) {
+        printf("Round-trip mismatch!\n");
+        return 1;
+    }
+
+    printf("zlib version: %s\n", zlibVersion());
+    printf("Original:     %s (%lu bytes)\n", original, src_len);
+    printf("Compressed:   %lu bytes\n", comp_len);
+    printf("Decompressed: %s (%lu bytes)\n", (char *)decompressed, decomp_len);
+    printf("Round-trip OK!\n");
+
+    return 0;
+}

--- a/examples/hello-zlib/z
+++ b/examples/hello-zlib/z
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Bootstrap wrapper for Nanvix build scripts.
+# Modeled on https://github.com/rust-lang/rust/blob/main/x
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+# Minimum required Python version.
+MIN_PYTHON_MAJOR=3
+MIN_PYTHON_MINOR=12
+
+# Locate a suitable Python interpreter.
+find_python() {
+    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
+    # then fall back to generic names.
+    local candidates=()
+    local minor
+    for ((minor=20; minor>=MIN_PYTHON_MINOR; minor--)); do
+        candidates+=("python3.${minor}")
+    done
+    candidates+=("python3" "python" "py")
+    for candidate in "${candidates[@]}"; do
+        if command -v "${candidate}" &>/dev/null; then
+            local version
+            if [[ "${candidate}" == "py" ]]; then
+                version=$("${candidate}" -3 -c \
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
+                    2>/dev/null) || continue
+            else
+                version=$("${candidate}" -c \
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
+                    2>/dev/null) || continue
+            fi
+            local major minor
+            major=$(echo "${version}" | tr -d '\r' | cut -d. -f1)
+            minor=$(echo "${version}" | tr -d '\r' | cut -d. -f2)
+            if [[ "${major}" -gt "${MIN_PYTHON_MAJOR}" ]] || \
+               [[ "${major}" -eq "${MIN_PYTHON_MAJOR}" && "${minor}" -ge "${MIN_PYTHON_MINOR}" ]]; then
+                echo "${candidate}"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+# Run the discovered Python interpreter (handles 'py -3' on Windows).
+run_python() {
+    if [[ "${PYTHON}" == "py" ]]; then
+        "${PYTHON}" -3 "$@"
+    else
+        "${PYTHON}" "$@"
+    fi
+}
+
+PYTHON=$(find_python) || {
+    echo "error: Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ not found in PATH." >&2
+    echo "hint:  Install Python 3.12+ and ensure it is on your PATH." >&2
+    exit 3
+}
+
+# Resolve the directory containing this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
+VENV_DIR="${SCRIPT_DIR}/.nanvix/venv"
+
+# Detect venv interpreter path (Scripts/python.exe on Windows/MSYS).
+if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
+    VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
+else
+    VENV_PYTHON="${VENV_DIR}/bin/python"
+fi
+
+# This example lives inside the zutils source tree.
+ZUTILS_SRC="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [[ ! -f "${Z_SCRIPT}" ]]; then
+    echo "error: ${Z_SCRIPT} not found." >&2
+    echo "hint:  Create .nanvix/z.py with a ZScript subclass." >&2
+    exit 3
+fi
+
+# Bootstrap: create venv and install nanvix-zutil from local source.
+if [[ ! -f "${VENV_PYTHON}" ]]; then
+    echo "bootstrap: creating venv …" >&2
+    run_python -m venv "${VENV_DIR}"
+
+    # Re-detect after venv creation.
+    if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
+        VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
+    fi
+
+    echo "bootstrap: installing nanvix-zutil (editable) …" >&2
+    "${VENV_PYTHON}" -m pip install -q -e "${ZUTILS_SRC}"
+fi
+
+exec "${VENV_PYTHON}" "${Z_SCRIPT}" "$@"

--- a/examples/hello-zlib/z.ps1
+++ b/examples/hello-zlib/z.ps1
@@ -1,0 +1,102 @@
+# Bootstrap wrapper for Nanvix build scripts.
+# Modeled on https://github.com/rust-lang/rust/blob/main/x.ps1
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# If script execution is disabled, run:
+#   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$MIN_MAJOR = 3
+$MIN_MINOR = 12
+
+function Find-Python {
+    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
+    # then fall back to generic names.
+    $candidates = @()
+    for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
+        $candidates += "python3.$minor"
+    }
+    $candidates += @("python3", "python")
+    foreach ($candidate in $candidates) {
+        $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -eq $cmd) { continue }
+
+        try {
+            $version = & $candidate -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+            if ($LASTEXITCODE -ne 0) { continue }
+            $parts = $version.Trim().Split(".")
+            $major = [int]$parts[0]
+            $minor = [int]$parts[1]
+            if ($major -gt $MIN_MAJOR -or ($major -eq $MIN_MAJOR -and $minor -ge $MIN_MINOR)) {
+                return $candidate
+            }
+        } catch {
+            continue
+        }
+    }
+
+    # Windows 'py' launcher: probe specific minor versions (high to low).
+    $pyCmd = Get-Command "py" -ErrorAction SilentlyContinue
+    if ($null -ne $pyCmd) {
+        for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
+            try {
+                $exe = & py "-3.$minor" -c "import sys; print(sys.executable)" 2>$null
+                if ($LASTEXITCODE -eq 0 -and $exe) {
+                    return $exe.Trim()
+                }
+            } catch {
+                continue
+            }
+        }
+    }
+
+    return $null
+}
+
+# Run the discovered Python interpreter.
+function Invoke-Python {
+    param([Parameter(ValueFromRemainingArguments)] [string[]]$Args_)
+    & $python @Args_
+}
+
+$python = Find-Python
+if ($null -eq $python) {
+    Write-Warning "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH."
+    Write-Host "hint:  Install Python 3.12+ and ensure it is on your PATH." -ForegroundColor Yellow
+    exit 3
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$zScript = Join-Path $scriptDir ".nanvix" "z.py"
+$venvDir = Join-Path $scriptDir ".nanvix" "venv"
+if ($IsWindows) {
+    $venvPython = Join-Path $venvDir "Scripts" "python.exe"
+} else {
+    $venvPython = Join-Path $venvDir "bin" "python"
+}
+
+# This example lives inside the zutils source tree.
+$zutilsSrc = Split-Path -Parent (Split-Path -Parent $scriptDir)
+
+if (-not (Test-Path $zScript)) {
+    Write-Warning "error: $zScript not found."
+    Write-Host "hint:  Create .nanvix/z.py with a ZScript subclass." -ForegroundColor Yellow
+    exit 3
+}
+
+# Bootstrap: create venv and install nanvix-zutil from local source.
+if (-not (Test-Path $venvPython)) {
+    Write-Host "bootstrap: creating venv …" -ForegroundColor Cyan
+    Invoke-Python -m venv $venvDir
+    Write-Host "bootstrap: installing nanvix-zutil (editable) …" -ForegroundColor Cyan
+    & $venvPython -m pip install -q -e $zutilsSrc
+}
+
+& $venvPython $zScript @args
+exit $LASTEXITCODE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanvix-zutil"
-version = "0.2.0"
+version = "0.2.1"
 description = "Build orchestration utilities for the Nanvix ecosystem"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanvix-zutil"
-version = "0.2.1"
+version = "0.2.2"
 description = "Build orchestration utilities for the Nanvix ecosystem"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -10,6 +10,9 @@ Public re-exports:
 - :class:`~nanvix_zutil.buildroot.Buildroot` — build-time dependency root
 - :class:`~nanvix_zutil.buildroot.Dependency` — library dependency descriptor
 - :class:`~nanvix_zutil.sysroot.Sysroot` — runtime sysroot management
+- :class:`~nanvix_zutil.requirements.Requirements` — parsed dependency file
+- :func:`~nanvix_zutil.requirements.load_requirements` — parse nanvix-requirements.txt
+- :func:`~nanvix_zutil.github.find_release_tag` — find release tag by suffix
 - :mod:`nanvix_zutil.log` — structured logging helpers
 """
 
@@ -30,6 +33,8 @@ from nanvix_zutil.exitcodes import (
     EXIT_SUCCESS,
     EXIT_TEST_FAILURE,
 )
+from nanvix_zutil.github import find_release_tag
+from nanvix_zutil.requirements import Requirements, load_requirements
 from nanvix_zutil.script import ZScript
 from nanvix_zutil.sysroot import Sysroot
 
@@ -48,6 +53,9 @@ __all__ = [
     "EXIT_NETWORK_ERROR",
     "EXIT_SUCCESS",
     "EXIT_TEST_FAILURE",
+    "Requirements",
     "Sysroot",
     "ZScript",
+    "find_release_tag",
+    "load_requirements",
 ]

--- a/src/nanvix_zutil/github.py
+++ b/src/nanvix_zutil/github.py
@@ -97,7 +97,10 @@ def download_release_asset(
             log.info(f"Asset already present: {out_path}")
             return out_path
 
-    url = f"{_GITHUB_API_BASE}/repos/{repo}/releases/tags/{tag}"
+    if tag == "latest":
+        url = f"{_GITHUB_API_BASE}/repos/{repo}/releases/latest"
+    else:
+        url = f"{_GITHUB_API_BASE}/repos/{repo}/releases/tags/{tag}"
     headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
     if gh_token:
         headers["Authorization"] = f"Bearer {gh_token}"
@@ -209,3 +212,61 @@ def download_release_asset(
 
     # Unreachable — log.fatal exits. Satisfy type checker.
     return out_path  # pragma: no cover
+
+
+def find_release_tag(
+    repo: str,
+    suffix: str,
+    gh_token: str | None = None,
+) -> str | None:
+    """Find a release tag ending with *suffix* in *repo*.
+
+    Queries ``GET /repos/{repo}/releases`` and returns the first tag name
+    whose value ends with *suffix*.  Returns ``None`` when no release
+    matches.
+
+    Args:
+        repo: Repository in ``owner/name`` format (e.g. ``"nanvix/zlib"``).
+        suffix: The suffix to match against release tag names
+            (e.g. ``"nanvix-fa06b88"``).
+        gh_token: Optional GitHub personal access token.
+
+    Returns:
+        The matching tag name, or ``None`` if no release tag ends with
+        *suffix*.
+    """
+    url = f"{_GITHUB_API_BASE}/repos/{repo}/releases"
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    if gh_token:
+        headers["Authorization"] = f"Bearer {gh_token}"
+
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+                raw: object = json.loads(resp.read())
+                if not isinstance(raw, list):
+                    log.fatal(
+                        f"Unexpected response from GitHub API for {repo} releases",
+                        code=EXIT_NETWORK_ERROR,
+                    )
+                releases = cast(list[object], raw)
+                for release in releases:
+                    if not isinstance(release, dict):
+                        continue
+                    tag = cast(dict[str, object], release).get("tag_name")
+                    if isinstance(tag, str) and tag.endswith(suffix):
+                        return tag
+                return None
+        except urllib.error.URLError as exc:
+            if attempt == _MAX_RETRIES:
+                log.fatal(
+                    f"Failed to list releases for {repo}: {exc}",
+                    code=EXIT_NETWORK_ERROR,
+                    hint="Check your network connection or set GH_TOKEN.",
+                )
+            wait = _BACKOFF_BASE**attempt
+            log.warning(f"Attempt {attempt} failed; retrying in {wait:.0f}s…")
+            time.sleep(wait)
+
+    return None  # pragma: no cover

--- a/src/nanvix_zutil/requirements.py
+++ b/src/nanvix_zutil/requirements.py
@@ -1,0 +1,163 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Declarative dependency file parser for ``nanvix-requirements.txt``.
+
+Parses a simple text format where each non-blank, non-comment line is
+either ``name`` or ``name@tag``.  When ``@tag`` is omitted the tag
+defaults to ``"latest"``.  Environment variables ``NANVIX_VERSION``
+(for the sysroot) and ``NANVIX_VERSION_<NAME>`` (for each dependency)
+override whatever tag the file specifies.
+
+The entry ``nanvix`` is **mandatory** and requires an explicit ``@tag``
+(e.g. ``nanvix@latest`` or ``nanvix@<hash>``); all other entries become
+:class:`~nanvix_zutil.buildroot.Dependency` objects under the
+``nanvix/`` GitHub organisation.
+
+Dependency tags that are not ``"latest"`` are automatically suffixed with
+``-nanvix-{sysroot_tag}`` so that consumers only need to specify the
+library version (e.g. ``zlib@b7a6a3c`` instead of
+``zlib@b7a6a3c-nanvix-fa06b88``).  Tags that already contain
+``-nanvix-`` are rejected to prevent accidental duplication.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from nanvix_zutil import log
+from nanvix_zutil.buildroot import Dependency
+from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_MISSING_DEP
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Requirements:
+    """Parsed contents of a ``nanvix-requirements.txt`` file.
+
+    Attributes:
+        sysroot_tag: Tag for the ``nanvix`` sysroot entry.
+        dependencies: Non-sysroot entries as :class:`Dependency` objects.
+    """
+
+    sysroot_tag: str
+    dependencies: list[Dependency] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_requirements(path: Path) -> Requirements:
+    """Parse a ``nanvix-requirements.txt`` file.
+
+    Each non-blank, non-comment line is ``name`` or ``name@tag``.  When
+    ``@tag`` is omitted the tag defaults to ``"latest"``.  Environment
+    variables ``NANVIX_VERSION`` (sysroot) and ``NANVIX_VERSION_<NAME>``
+    (dependencies) take precedence over file-specified tags.
+
+    The ``nanvix`` entry is mandatory and maps to the sysroot tag; all
+    other entries become :class:`Dependency` objects.  Duplicate names
+    are resolved as last-wins.
+
+    Dependency tags that are not ``"latest"`` are automatically suffixed
+    with ``-nanvix-{sysroot_tag}``.  Tags that already contain
+    ``-nanvix-`` are rejected.
+
+    Args:
+        path: Path to the requirements file.
+
+    Returns:
+        A :class:`Requirements` instance.
+
+    Raises:
+        SystemExit: With exit code ``3`` if the file does not exist, or
+            exit code ``2`` if the ``nanvix`` entry is missing.
+    """
+    if not path.is_file():
+        log.fatal(
+            f"Required file not found: {path}",
+            code=EXIT_MISSING_DEP,
+            hint="Create a nanvix-requirements.txt in the .nanvix/ directory.",
+        )
+
+    text = path.read_text(encoding="utf-8")
+
+    sysroot_tag: str | None = None
+    seen: dict[str, Dependency] = {}
+
+    for raw_line in text.splitlines():
+        # Strip inline comments.
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+
+        if "@" in line:
+            name, tag = line.split("@", 1)
+            name = name.strip()
+            tag = tag.strip()
+            if not name:
+                log.fatal(
+                    f"{path}: empty dependency name in '{raw_line.strip()}'",
+                    code=EXIT_INVALID_ARGS,
+                    hint="Each line must be 'name' or 'name@tag'.",
+                )
+            if not tag:
+                log.fatal(
+                    f"{path}: empty tag for '{name}' in '{raw_line.strip()}'",
+                    code=EXIT_INVALID_ARGS,
+                    hint="Either remove the '@' to default to 'latest',"
+                    " or specify a tag (e.g. 'latest' or a commit hash).",
+                )
+        else:
+            name = line
+            tag = "latest"
+
+        if name == "nanvix":
+            if tag == "latest" and "@" not in line:
+                log.fatal(
+                    f"{path}: 'nanvix' entry requires an explicit tag"
+                    " (e.g. 'nanvix@latest' or 'nanvix@<hash>')",
+                    code=EXIT_INVALID_ARGS,
+                    hint="Write 'nanvix@latest' for the latest release,"
+                    " or 'nanvix@<hash>' to pin a specific build.",
+                )
+            sysroot_tag = os.environ.get("NANVIX_VERSION", tag)
+            continue
+
+        env_key = f"NANVIX_VERSION_{name.upper()}"
+        tag = os.environ.get(env_key, tag)
+
+        if "-nanvix-" in tag:
+            log.fatal(
+                f"{path}: dependency '{name}' must not include the nanvix"
+                f" version in its tag (got '{tag}')",
+                code=EXIT_INVALID_ARGS,
+                hint=f"Use '{name}@{tag.split('-nanvix-')[0]}' — the nanvix"
+                " version is derived automatically from the 'nanvix' entry.",
+            )
+
+        dep = Dependency(name=name, repo=f"nanvix/{name}", tag=tag)
+        seen[name] = dep
+
+    if sysroot_tag is None:
+        log.fatal(
+            f"{path}: missing mandatory 'nanvix' entry",
+            code=EXIT_INVALID_ARGS,
+            hint="Add a 'nanvix' line to the requirements file.",
+        )
+
+    # Auto-suffix dependency tags with the nanvix version so that
+    # consumers write e.g. ``zlib@b7a6a3c`` instead of the full
+    # ``zlib@b7a6a3c-nanvix-fa06b88``.
+    for dep in seen.values():
+        if dep.tag != "latest":
+            dep.tag = f"{dep.tag}-nanvix-{sysroot_tag}"
+
+    return Requirements(sysroot_tag=sysroot_tag, dependencies=list(seen.values()))

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -45,6 +45,9 @@ class ZScript:
             ``.nanvix/env.json`` and environment variables.
         repo_root: Absolute path to the consumer repository root.
         nanvix_dir: Absolute path to the ``.nanvix/`` directory.
+        targets: Arguments passed after ``--`` on the command line.
+            Lifecycle hooks can use these to customise behavior
+            (e.g. ``./z test -- smoke integration``).
     """
 
     SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
@@ -82,6 +85,7 @@ class ZScript:
         self.repo_root = repo_root.resolve()
         self.nanvix_dir = self.repo_root / ".nanvix"
         self.config = Config(self.nanvix_dir)
+        self.targets: list[str] = []
 
     # ------------------------------------------------------------------
     # Lifecycle hooks — override in subclass
@@ -180,7 +184,18 @@ class ZScript:
         location of the calling script (``sys.argv[0]``).
         """
         parser = build_parser()
-        args = parser.parse_args()
+
+        # Split sys.argv on '--' to separate framework args from targets.
+        argv = sys.argv[1:]
+        if "--" in argv:
+            sep = argv.index("--")
+            framework_argv = argv[:sep]
+            targets = argv[sep + 1:]
+        else:
+            framework_argv = argv
+            targets = []
+
+        args = parser.parse_args(framework_argv)
 
         if args.json:
             log.set_json_mode(True)
@@ -194,6 +209,7 @@ class ZScript:
             repo_root = script_path.parent
 
         instance = cls(repo_root)
+        instance.targets = targets
 
         subcommand: str | None = args.subcommand
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -190,7 +190,7 @@ class ZScript:
         if "--" in argv:
             sep = argv.index("--")
             framework_argv = argv[:sep]
-            targets = argv[sep + 1:]
+            targets = argv[sep + 1 :]
         else:
             framework_argv = argv
             targets = []

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -26,6 +26,7 @@ from nanvix_zutil import log
 from nanvix_zutil.cli import build_parser
 from nanvix_zutil.config import Config
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_INVALID_ARGS
+from nanvix_zutil.requirements import Requirements, load_requirements
 
 
 class ZScript:
@@ -86,6 +87,9 @@ class ZScript:
         self.nanvix_dir = self.repo_root / ".nanvix"
         self.config = Config(self.nanvix_dir)
         self.targets: list[str] = []
+        self.requirements: Requirements = load_requirements(
+            self.nanvix_dir / "nanvix-requirements.txt"
+        )
 
     # ------------------------------------------------------------------
     # Lifecycle hooks — override in subclass

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -36,9 +36,11 @@ class ZScript:
     hooks they need.
 
     Attributes:
-        SYSROOT_REQUIRED_FILES: Files that must exist in the sysroot for
-            verification to pass.  Override in subclasses when a different
-            set of files is required.
+        SYSROOT_REQUIRED_FILES: Files that must exist in the sysroot
+            regardless of deployment mode.  Override in subclasses to add
+            library-specific files.
+        SYSROOT_MULTI_PROCESS_FILES: Additional files required only for
+            multi-process deployments (``linuxd.elf``, ``uservm.elf``).
         config: Persistent build configuration loaded from
             ``.nanvix/env.json`` and environment variables.
         repo_root: Absolute path to the consumer repository root.
@@ -50,10 +52,25 @@ class ZScript:
         "lib/user.ld",
         "bin/nanvixd.elf",
         "bin/kernel.elf",
-        "bin/linuxd.elf",
-        "bin/uservm.elf",
         "bin/mkramfs.elf",
     )
+
+    SYSROOT_MULTI_PROCESS_FILES: tuple[str, ...] = (
+        "bin/linuxd.elf",
+        "bin/uservm.elf",
+    )
+
+    def sysroot_required_files(self) -> list[str]:
+        """Return the sysroot files required for the current deployment mode.
+
+        Multi-process mode additionally requires ``linuxd.elf`` and
+        ``uservm.elf``.  Subclasses can extend by overriding the class
+        attributes or this method.
+        """
+        files = list(self.SYSROOT_REQUIRED_FILES)
+        if self.config.deployment_mode == "multi-process":
+            files.extend(self.SYSROOT_MULTI_PROCESS_FILES)
+        return files
 
     def __init__(self, repo_root: Path) -> None:
         """Initialise ZScript for *repo_root*.

--- a/templates/z
+++ b/templates/z
@@ -12,9 +12,9 @@ MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.2.1"
+ZUTIL_TAG="v0.2.2"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:d948484f8e8a170dc37e1aff6a025f9c9684f19fd2f4f2f5a52afb9ff431c4ab"
+ZUTIL_HASH="sha256:0161a19853cc91d4f42f7bac3328c58e6abe2e530a6b05ea1799f91074ac0579"
 
 # Locate a suitable Python interpreter.
 find_python() {

--- a/templates/z
+++ b/templates/z
@@ -12,9 +12,9 @@ MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.2.0"
+ZUTIL_TAG="v0.2.1"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+ZUTIL_HASH="sha256:d948484f8e8a170dc37e1aff6a025f9c9684f19fd2f4f2f5a52afb9ff431c4ab"
 
 # Locate a suitable Python interpreter.
 find_python() {

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -16,9 +16,9 @@ $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.2.1"
+$ZUTIL_TAG = "v0.2.2"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:d948484f8e8a170dc37e1aff6a025f9c9684f19fd2f4f2f5a52afb9ff431c4ab"
+$ZUTIL_HASH = "sha256:0161a19853cc91d4f42f7bac3328c58e6abe2e530a6b05ea1799f91074ac0579"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -16,9 +16,9 @@ $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.2.0"
+$ZUTIL_TAG = "v0.2.1"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+$ZUTIL_HASH = "sha256:d948484f8e8a170dc37e1aff6a025f9c9684f19fd2f4f2f5a52afb9ff431c4ab"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,

--- a/tests/test_example_zlib.py
+++ b/tests/test_example_zlib.py
@@ -1,0 +1,248 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Integration tests for the hello-zlib example.
+
+These tests exercise the bootstrap chain by invoking the example through
+the actual ``z`` (Bash) and ``z.ps1`` (PowerShell) wrappers — the same
+way an end-user would run ``./z <command>``.
+
+The full lifecycle test (setup → build → test → clean) requires the
+Nanvix cross-compiler (``i686-nanvix-gcc``) and network access to
+download release assets from GitHub.  Detection order:
+
+1. ``NANVIX_TOOLCHAIN`` environment variable
+2. Default path ``/opt/nanvix/``
+3. Docker image ``nanvix/toolchain:latest-minimal``
+
+CLI flag tests (--help, --json) work without any external dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import cast
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLE_DIR = _REPO_ROOT / "examples" / "hello-zlib"
+_Z_BASH = _EXAMPLE_DIR / "z"
+_Z_PS1 = _EXAMPLE_DIR / "z.ps1"
+_HAS_PWSH = shutil.which("pwsh") is not None
+_HAS_BASH = shutil.which("bash") is not None
+
+
+def _has_nanvix_toolchain() -> bool:
+    """Return True if the Nanvix cross-compiler is available."""
+    custom = os.environ.get("NANVIX_TOOLCHAIN", "")
+    if custom and Path(custom, "bin", "i686-nanvix-gcc").exists():
+        return True
+    if Path("/opt/nanvix/bin/i686-nanvix-gcc").exists():
+        return True
+    if shutil.which("docker"):
+        result = subprocess.run(
+            ["docker", "image", "inspect", "nanvix/toolchain:latest-minimal"],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    return False
+
+
+def _has_kvm() -> bool:
+    """Return True if /dev/kvm is accessible."""
+    return os.access("/dev/kvm", os.R_OK | os.W_OK)
+
+
+_HAS_TOOLCHAIN = _has_nanvix_toolchain()
+_HAS_KVM = _has_kvm()
+_SKIP_LIFECYCLE = "Nanvix toolchain not available (set NANVIX_TOOLCHAIN, install to /opt/nanvix, or pull Docker image)"
+_SKIP_NO_KVM = "KVM not available (/dev/kvm not accessible)"
+_LIFECYCLE_TIMEOUT = (
+    600  # seconds — setup downloads assets + build + VM boot + test + clean
+)
+
+
+@unittest.skipUnless(_HAS_BASH, "bash not found in PATH")
+class TestHelloZlibBash(unittest.TestCase):
+    """End-to-end tests for the ``z`` (Bash) bootstrap wrapper."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _run_z(*args: str) -> subprocess.CompletedProcess[str]:
+        """Run the example via ``bash z`` with the given arguments."""
+        return subprocess.run(
+            ["bash", str(_Z_BASH), *args],
+            cwd=str(_EXAMPLE_DIR),
+            capture_output=True,
+            text=True,
+            timeout=_LIFECYCLE_TIMEOUT,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle (requires toolchain + KVM + network)
+    # ------------------------------------------------------------------
+
+    @unittest.skipUnless(_HAS_TOOLCHAIN, _SKIP_LIFECYCLE)
+    @unittest.skipUnless(_HAS_KVM, _SKIP_NO_KVM)
+    def test_full_lifecycle(self) -> None:
+        """Run setup → build → test → clean and verify each step."""
+        # setup (downloads sysroot + zlib)
+        r = self._run_z("setup")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        # build
+        r = self._run_z("build")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(
+            (_EXAMPLE_DIR / "hello-zlib.elf").exists(),
+            "hello-zlib.elf should exist after build",
+        )
+
+        # test
+        r = self._run_z("test")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        # clean
+        r = self._run_z("clean")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertFalse(
+            (_EXAMPLE_DIR / "hello-zlib.elf").exists(),
+            "hello-zlib.elf should not exist after clean",
+        )
+
+    # ------------------------------------------------------------------
+    # CLI flags (no toolchain required)
+    # ------------------------------------------------------------------
+
+    def test_help_returns_zero(self) -> None:
+        """``--help`` exits successfully."""
+        r = self._run_z("--help")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_json_mode(self) -> None:
+        """``--json`` produces parseable JSON on stdout."""
+        r = self._run_z("--json", "clean")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        json_lines = [ln for ln in r.stdout.splitlines() if ln.startswith("{")]
+        self.assertTrue(json_lines, "expected at least one JSON line on stdout")
+        for line in json_lines:
+            obj: object = json.loads(line)
+            self.assertIsInstance(obj, dict)
+            assert isinstance(obj, dict)
+            typed = cast(dict[str, object], obj)
+            self.assertIn("level", typed)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Remove build artifacts left over from test runs."""
+        for artifact in ("hello-zlib.o", "hello-zlib.elf"):
+            path = _EXAMPLE_DIR / artifact
+            if path.exists():
+                path.unlink()
+
+
+@unittest.skipUnless(_HAS_PWSH, "pwsh (PowerShell) not found in PATH")
+class TestHelloZlibPS1(unittest.TestCase):
+    """End-to-end tests for the ``z.ps1`` bootstrap wrapper."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _run_z_ps1(*args: str) -> subprocess.CompletedProcess[str]:
+        """Run the example via ``pwsh z.ps1`` with the given arguments."""
+        return subprocess.run(
+            ["pwsh", "-NoProfile", "-File", str(_Z_PS1), *args],
+            cwd=str(_EXAMPLE_DIR),
+            capture_output=True,
+            text=True,
+            timeout=_LIFECYCLE_TIMEOUT,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle (requires toolchain + KVM + network)
+    # ------------------------------------------------------------------
+
+    @unittest.skipUnless(_HAS_TOOLCHAIN, _SKIP_LIFECYCLE)
+    @unittest.skipUnless(_HAS_KVM, _SKIP_NO_KVM)
+    def test_full_lifecycle(self) -> None:
+        """Run setup → build → test → clean via z.ps1."""
+        # setup
+        r = self._run_z_ps1("setup")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        # build
+        r = self._run_z_ps1("build")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(
+            (_EXAMPLE_DIR / "hello-zlib.elf").exists(),
+            "hello-zlib.elf should exist after build",
+        )
+
+        # test
+        r = self._run_z_ps1("test")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        # clean
+        r = self._run_z_ps1("clean")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertFalse(
+            (_EXAMPLE_DIR / "hello-zlib.elf").exists(),
+            "hello-zlib.elf should not exist after clean",
+        )
+
+    # ------------------------------------------------------------------
+    # CLI flags (no toolchain required)
+    # ------------------------------------------------------------------
+
+    def test_help_returns_zero(self) -> None:
+        """``z.ps1 --help`` exits successfully."""
+        r = self._run_z_ps1("--help")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_no_args_shows_help(self) -> None:
+        """``z.ps1`` with no arguments prints help and exits 0."""
+        r = self._run_z_ps1()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("usage:", r.stdout)
+
+    def test_json_mode(self) -> None:
+        """``z.ps1 --json clean`` produces parseable JSON on stdout."""
+        r = self._run_z_ps1("--json", "clean")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        json_lines = [ln for ln in r.stdout.splitlines() if ln.startswith("{")]
+        self.assertTrue(json_lines, "expected at least one JSON line on stdout")
+        for line in json_lines:
+            obj: object = json.loads(line)
+            self.assertIsInstance(obj, dict)
+            assert isinstance(obj, dict)
+            typed = cast(dict[str, object], obj)
+            self.assertIn("level", typed)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Remove build artifacts left over from test runs."""
+        for artifact in ("hello-zlib.o", "hello-zlib.elf"):
+            path = _EXAMPLE_DIR / artifact
+            if path.exists():
+                path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -7,6 +7,7 @@ import json
 import tempfile
 import unittest
 import urllib.error
+import urllib.request
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -136,8 +137,6 @@ class TestDownloadReleaseAssetSuccess(unittest.TestCase):
                 gh_token="mytoken",
             )
 
-        import urllib.request
-
         first_req = captured_requests[0]
         self.assertIsInstance(first_req, urllib.request.Request)
         assert isinstance(first_req, urllib.request.Request)
@@ -248,6 +247,86 @@ class TestDownloadReleaseAssetNetworkError(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 4)
 
 
+class TestDownloadReleaseAssetLatestTag(unittest.TestCase):
+    """download_release_asset uses /releases/latest when tag is 'latest'."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_latest_tag_uses_releases_latest_endpoint(self) -> None:
+        dest = Path(self._tmpdir.name)
+        asset_name = "zlib-hyperlight-multi-process-128mb.tar.bz2"
+        download_url = "https://example.com/" + asset_name
+        file_content = b"archive-bytes"
+
+        metadata_resp = _make_urlopen_response(
+            _make_release_payload(asset_name, download_url)
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        captured_requests: list[object] = []
+
+        def capture_urlopen(req: object, **kwargs: object) -> object:
+            captured_requests.append(req)
+            if len(captured_requests) == 1:
+                return metadata_resp
+            return file_resp
+
+        with patch("urllib.request.urlopen", side_effect=capture_urlopen):
+            github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                tag="latest",
+                asset_name=asset_name,
+                dest=dest,
+            )
+
+        first_req = captured_requests[0]
+        assert isinstance(first_req, urllib.request.Request)
+        self.assertEqual(
+            first_req.full_url,
+            "https://api.github.com/repos/nanvix/zlib/releases/latest",
+        )
+
+    def test_non_latest_tag_uses_releases_tags_endpoint(self) -> None:
+        dest = Path(self._tmpdir.name)
+        asset_name = "zlib-hyperlight-multi-process-128mb.tar.bz2"
+        download_url = "https://example.com/" + asset_name
+        file_content = b"archive-bytes"
+
+        metadata_resp = _make_urlopen_response(
+            _make_release_payload(asset_name, download_url)
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        captured_requests: list[object] = []
+
+        def capture_urlopen(req: object, **kwargs: object) -> object:
+            captured_requests.append(req)
+            if len(captured_requests) == 1:
+                return metadata_resp
+            return file_resp
+
+        with patch("urllib.request.urlopen", side_effect=capture_urlopen):
+            github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                tag="abc1234-nanvix-def5678",
+                asset_name=asset_name,
+                dest=dest,
+            )
+
+        first_req = captured_requests[0]
+        assert isinstance(first_req, urllib.request.Request)
+        self.assertEqual(
+            first_req.full_url,
+            "https://api.github.com/repos/nanvix/zlib/releases/tags/abc1234-nanvix-def5678",
+        )
+
+
 class TestDownloadReleaseAssetPrefixMatch(unittest.TestCase):
     """download_release_asset with match_prefix=True."""
 
@@ -319,6 +398,89 @@ class TestDownloadReleaseAssetPrefixMatch(unittest.TestCase):
                     match_prefix=True,
                 )
         self.assertEqual(ctx.exception.code, 3)
+
+
+# ---------------------------------------------------------------------------
+# find_release_tag
+# ---------------------------------------------------------------------------
+
+
+def _make_releases_list_payload(tags: list[str]) -> bytes:
+    """Return a minimal GitHub ``GET /repos/{repo}/releases`` response."""
+    return json.dumps([{"tag_name": t} for t in tags]).encode()
+
+
+class TestFindReleaseTag(unittest.TestCase):
+    """Tests for :func:`github.find_release_tag`."""
+
+    def setUp(self) -> None:
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        log_mod.set_json_mode(False)
+
+    def test_returns_matching_tag(self) -> None:
+        tags = [
+            "b7a6a3c-nanvix-fa06b88",
+            "25e1341-nanvix-fa06b88",
+            "bd416c7-nanvix-98c15d9",
+        ]
+        resp = _make_urlopen_response(_make_releases_list_payload(tags))
+
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = github_mod.find_release_tag("nanvix/zlib", "nanvix-fa06b88")
+
+        self.assertEqual(result, "b7a6a3c-nanvix-fa06b88")
+
+    def test_returns_none_when_no_match(self) -> None:
+        tags = ["b7a6a3c-nanvix-fa06b88", "25e1341-nanvix-fa06b88"]
+        resp = _make_urlopen_response(_make_releases_list_payload(tags))
+
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = github_mod.find_release_tag("nanvix/zlib", "nanvix-000000")
+
+        self.assertIsNone(result)
+
+    def test_returns_none_for_empty_releases(self) -> None:
+        resp = _make_urlopen_response(json.dumps([]).encode())
+
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = github_mod.find_release_tag("nanvix/zlib", "nanvix-fa06b88")
+
+        self.assertIsNone(result)
+
+    def test_gh_token_passed_in_header(self) -> None:
+        tags = ["abc-nanvix-def"]
+        resp = _make_urlopen_response(_make_releases_list_payload(tags))
+
+        captured: list[urllib.request.Request] = []
+
+        def capture(req: object, **kwargs: object) -> object:
+            assert isinstance(req, urllib.request.Request)
+            captured.append(req)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=capture):
+            github_mod.find_release_tag("nanvix/zlib", "nanvix-def", gh_token="tok123")
+
+        self.assertEqual(len(captured), 1)
+        self.assertIn("Authorization", captured[0].headers)
+        self.assertEqual(captured[0].headers["Authorization"], "Bearer tok123")
+
+    def test_network_error_exits_4(self) -> None:
+        log_mod.set_json_mode(True)
+
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=urllib.error.URLError("connection refused"),
+            ),
+            patch("time.sleep"),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                github_mod.find_release_tag("nanvix/zlib", "nanvix-fa06b88")
+
+        self.assertEqual(ctx.exception.code, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -186,6 +186,21 @@ class TestIntegrationLifecycle(unittest.TestCase):
         self.assertEqual(instance.config.deployment_mode, "multi-process")
         self.assertEqual(instance.config.memory_size, "128mb")
 
+    def test_targets_empty_by_default(self) -> None:
+        """Without --, targets should be an empty list."""
+        instance = self._run_main("build")
+        self.assertEqual(instance.targets, [])
+
+    def test_targets_passed_after_double_dash(self) -> None:
+        """Arguments after -- are available as instance.targets."""
+        instance = self._run_main("test", extra_argv=["--", "smoke", "integration"])
+        self.assertEqual(instance.targets, ["smoke", "integration"])
+
+    def test_targets_single_value(self) -> None:
+        """A single target after -- is a one-element list."""
+        instance = self._run_main("build", extra_argv=["--", "all"])
+        self.assertEqual(instance.targets, ["all"])
+
 
 class TestIntegrationConfigPersistence(unittest.TestCase):
     """Config.save() / load() round-trip via ZScript."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,17 @@ from unittest.mock import patch
 import nanvix_zutil.log as log_mod
 from nanvix_zutil import ZScript
 
+# Minimal valid requirements content.
+_MINIMAL_REQS = "nanvix@latest\n"
+
+
+def _write_requirements(repo_root: Path) -> None:
+    """Create ``.nanvix/nanvix-requirements.txt`` inside *repo_root*."""
+    nanvix_dir = repo_root / ".nanvix"
+    nanvix_dir.mkdir(parents=True, exist_ok=True)
+    (nanvix_dir / "nanvix-requirements.txt").write_text(_MINIMAL_REQS)
+
+
 # ---------------------------------------------------------------------------
 # Mock consumer
 # ---------------------------------------------------------------------------
@@ -61,6 +72,7 @@ class TestIntegrationLifecycle(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._repo_root = Path(self._tmpdir.name)
+        _write_requirements(self._repo_root)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
         log_mod.set_json_mode(False)
@@ -208,6 +220,7 @@ class TestIntegrationConfigPersistence(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._repo_root = Path(self._tmpdir.name)
+        _write_requirements(self._repo_root)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
         log_mod.set_json_mode(False)
@@ -232,6 +245,7 @@ class TestIntegrationRunSubprocess(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._repo_root = Path(self._tmpdir.name)
+        _write_requirements(self._repo_root)
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,329 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Tests for nanvix_zutil.requirements."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import nanvix_zutil.log as log_mod
+from nanvix_zutil.requirements import load_requirements
+
+
+class TestLoadRequirementsFileNotFound(unittest.TestCase):
+    """load_requirements exits 3 when the file does not exist."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_missing_file_exits_3(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+
+        self.assertEqual(ctx.exception.code, 3)
+
+
+class TestLoadRequirementsBasic(unittest.TestCase):
+    """load_requirements parses a simple requirements file."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_single_dependency(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\nzlib\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "latest")
+        self.assertEqual(len(reqs.dependencies), 1)
+        self.assertEqual(reqs.dependencies[0].name, "zlib")
+        self.assertEqual(reqs.dependencies[0].repo, "nanvix/zlib")
+        self.assertEqual(reqs.dependencies[0].tag, "latest")
+
+    def test_explicit_tags(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@fa06b88\nzlib@b7a6a3c\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "fa06b88")
+        self.assertEqual(len(reqs.dependencies), 1)
+        self.assertEqual(reqs.dependencies[0].name, "zlib")
+        self.assertEqual(reqs.dependencies[0].tag, "b7a6a3c-nanvix-fa06b88")
+
+    def test_sysroot_and_multiple_deps(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\nzlib\nopenssl@abc1234\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "latest")
+        self.assertEqual(len(reqs.dependencies), 2)
+        self.assertEqual(reqs.dependencies[0].name, "zlib")
+        self.assertEqual(reqs.dependencies[0].tag, "latest")
+        self.assertEqual(reqs.dependencies[1].name, "openssl")
+        self.assertEqual(reqs.dependencies[1].repo, "nanvix/openssl")
+        self.assertEqual(reqs.dependencies[1].tag, "abc1234-nanvix-latest")
+
+
+class TestLoadRequirementsCommentsAndBlanks(unittest.TestCase):
+    """load_requirements ignores comments and blank lines."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_comments_and_blanks_ignored(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text(
+            "# Nanvix sysroot\n"
+            "nanvix@latest\n"
+            "\n"
+            "# Build dependencies\n"
+            "zlib  # compression library\n"
+            "\n"
+        )
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "latest")
+        self.assertEqual(len(reqs.dependencies), 1)
+        self.assertEqual(reqs.dependencies[0].name, "zlib")
+
+
+class TestLoadRequirementsMandatoryNanvix(unittest.TestCase):
+    """The 'nanvix' entry is mandatory."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_missing_nanvix_exits_2(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("zlib\n")
+
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_bare_nanvix_exits_2(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix\nzlib\n")
+
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_empty_file_exits_2(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("")
+
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+
+class TestLoadRequirementsMalformedEntries(unittest.TestCase):
+    """Malformed entries with empty name or tag are rejected."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_empty_name_exits_2(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\n@tag\n")
+
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_empty_tag_exits_2(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\nzlib@\n")
+
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_empty_name_and_tag_exits_2(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\n@\n")
+
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+
+class TestLoadRequirementsDuplicates(unittest.TestCase):
+    """Duplicate names: last entry wins."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_last_wins(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\nzlib@aaa\nzlib@bbb\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(len(reqs.dependencies), 1)
+        self.assertEqual(reqs.dependencies[0].tag, "bbb-nanvix-latest")
+
+
+class TestLoadRequirementsEnvOverride(unittest.TestCase):
+    """Environment variables override file-specified tags."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_nanvix_version_overrides_sysroot(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\nzlib\n")
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "override_sha"}):
+            reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "override_sha")
+        self.assertEqual(reqs.dependencies[0].tag, "latest")
+
+    def test_nanvix_version_dep_overrides_dep(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\nzlib@file_sha\n")
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "env_sha"}):
+            reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "latest")
+        self.assertEqual(reqs.dependencies[0].tag, "env_sha-nanvix-latest")
+
+    def test_env_overrides_both(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@file_nanvix\nzlib@file_zlib\n")
+
+        with patch.dict(
+            os.environ,
+            {"NANVIX_VERSION": "env_nanvix", "NANVIX_VERSION_ZLIB": "env_zlib"},
+        ):
+            reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "env_nanvix")
+        self.assertEqual(reqs.dependencies[0].tag, "env_zlib-nanvix-env_nanvix")
+
+
+class TestLoadRequirementsDefaultTag(unittest.TestCase):
+    """When @tag is omitted, the tag defaults to 'latest'."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_no_at_defaults_to_latest(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@latest\nzlib\nopenssl\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.sysroot_tag, "latest")
+        for dep in reqs.dependencies:
+            self.assertEqual(dep.tag, "latest")
+
+
+class TestLoadRequirementsAutoSuffix(unittest.TestCase):
+    """Dependency tags are auto-suffixed with the nanvix version."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_short_tag_suffixed(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@fa06b88\nzlib@b7a6a3c\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.dependencies[0].tag, "b7a6a3c-nanvix-fa06b88")
+
+    def test_full_tag_with_nanvix_rejected(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@fa06b88\nzlib@b7a6a3c-nanvix-fa06b88\n")
+
+        log_mod.set_json_mode(True)
+        with self.assertRaises(SystemExit) as ctx:
+            load_requirements(path)
+        log_mod.set_json_mode(False)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_latest_dep_not_suffixed(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@fa06b88\nzlib\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.dependencies[0].tag, "latest")
+
+    def test_multiple_deps_suffixed(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix-requirements.txt"
+        path.write_text("nanvix@abc123\nzlib@aaa\nopenssl@bbb\n")
+
+        reqs = load_requirements(path)
+
+        self.assertEqual(reqs.dependencies[0].tag, "aaa-nanvix-abc123")
+        self.assertEqual(reqs.dependencies[1].tag, "bbb-nanvix-abc123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -96,5 +96,59 @@ class TestZScriptRun(unittest.TestCase):
             log_mod.set_json_mode(False)
 
 
+class TestZScriptSysrootRequiredFiles(unittest.TestCase):
+    """sysroot_required_files() varies by deployment mode."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def test_multi_process_includes_linuxd_and_uservm(self) -> None:
+        os.environ["NANVIX_DEPLOYMENT_MODE"] = "multi-process"
+        script = ZScript(Path(self._tmpdir.name))
+        files = script.sysroot_required_files()
+        self.assertIn("bin/linuxd.elf", files)
+        self.assertIn("bin/uservm.elf", files)
+
+    def test_single_process_excludes_linuxd_and_uservm(self) -> None:
+        os.environ["NANVIX_DEPLOYMENT_MODE"] = "single-process"
+        script = ZScript(Path(self._tmpdir.name))
+        files = script.sysroot_required_files()
+        self.assertNotIn("bin/linuxd.elf", files)
+        self.assertNotIn("bin/uservm.elf", files)
+
+    def test_standalone_excludes_linuxd_and_uservm(self) -> None:
+        os.environ["NANVIX_DEPLOYMENT_MODE"] = "standalone"
+        script = ZScript(Path(self._tmpdir.name))
+        files = script.sysroot_required_files()
+        self.assertNotIn("bin/linuxd.elf", files)
+        self.assertNotIn("bin/uservm.elf", files)
+
+    def test_base_files_always_present(self) -> None:
+        """Core files are required regardless of deployment mode."""
+        for mode in ("multi-process", "single-process", "standalone"):
+            os.environ["NANVIX_DEPLOYMENT_MODE"] = mode
+            script = ZScript(Path(self._tmpdir.name))
+            files = script.sysroot_required_files()
+            self.assertIn("lib/libposix.a", files, f"missing in {mode}")
+            self.assertIn("lib/user.ld", files, f"missing in {mode}")
+            self.assertIn("bin/nanvixd.elf", files, f"missing in {mode}")
+            self.assertIn("bin/kernel.elf", files, f"missing in {mode}")
+            self.assertIn("bin/mkramfs.elf", files, f"missing in {mode}")
+
+    def test_default_deployment_mode_is_multi_process(self) -> None:
+        """Default (no env override) should be multi-process."""
+        script = ZScript(Path(self._tmpdir.name))
+        files = script.sysroot_required_files()
+        self.assertIn("bin/linuxd.elf", files)
+        self.assertIn("bin/uservm.elf", files)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -12,12 +12,23 @@ from pathlib import Path
 import nanvix_zutil.log as log_mod
 from nanvix_zutil.script import ZScript
 
+# Minimal valid requirements content.
+_MINIMAL_REQS = "nanvix@latest\n"
+
+
+def _write_requirements(repo_root: Path, content: str = _MINIMAL_REQS) -> None:
+    """Create ``.nanvix/nanvix-requirements.txt`` inside *repo_root*."""
+    nanvix_dir = repo_root / ".nanvix"
+    nanvix_dir.mkdir(parents=True, exist_ok=True)
+    (nanvix_dir / "nanvix-requirements.txt").write_text(content)
+
 
 class TestZScriptInit(unittest.TestCase):
     """ZScript initialises correctly."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
+        _write_requirements(Path(self._tmpdir.name))
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
@@ -39,12 +50,30 @@ class TestZScriptInit(unittest.TestCase):
         script = ZScript(repo_root)
         self.assertEqual(script.config.machine, "hyperlight")
 
+    def test_requirements_loaded(self) -> None:
+        repo_root = Path(self._tmpdir.name)
+        script = ZScript(repo_root)
+        self.assertEqual(script.requirements.sysroot_tag, "latest")
+
+    def test_missing_requirements_exits_3(self) -> None:
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        repo_root = Path(tmpdir.name)
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                ZScript(repo_root)
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
 
 class TestZScriptLifecycleHooks(unittest.TestCase):
     """Default lifecycle hooks are no-ops."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
+        _write_requirements(Path(self._tmpdir.name))
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
@@ -76,6 +105,7 @@ class TestZScriptRun(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
+        _write_requirements(Path(self._tmpdir.name))
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
@@ -101,6 +131,7 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
+        _write_requirements(Path(self._tmpdir.name))
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "nanvix-zutil"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "nanvix-zutil"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Add a requirements file parser (`nanvix-requirements.txt`) and a hello-zlib example demonstrating build-time dependency management.

## Changes

### New: Requirements File Parser (`requirements.py`)
- `Requirements` dataclass and `load_requirements()` parser for `nanvix-requirements.txt` declarative dependency files
- Supports `name`, `repo`, `tag`, `version`, and `artifacts` fields with validation
- Re-exported from `__init__.py`

### New: GitHub Release Helpers (`github.py`)
- `download_release_asset()` now supports `tag="latest"` using the `/releases/latest` API endpoint
- New `find_release_tag()` helper: finds release tags by suffix match across a repo's releases

### New: hello-zlib Example
- Full example demonstrating how to use `zlib` as a build dependency via `nanvix-requirements.txt`
- Includes `Makefile.nanvix`, bootstrap scripts (`z`/`z.ps1`), C source, and README

### Tests
- `test_requirements.py` — unit tests for the requirements parser (329 lines)
- `test_example_zlib.py` — integration tests for the hello-zlib example (248 lines)
- Additional tests for `find_release_tag()` and `latest` tag support in `test_github.py`
- Integration and script-level test additions

### Stats
- **22 files changed**, **+1620 / −15 lines**
