### PR TITLE
Allow "latest" as a valid nanvix-version specifier

### DIFF
--- a/examples/hello-world/.nanvix/nanvix.toml
+++ b/examples/hello-world/.nanvix/nanvix.toml
@@ -1,4 +1,4 @@
 [package]
 name = "hello-world"
 version = "0.1.0"
-nanvix-version = "0.12.267"
+nanvix-version = "latest"

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -31,7 +31,7 @@ Public re-exports:
 - :mod:`nanvix_zutil.log` — structured logging helpers
 """
 
-from nanvix_zutil.buildroot import Buildroot, Dependency, Ref, RefKind
+from nanvix_zutil.buildroot import Buildroot, Dependency, Ref, RefKind, suffix_dep
 from nanvix_zutil.config import (
     CFG_GH_TOKEN,
     CFG_SYSROOT,
@@ -113,5 +113,6 @@ __all__ = [
     "read_lockfile",
     "resolve",
     "resolve_release",
+    "suffix_dep",
     "write_lockfile",
 ]

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -11,7 +11,7 @@ describes a single library fetched from a GitHub release.
 from __future__ import annotations
 
 import tarfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as _dc_replace
 from enum import Enum
 from pathlib import Path
 
@@ -84,6 +84,31 @@ class Dependency:
     artifact_pattern: str = "{name}-{machine}-{mode}-{mem}.tar.bz2"
     install_libs: list[str] | None = None
     install_headers: list[str] | None = None
+
+
+def suffix_dep(dep: Dependency, version: str) -> Dependency:
+    """Return a copy of *dep* with its VERSION ref suffixed with *version*.
+
+    If *dep* has a non-VERSION ref kind, it is returned unchanged.
+
+    Args:
+        dep: The dependency to suffix.
+        version: The nanvix sysroot version to append
+            (e.g. ``"0.12.277"``).
+
+    Returns:
+        A new :class:`Dependency` with the suffixed ref, or the
+        original if no suffixing is needed.
+    """
+    if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
+        return _dc_replace(
+            dep,
+            ref=Ref(
+                kind=dep.ref.kind,
+                value=f"{dep.ref.value}-nanvix-{version}",
+            ),
+        )
+    return dep
 
 
 # ---------------------------------------------------------------------------

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -125,6 +125,7 @@ def _parse_nanvix_version(raw: object, path: Path) -> Ref:
             " 'nanvix-version = \"latest\"'.",
         )
     if raw == "latest":
+        # "latest" is a supported first-class sysroot specifier; no warning needed.
         return Ref(kind=RefKind.TAG, value="latest")
     if not SEMVER_RE.match(raw):
         log.fatal(

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -4,9 +4,10 @@
 """TOML-based manifest parser for ``nanvix.toml``.
 
 Parses a structured TOML manifest that declares package metadata and
-dependencies.  ``nanvix-version`` must be a semver string (``X.Y.Z``).
-Dependency version fields accept a plain string (``version`` specifier),
-or a table with one of ``version``, ``tag``, ``commitish``, or ``id``.
+dependencies.  ``nanvix-version`` must be a semver string (``X.Y.Z``)
+or the literal ``"latest"``.  Dependency version fields accept a plain
+string (``version`` specifier), or a table with one of ``version``,
+``tag``, ``commitish``, or ``id``.
 
 Environment variables ``NANVIX_VERSION`` (for the sysroot) and
 ``NANVIX_VERSION_<NAME>`` (for individual dependencies) override the
@@ -16,7 +17,8 @@ Only ``version`` specifier refs (plain string or ``{ version = "..." }``)
 are auto-suffixed with ``-nanvix-{sysroot_version}``.  ``tag``,
 ``commitish``, and ``id`` specifiers are exact-match and never suffixed.
 Refs that already contain ``-nanvix-`` are rejected to prevent accidental
