### PR TITLE
[ci] E: Rename release branches to release/vX.Y.Z

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: ["dev", "main", "release-*"]
+    branches: ["dev", "main", "release/v*"]
   pull_request:
-    branches: ["dev", "main", "release-*"]
+    branches: ["dev", "main", "release/v*"]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,137 +4,137 @@
 name: Release
 
 on:
-    push:
-        branches: ["release-*"]
-    workflow_dispatch:
-        inputs:
-            version:
-                description: "Version to release (must match pyproject.toml, e.g. 0.1.0)"
-                required: true
-                type: string
+  push:
+    branches: ["release/v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (must match pyproject.toml, e.g. 0.1.0)"
+        required: true
+        type: string
 
 permissions:
-    contents: write # create tags and GitHub releases
-    id-token: write # OIDC trusted publishing to PyPI
+  contents: write # create tags and GitHub releases
+  id-token: write # OIDC trusted publishing to PyPI
 
 jobs:
-    lint-and-typecheck:
-        name: Lint & Type Check
-        runs-on: ubuntu-latest
-        if: >-
-            github.event_name == 'workflow_dispatch' ||
-            github.event_name == 'push' ||
-            (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-'))
-        steps:
-            - uses: actions/checkout@v4
+  lint-and-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release/v'))
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Install uv
-              uses: astral-sh/setup-uv@v7
-              with:
-                  python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
 
-            - name: Install dependencies
-              run: uv sync
+      - name: Install dependencies
+        run: uv sync
 
-            - name: Check formatting (black)
-              run: uv run black --check src/ tests/
+      - name: Check formatting (black)
+        run: uv run black --check src/ tests/
 
-            - name: Type check (basedpyright)
-              run: uv run basedpyright src/ tests/
+      - name: Type check (basedpyright)
+        run: uv run basedpyright src/ tests/
 
-    test:
-        name: Tests
-        runs-on: ubuntu-latest
-        container:
-            image: nanvix/toolchain:latest-minimal
-            options: --device /dev/kvm
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    container:
+      image: nanvix/toolchain:latest-minimal
+      options: --device /dev/kvm
+    env:
+      NANVIX_TOOLCHAIN: /opt/nanvix
+      USER: runner
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release/v'))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install project and dev dependencies
+        run: uv sync --python 3.12
+
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
+  release:
+    name: Build & Publish
+    needs: [lint-and-typecheck, test]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#release/v}"
+          fi
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid semver: $VERSION"
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Verify version matches pyproject.toml
+        run: |
+          actual=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
+          if [ "$actual" != "${{ steps.version.outputs.value }}" ]; then
+            echo "Version mismatch: pyproject.toml=$actual expected=${{ steps.version.outputs.value }}"
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        run: |
+          if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.value }}" | grep -q .; then
+            echo "Tag v${{ steps.version.outputs.value }} already exists on origin. Bump the version in pyproject.toml before releasing."
+            exit 1
+          fi
+
+      - name: Build wheel and sdist
+        run: uv build
+
+      - name: Create and push release tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.value }}"
+          git push origin "v${{ steps.version.outputs.value }}"
+
+      - name: Create GitHub release
+        run: |
+          gh release create "v${{ steps.version.outputs.value }}" \
+            dist/*.whl dist/*.tar.gz \
+            --title "nanvix-zutil v${{ steps.version.outputs.value }}" \
+            --generate-notes
         env:
-            NANVIX_TOOLCHAIN: /opt/nanvix
-            USER: runner
-        if: >-
-            github.event_name == 'workflow_dispatch' ||
-            github.event_name == 'push' ||
-            (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-'))
-        steps:
-            - uses: actions/checkout@v4
+          GH_TOKEN: ${{ github.token }}
 
-            - name: Install uv
-              run: |
-                  curl -LsSf https://astral.sh/uv/install.sh | sh
-                  echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-            - name: Install project and dev dependencies
-              run: uv sync --python 3.12
-
-            - name: Run tests
-              run: uv run pytest tests/ -v
-
-    release:
-        name: Build & Publish
-        needs: [lint-and-typecheck, test]
-        runs-on: ubuntu-latest
-        environment: release
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-
-            - name: Resolve version
-              id: version
-              run: |
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-                    VERSION="${{ inputs.version }}"
-                  else
-                    VERSION="${GITHUB_REF_NAME#release-}"
-                  fi
-                  if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
-                    echo "::error::Invalid semver: $VERSION"
-                    exit 1
-                  fi
-                  echo "value=$VERSION" >> "$GITHUB_OUTPUT"
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@v7
-              with:
-                  python-version: "3.12"
-
-            - name: Install dependencies
-              run: uv sync
-
-            - name: Verify version matches pyproject.toml
-              run: |
-                  actual=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
-                  if [ "$actual" != "${{ steps.version.outputs.value }}" ]; then
-                    echo "Version mismatch: pyproject.toml=$actual expected=${{ steps.version.outputs.value }}"
-                    exit 1
-                  fi
-
-            - name: Check tag does not already exist
-              run: |
-                  if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.value }}" | grep -q .; then
-                    echo "Tag v${{ steps.version.outputs.value }} already exists on origin. Bump the version in pyproject.toml before releasing."
-                    exit 1
-                  fi
-
-            - name: Build wheel and sdist
-              run: uv build
-
-            - name: Create and push release tag
-              run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git tag "v${{ steps.version.outputs.value }}"
-                  git push origin "v${{ steps.version.outputs.value }}"
-
-            - name: Create GitHub release
-              run: |
-                  gh release create "v${{ steps.version.outputs.value }}" \
-                    dist/*.whl dist/*.tar.gz \
-                    --title "nanvix-zutil v${{ steps.version.outputs.value }}" \
-                    --generate-notes
-              env:
-                  GH_TOKEN: ${{ github.token }}
-
-            # TODO: PyPI repo not yet set up
-            # - name: Publish to PyPI
-            #   run: uv publish
+      # TODO: PyPI repo not yet set up
+      # - name: Publish to PyPI
+      #   run: uv publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,13 +69,12 @@ locally, plus the `gh act` extension (`gh extension install nektos/gh-act`).
    ```bash
    git checkout dev
    git pull origin dev
-   git checkout -b release-0.3.0   # must be release-<version>
-   git push origin release-0.3.0
+   git checkout -b release/v0.3.0   # must be release/vX.Y.Z
+   git push origin release/v0.3.0
    ```
 
-   > **Important:** the branch name must use a hyphen (`release-X.Y.Z`), not a
-   > slash. The release workflow triggers on `push` to branches matching
-   > `release-*`.
+   > The release workflow triggers on `push` to branches matching
+   > `release/v*`.
 
 3. **Wait for the workflow.** Pushing the branch automatically triggers the
    [Release workflow](/.github/workflows/release.yml), which:
@@ -106,7 +105,7 @@ Append a pre-release suffix to the version for release candidates:
 version = "0.4.0-rc1"
 ```
 
-Branch name: `release-0.4.0-rc1`. The workflow accepts any valid semver
+Branch name: `release/v0.4.0-rc1`. The workflow accepts any valid semver
 string, including pre-release (`-rc1`, `-alpha.2`) and build metadata
 (`+build.42`) suffixes.
 


### PR DESCRIPTION
Rename release branch pattern from `release-*` to `release/v*` across all workflows and documentation.

### Changes
- **ci.yml** — updated branch triggers from `release-*` to `release/v*`
- **release.yml** — updated branch trigger, `startsWith` conditions, and version extraction (`${GITHUB_REF_NAME#release/v}`)
- **CONTRIBUTING.md** — updated examples and notes to use `release/vX.Y.Z` convention