-duplication.
+duplication.  When the sysroot is ``"latest"``, auto-suffixing is
+deferred to the resolver (which resolves the actual version first).
 """
 
 from __future__ import annotations
@@ -105,7 +107,7 @@ def _validate_version_string(raw: str, context: str, path: Path) -> str:
 
 
 def _parse_nanvix_version(raw: object, path: Path) -> Ref:
-    """Parse ``nanvix-version``: must be a plain semver string ``X.Y.Z``.
+    """Parse ``nanvix-version``: semver ``X.Y.Z`` or ``"latest"``.
 
     Args:
         raw: The raw TOML value for ``nanvix-version``.
@@ -119,13 +121,18 @@ def _parse_nanvix_version(raw: object, path: Path) -> Ref:
             f"{path}: 'nanvix-version' must be a plain string"
             f" (got {type(raw).__name__})",
             code=EXIT_INVALID_ARGS,
-            hint="Use 'nanvix-version = \"X.Y.Z\"' (semver).",
+            hint="Use 'nanvix-version = \"X.Y.Z\"' (semver) or"
+            " 'nanvix-version = \"latest\"'.",
         )
+    if raw == "latest":
+        return Ref(kind=RefKind.TAG, value="latest")
     if not SEMVER_RE.match(raw):
         log.fatal(
-            f"{path}: 'nanvix-version' must be semver X.Y.Z (got '{raw}')",
+            f"{path}: 'nanvix-version' must be semver X.Y.Z"
+            f" or 'latest' (got '{raw}')",
             code=EXIT_INVALID_ARGS,
-            hint="Use a version like 'nanvix-version = \"0.12.257\"'.",
+            hint="Use a version like 'nanvix-version = \"0.12.257\"'"
+            " or 'nanvix-version = \"latest\"'.",
         )
     return Ref(kind=RefKind.TAG, value=raw)
 
@@ -362,12 +369,15 @@ def load_manifest(path: Path) -> Manifest:
     )
 
     # Auto-suffix VERSION refs with the nanvix sysroot version.
-    for dep in [*dependencies, *system_dependencies]:
-        if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
-            dep.ref = Ref(
-                kind=dep.ref.kind,
-                value=f"{dep.ref.value}-nanvix-{sysroot_ref.value}",
-            )
+    # When the sysroot is "latest", suffixing is deferred to the resolver
+    # (which resolves the sysroot first and knows the actual version).
+    if sysroot_ref.value != "latest":
+        for dep in [*dependencies, *system_dependencies]:
+            if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
+                dep.ref = Ref(
+                    kind=dep.ref.kind,
+                    value=f"{dep.ref.value}-nanvix-{sysroot_ref.value}",
+                )
 
     return Manifest(
         name=pkg_name,

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -21,7 +21,7 @@ from typing import cast
 
 from nanvix_zutil import github, log
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
-from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS
+from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_NETWORK_ERROR
 from nanvix_zutil.lockfile import (
     Lockfile,
     LockfileMetadata,
@@ -231,6 +231,8 @@ def _resolve_inner(
         semver=True,
     )
     tag, commitish, rel_id = _extract_release_fields(sysroot_release)
+    # ref preserves the original specifier ("latest" or semver) — resolved_tag
+    # is the canonical pin used for deterministic artifact downloads.
     sysroot_pkg = ResolvedPackage(
         name="nanvix",
         repo="nanvix/nanvix",
@@ -250,6 +252,11 @@ def _resolve_inner(
     # so the caller's Manifest is never mutated.
     if manifest.sysroot_ref.value == "latest":
         resolved_version = tag.removeprefix("v")
+        if not resolved_version:
+            log.fatal(
+                "Resolved sysroot release has no tag" " — cannot suffix VERSION deps.",
+                code=EXIT_NETWORK_ERROR,
+            )
 
         def _suffix(dep: Dependency) -> Dependency:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
@@ -393,6 +400,11 @@ def is_stale(lockfile: Lockfile, manifest_path: Path) -> bool:
 
     Compares the ``manifest_hash`` stored in the lockfile metadata
     against the current hash of the manifest file.
+
+    Note: when ``nanvix-version = "latest"`` the manifest hash is
+    stable, so this function will always return ``False`` even if
+    upstream has published a new release.  Re-run ``./z lock``
+    explicitly to pick up new versions.
 
     Args:
         lockfile: The lockfile to check.

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import cast
 
 from nanvix_zutil import github, log
-from nanvix_zutil.buildroot import Dependency, Ref, RefKind
+from nanvix_zutil.buildroot import Dependency, suffix_dep
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_NETWORK_ERROR
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -254,25 +254,18 @@ def _resolve_inner(
         resolved_version = tag.removeprefix("v")
         if not resolved_version:
             log.fatal(
-                "Resolved sysroot release has no tag" " — cannot suffix VERSION deps.",
+                "Resolved sysroot release has no tag — cannot suffix VERSION deps.",
                 code=EXIT_NETWORK_ERROR,
             )
 
-        def _suffix(dep: Dependency) -> Dependency:
-            if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
-                return _dc_replace(
-                    dep,
-                    ref=Ref(
-                        kind=dep.ref.kind,
-                        value=f"{dep.ref.value}-nanvix-{resolved_version}",
-                    ),
-                )
-            return dep
-
         manifest = _dc_replace(
             manifest,
-            dependencies=[_suffix(d) for d in manifest.dependencies],
-            system_dependencies=[_suffix(d) for d in manifest.system_dependencies],
+            dependencies=[
+                suffix_dep(d, resolved_version) for d in manifest.dependencies
+            ],
+            system_dependencies=[
+                suffix_dep(d, resolved_version) for d in manifest.system_dependencies
+            ],
         )
 
     # 2. Seed queue with direct deps
@@ -414,4 +407,15 @@ def is_stale(lockfile: Lockfile, manifest_path: Path) -> bool:
         ``True`` if the lockfile is stale (hashes differ).
     """
     current_hash = compute_manifest_hash(manifest_path)
-    return lockfile.metadata.manifest_hash != current_hash
+    stale = lockfile.metadata.manifest_hash != current_hash
+
+    if not stale:
+        sysroot_pkg = next((p for p in lockfile.packages if p.name == "nanvix"), None)
+        if sysroot_pkg is not None and sysroot_pkg.ref.value == "latest":
+            log.warning(
+                "'nanvix-version = \"latest\"' — lockfile staleness cannot"
+                " be detected by hash; re-run './z lock' to pick up new"
+                " releases."
+            )
+
+    return stale

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import shutil
 import tempfile
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as _dc_replace
 from pathlib import Path
 from typing import cast
 
@@ -246,15 +246,27 @@ def _resolve_inner(
     # Deferred auto-suffix: when sysroot is "latest", load_manifest()
     # skips suffixing because the real version isn't known yet.  Now
     # that the sysroot is resolved, extract the version from its tag
-    # and apply the suffix to VERSION deps.
+    # and apply the suffix to VERSION deps.  We build a shallow copy
+    # so the caller's Manifest is never mutated.
     if manifest.sysroot_ref.value == "latest":
         resolved_version = tag.removeprefix("v")
-        for dep in [*manifest.dependencies, *manifest.system_dependencies]:
+
+        def _suffix(dep: Dependency) -> Dependency:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
-                dep.ref = Ref(
-                    kind=dep.ref.kind,
-                    value=f"{dep.ref.value}-nanvix-{resolved_version}",
+                return _dc_replace(
+                    dep,
+                    ref=Ref(
+                        kind=dep.ref.kind,
+                        value=f"{dep.ref.value}-nanvix-{resolved_version}",
+                    ),
                 )
+            return dep
+
+        manifest = _dc_replace(
+            manifest,
+            dependencies=[_suffix(d) for d in manifest.dependencies],
+            system_dependencies=[_suffix(d) for d in manifest.system_dependencies],
+        )
 
     # 2. Seed queue with direct deps
     queue: deque[_QueueItem] = deque()

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -407,15 +407,4 @@ def is_stale(lockfile: Lockfile, manifest_path: Path) -> bool:
         ``True`` if the lockfile is stale (hashes differ).
     """
     current_hash = compute_manifest_hash(manifest_path)
-    stale = lockfile.metadata.manifest_hash != current_hash
-
-    if not stale:
-        sysroot_pkg = next((p for p in lockfile.packages if p.name == "nanvix"), None)
-        if sysroot_pkg is not None and sysroot_pkg.ref.value == "latest":
-            log.warning(
-                "'nanvix-version = \"latest\"' — lockfile staleness cannot"
-                " be detected by hash; re-run './z lock' to pick up new"
-                " releases."
-            )
-
-    return stale
+    return lockfile.metadata.manifest_hash != current_hash

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import cast
 
 from nanvix_zutil import github, log
-from nanvix_zutil.buildroot import Dependency
+from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -242,6 +242,19 @@ def _resolve_inner(
     )
     resolved["nanvix"] = sysroot_pkg
     releases["nanvix"] = sysroot_release
+
+    # Deferred auto-suffix: when sysroot is "latest", load_manifest()
+    # skips suffixing because the real version isn't known yet.  Now
+    # that the sysroot is resolved, extract the version from its tag
+    # and apply the suffix to VERSION deps.
+    if manifest.sysroot_ref.value == "latest":
+        resolved_version = tag.removeprefix("v")
+        for dep in [*manifest.dependencies, *manifest.system_dependencies]:
+            if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
+                dep.ref = Ref(
+                    kind=dep.ref.kind,
+                    value=f"{dep.ref.value}-nanvix-{resolved_version}",
+                )
 
     # 2. Seed queue with direct deps
     queue: deque[_QueueItem] = deque()

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -354,6 +354,16 @@ class ZScript:
         lock_path = self.nanvix_dir / "nanvix.lock"
         manifest_path = self.nanvix_dir / "nanvix.toml"
         lockfile = read_lockfile(lock_path)
+
+        # Warn when "latest" lockfile may silently be stale.
+        sysroot_pkg = next((p for p in lockfile.packages if p.name == "nanvix"), None)
+        if sysroot_pkg is not None and sysroot_pkg.ref.value == "latest":
+            log.warning(
+                "'nanvix-version = \"latest\"' — lockfile staleness cannot"
+                " be detected by hash; re-run './z lock' to pick up new"
+                " releases."
+            )
+
         if is_stale(lockfile, manifest_path):
             log.fatal(
                 "Lockfile is stale — nanvix.toml has changed since it was generated.",

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -26,7 +26,7 @@ import sys
 from pathlib import Path
 
 from nanvix_zutil import log
-from nanvix_zutil.buildroot import Buildroot, Dependency, Ref, RefKind
+from nanvix_zutil.buildroot import Buildroot, Dependency, suffix_dep
 from nanvix_zutil.cli import build_parser
 from nanvix_zutil.config import CFG_GH_TOKEN, CFG_SYSROOT, Config
 from nanvix_zutil.docker import (
@@ -285,21 +285,15 @@ class ZScript:
         # that the sysroot is resolved, suffix VERSION deps before
         # passing them to install_dep().
         deps: list[Dependency] = list(self.manifest.dependencies)
-        if self.manifest.sysroot_ref.value == "latest" and self.sysroot.tag:
+        if self.manifest.sysroot_ref.value == "latest":
+            if not self.sysroot.tag:
+                log.fatal(
+                    "Sysroot resolved to 'latest' but no tag is available"
+                    " — delete .nanvix/sysroot and re-run './z setup'.",
+                    code=EXIT_MISSING_DEP,
+                )
             resolved_version = self.sysroot.tag.removeprefix("v")
-
-            def _suffix_dep(dep: Dependency) -> Dependency:
-                if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
-                    return dataclasses.replace(
-                        dep,
-                        ref=Ref(
-                            kind=dep.ref.kind,
-                            value=f"{dep.ref.value}-nanvix-{resolved_version}",
-                        ),
-                    )
-                return dep
-
-            deps = [_suffix_dep(d) for d in deps]
+            deps = [suffix_dep(d, resolved_version) for d in deps]
 
         if deps:
             self.buildroot = Buildroot.create(self.nanvix_dir / "buildroot")

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -26,7 +26,7 @@ import sys
 from pathlib import Path
 
 from nanvix_zutil import log
-from nanvix_zutil.buildroot import Buildroot
+from nanvix_zutil.buildroot import Buildroot, Dependency, Ref, RefKind
 from nanvix_zutil.cli import build_parser
 from nanvix_zutil.config import CFG_GH_TOKEN, CFG_SYSROOT, Config
 from nanvix_zutil.docker import (
@@ -280,9 +280,30 @@ class ZScript:
         self.sysroot.verify(self.sysroot_required_files())
         self.config.set(CFG_SYSROOT, str(self.sysroot.path))
 
-        if self.manifest.dependencies:
+        # Deferred auto-suffix: when sysroot is "latest", load_manifest()
+        # skips suffixing because the real version isn't known yet.  Now
+        # that the sysroot is resolved, suffix VERSION deps before
+        # passing them to install_dep().
+        deps: list[Dependency] = list(self.manifest.dependencies)
+        if self.manifest.sysroot_ref.value == "latest" and self.sysroot.tag:
+            resolved_version = self.sysroot.tag.removeprefix("v")
+
+            def _suffix_dep(dep: Dependency) -> Dependency:
+                if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
+                    return dataclasses.replace(
+                        dep,
+                        ref=Ref(
+                            kind=dep.ref.kind,
+                            value=f"{dep.ref.value}-nanvix-{resolved_version}",
+                        ),
+                    )
+                return dep
+
+            deps = [_suffix_dep(d) for d in deps]
+
+        if deps:
             self.buildroot = Buildroot.create(self.nanvix_dir / "buildroot")
-            for dep in self.manifest.dependencies:
+            for dep in deps:
                 self.buildroot.install_dep(
                     dep=dep,
                     machine=self.config.machine,

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -41,18 +41,22 @@ class Sysroot:
 
     Attributes:
         path: Absolute path to the sysroot directory.
+        commitish: Short commitish hash of the resolved release.
+        tag: Resolved tag name (e.g. ``"v0.12.277"``).
     """
 
-    def __init__(self, path: Path, commitish: str = "") -> None:
+    def __init__(self, path: Path, commitish: str = "", tag: str = "") -> None:
         """Initialise the Sysroot with an existing directory.
 
         Args:
             path: Path to the sysroot directory.
             commitish: Short commitish hash of the resolved sysroot
                 release (set by :meth:`download`).
+            tag: Resolved release tag name (set by :meth:`download`).
         """
         self.path = path
         self.commitish = commitish
+        self.tag = tag
 
     # ------------------------------------------------------------------
     # Factory / download
@@ -106,7 +110,10 @@ class Sysroot:
                     if config is not None
                     else ""
                 )
-                return Sysroot(sysroot_dir.resolve(), commitish=cached)
+                cached_tag = (
+                    config.get("sysroot_tag", "") or "" if config is not None else ""
+                )
+                return Sysroot(sysroot_dir.resolve(), commitish=cached, tag=cached_tag)
             log.fatal(
                 f"Sysroot path '{sysroot_dir}' exists but is not a directory.",
                 code=EXIT_MISSING_DEP,
@@ -117,6 +124,8 @@ class Sysroot:
         release = github.resolve_release(_SYSROOT_REPO, tag, gh_token, semver=True)
         commitish_raw = release.get("target_commitish", "")
         commitish = commitish_raw[:7] if isinstance(commitish_raw, str) else ""
+        tag_name = release.get("tag_name", "")
+        resolved_tag = tag_name if isinstance(tag_name, str) else ""
 
         asset_prefix = _SYSROOT_ASSET_PREFIX.format(
             machine=machine,
@@ -144,8 +153,9 @@ class Sysroot:
         log.success(f"Sysroot extracted to {sysroot_dir}")
         if config is not None:
             config.set("sysroot_commitish", commitish)
+            config.set("sysroot_tag", resolved_tag)
             config.save()
-        return Sysroot(sysroot_dir.resolve(), commitish=commitish)
+        return Sysroot(sysroot_dir.resolve(), commitish=commitish, tag=resolved_tag)
 
     # ------------------------------------------------------------------
     # Verification

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -251,7 +251,7 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 2)
 
-    def test_latest_nanvix_version_exits_2(self) -> None:
+    def test_latest_nanvix_version_accepted(self) -> None:
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -260,10 +260,44 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
             'nanvix-version = "latest"\n'
         )
 
-        with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+        m = load_manifest(path)
 
-        self.assertEqual(ctx.exception.code, 2)
+        self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
+        self.assertEqual(m.sysroot_ref.value, "latest")
+
+    def test_latest_sysroot_skips_dep_suffix(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "latest"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        )
+
+        m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.value, "latest")
+        # Dep should NOT be suffixed — deferred to resolver
+        self.assertEqual(m.dependencies[0].ref.value, "1.3.1")
+
+    def test_latest_sysroot_env_override_suffixes_normally(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "latest"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        )
+
+        with patch.dict("os.environ", {"NANVIX_VERSION": "0.12.258"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.value, "0.12.258")
+        self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-0.12.258")
 
     def test_nanvix_version_table_exits_2(self) -> None:
         path = Path(self._tmpdir.name) / "nanvix.toml"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -532,6 +532,76 @@ class TestIsStale(unittest.TestCase):
 
 @patch("nanvix_zutil.resolver.download_lockfile_asset")
 @patch("nanvix_zutil.resolver.github.resolve_release")
+class TestResolveLatestSysroot(unittest.TestCase):
+    """Resolver with 'latest' sysroot and a VERSION dep."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
+        self._manifest_dir.mkdir(parents=True)
+        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path.write_text(
+            '[package]\nname = "test"\nversion = "0.1.0"\n'
+            'nanvix-version = "latest"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        )
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_latest_sysroot_deferred_suffix(
+        self,
+        mock_resolve: MagicMock,
+        mock_download: MagicMock,
+    ) -> None:
+        sysroot_release = _make_release(
+            tag="v0.12.277", commitish="fa06b88", release_id=100
+        )
+        zlib_release = _make_release(
+            tag="v1.3.1-nanvix-fa06b88",
+            commitish="bbb222",
+            release_id=200,
+            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+        )
+        mock_resolve.side_effect = [sysroot_release, zlib_release]
+        mock_download.return_value = None
+
+        manifest = _make_manifest(
+            deps=[
+                Dependency(
+                    name="zlib",
+                    repo="nanvix/zlib",
+                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
+                )
+            ],
+        )
+        # Set sysroot to "latest" (simulates load_manifest output)
+        manifest.sysroot_ref = Ref(kind=RefKind.TAG, value="latest")
+
+        lockfile = resolve(
+            manifest,
+            cache_dir=Path(self._tmpdir.name) / "cache",
+            manifest_path=self._manifest_path,
+        )
+
+        self.assertEqual(len(lockfile.packages), 2)
+        # Verify sysroot resolved correctly
+        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
+        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.277")
+        # Verify dep was suffixed with resolved version
+        zlib_pkg = next(p for p in lockfile.packages if p.name == "zlib")
+        self.assertEqual(zlib_pkg.ref.value, "1.3.1-nanvix-0.12.277")
+        # Verify resolve_release was called with suffixed value
+        mock_resolve.assert_any_call(
+            "nanvix/zlib", "1.3.1-nanvix-0.12.277", gh_token=None
+        )
+
+
+@patch("nanvix_zutil.resolver.download_lockfile_asset")
+@patch("nanvix_zutil.resolver.github.resolve_release")
 class TestAssetFiltering(unittest.TestCase):
     """Resolver filters out non-.tar.bz2 assets and nanvix.lock."""
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -39,12 +39,13 @@ def _make_release(
 def _make_manifest(
     deps: list[Dependency] | None = None,
     sys_deps: list[Dependency] | None = None,
+    sysroot_ref: Ref | None = None,
 ) -> Manifest:
     """Build a Manifest with the given dependencies."""
     return Manifest(
         name="test",
         version="0.1.0",
-        sysroot_ref=Ref(kind=RefKind.TAG, value="0.1.0"),
+        sysroot_ref=sysroot_ref or Ref(kind=RefKind.TAG, value="0.1.0"),
         dependencies=deps or [],
         system_dependencies=sys_deps or [],
     )
@@ -577,9 +578,8 @@ class TestResolveLatestSysroot(unittest.TestCase):
                     ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
                 )
             ],
+            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
         )
-        # Set sysroot to "latest" (simulates load_manifest output)
-        manifest.sysroot_ref = Ref(kind=RefKind.TAG, value="latest")
 
         lockfile = resolve(
             manifest,

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -19,7 +19,11 @@ from nanvix_zutil.docker import (
     Mount,
 )
 from nanvix_zutil.script import ZScript
-from tests.testutils import MANIFEST_WITH_DEPS, write_manifest
+from tests.testutils import (
+    MANIFEST_LATEST_WITH_DEPS,
+    MANIFEST_WITH_DEPS,
+    write_manifest,
+)
 
 
 class TestZScriptInit(unittest.TestCase):
@@ -181,6 +185,63 @@ class TestZScriptAutoSetup(unittest.TestCase):
 
         config_file = Path(self._tmpdir.name) / ".nanvix" / "env.json"
         self.assertTrue(config_file.exists())
+
+
+class TestZScriptSetupLatestSysroot(unittest.TestCase):
+    """setup() with nanvix-version = "latest" suffixes deps correctly."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name), MANIFEST_LATEST_WITH_DEPS)
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_setup_latest_sysroot_suffixes_deps(self) -> None:
+        """setup() suffixes VERSION deps with the resolved sysroot tag."""
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        fake_sysroot.commitish = "fa06b88"
+        fake_sysroot.tag = "v0.12.277"
+
+        fake_buildroot = MagicMock()
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
+        ):
+            script = ZScript(Path(self._tmpdir.name))
+            script.setup()
+
+        # install_dep should be called with the suffixed ref value.
+        fake_buildroot.install_dep.assert_called_once()
+        _, kwargs = fake_buildroot.install_dep.call_args
+        self.assertEqual(kwargs["dep"].ref.value, "1.3.1-nanvix-0.12.277")
+
+    def test_setup_latest_sysroot_empty_tag_fatal(self) -> None:
+        """setup() exits fatally when sysroot tag is empty (upgrade path)."""
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        fake_sysroot.commitish = "fa06b88"
+        fake_sysroot.tag = ""
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                patch(
+                    "nanvix_zutil.script.Sysroot.download",
+                    return_value=fake_sysroot,
+                ),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                script = ZScript(Path(self._tmpdir.name))
+                script.setup()
+
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
 
 
 class TestZScriptLifecycleHooks(unittest.TestCase):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -21,6 +21,17 @@ MANIFEST_WITH_DEPS = (
     'zlib = "1.0"\n'
 )
 
+# Manifest with "latest" sysroot and a VERSION dep.
+MANIFEST_LATEST_WITH_DEPS = (
+    "[package]\n"
+    'name = "test"\n'
+    'version = "0.1.0"\n'
+    'nanvix-version = "latest"\n'
+    "\n"
+    "[dependencies]\n"
+    'zlib = "1.3.1"\n'
+)
+
 
 def write_manifest(repo_root: Path, content: str = MINIMAL_MANIFEST) -> None:
     """Create ``.nanvix/nanvix.toml`` inside *repo_root*."""


### PR DESCRIPTION
## Summary

Accept `"latest"` as a valid `nanvix-version` value in `nanvix.toml`, enabling manifests to declare "build against the current sysroot" as a default. Upstream dispatchers can override with `NANVIX_VERSION=X.Y.Z` for pinned builds.

Closes #28

## Design

When `nanvix-version = "latest"`:
1. **Manifest parser** accepts `"latest"` and returns `Ref(TAG, "latest")`, skipping auto-suffixing of VERSION deps (since the real version is unknown at parse time).
2. **Resolver** resolves the sysroot via `/releases/latest`, extracts the version from the resolved tag, and applies the deferred suffix to all VERSION deps before resolving them.
3. **`setup()`** applies the same deferred suffix after `Sysroot.download()` resolves the tag, before calling `install_dep()`.
4. **Env override** (`NANVIX_VERSION=X.Y.Z`) replaces `"latest"` before suffixing, so the normal pinned-version flow kicks in.

A shared `suffix_dep()` helper in `buildroot.py` is used by both the resolver and `setup()` to avoid duplication.

## Changes

| File | Changes |
|------|---------|
| `manifest.py` | Accept `"latest"` in `_parse_nanvix_version()`; skip auto-suffix when sysroot is `"latest"` |
| `resolver.py` | Deferred suffix after sysroot resolution; empty-tag guard; `is_stale()` docstring note |
| `script.py` | Deferred suffix in `setup()`; `"latest"` warning in `lock_check()` |
| `buildroot.py` | New `suffix_dep()` shared helper |
| `sysroot.py` | Add `tag` attribute; persist/restore via config |
| `__init__.py` | Re-export `suffix_dep` |
| `test_manifest.py` | 3 new/updated tests |
| `test_resolver.py` | New `TestResolveLatestSysroot` class |
| `test_script.py` | New `TestZScriptSetupLatestSysroot` class (2 tests) |
| `testutils.py` | New `MANIFEST_LATEST_WITH_DEPS` fixture |

## Validation

- ✅ `black --check` — pass
- ✅ `basedpyright` strict — 0 errors
- ✅ `pytest` — 351/351 pass
