### PR TITLE
[zutils] Route info and success logs to stderr

### DIFF
--- a/src/nanvix_zutil/log.py
+++ b/src/nanvix_zutil/log.py
@@ -46,9 +46,13 @@ def info(msg: str) -> None:
         msg: The message text.
     """
     if _json_mode:
-        print(json.dumps({"level": "info", "message": msg}), flush=True)
+        print(
+            json.dumps({"level": "info", "message": msg}),
+            file=sys.stderr,
+            flush=True,
+        )
     else:
-        print(f"\033[36minfo:\033[0m {msg}", flush=True)
+        print(f"\033[36minfo:\033[0m {msg}", file=sys.stderr, flush=True)
 
 
 def success(msg: str) -> None:
@@ -58,9 +62,13 @@ def success(msg: str) -> None:
         msg: The message text.
     """
     if _json_mode:
-        print(json.dumps({"level": "success", "message": msg}), flush=True)
+        print(
+            json.dumps({"level": "success", "message": msg}),
+            file=sys.stderr,
+            flush=True,
+        )
     else:
-        print(f"\033[32msuccess:\033[0m {msg}", flush=True)
+        print(f"\033[32msuccess:\033[0m {msg}", file=sys.stderr, flush=True)
 
 
 def warning(msg: str) -> None:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -120,11 +120,11 @@ class TestHelloWorldBash(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
 
     def test_json_mode(self) -> None:
-        """``--json`` produces parseable JSON on stdout."""
+        """``--json`` produces parseable JSON on stderr."""
         r = self._run_z("--json", "clean")
         self.assertEqual(r.returncode, 0, r.stderr)
-        json_lines = [ln for ln in r.stdout.splitlines() if ln.startswith("{")]
-        self.assertTrue(json_lines, "expected at least one JSON line on stdout")
+        json_lines = [ln for ln in r.stderr.splitlines() if ln.startswith("{")]
+        self.assertTrue(json_lines, "expected at least one JSON line on stderr")
         for line in json_lines:
             obj: object = json.loads(line)
             self.assertIsInstance(obj, dict)

--- a/tests/test_example_transitive.py
+++ b/tests/test_example_transitive.py
@@ -259,11 +259,11 @@ class TestHelloTransitiveCli(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
 
     def test_json_mode(self) -> None:
-        """``--json`` produces parseable JSON on stdout."""
+        """``--json`` produces parseable JSON on stderr."""
         r = self._run_z("--json", "clean")
         self.assertEqual(r.returncode, 0, r.stderr)
-        json_lines = [ln for ln in r.stdout.splitlines() if ln.startswith("{")]
-        self.assertTrue(json_lines, "expected at least one JSON line on stdout")
+        json_lines = [ln for ln in r.stderr.splitlines() if ln.startswith("{")]
+        self.assertTrue(json_lines, "expected at least one JSON line on stderr")
         for line in json_lines:
             obj: object = json.loads(line)
             self.assertIsInstance(obj, dict)

--- a/tests/test_example_zlib.py
+++ b/tests/test_example_zlib.py
@@ -124,11 +124,11 @@ class TestHelloZlibBash(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
 
     def test_json_mode(self) -> None:
-        """``--json`` produces parseable JSON on stdout."""
+        """``--json`` produces parseable JSON on stderr."""
         r = self._run_z("--json", "clean")
         self.assertEqual(r.returncode, 0, r.stderr)
-        json_lines = [ln for ln in r.stdout.splitlines() if ln.startswith("{")]
-        self.assertTrue(json_lines, "expected at least one JSON line on stdout")
+        json_lines = [ln for ln in r.stderr.splitlines() if ln.startswith("{")]
+        self.assertTrue(json_lines, "expected at least one JSON line on stderr")
         for line in json_lines:
             obj: object = json.loads(line)
             self.assertIsInstance(obj, dict)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -131,7 +131,7 @@ class TestIntegrationLifecycle(unittest.TestCase):
         self.assertIn("distclean", instance.called)
 
     def test_json_flag_enables_json_mode(self) -> None:
-        """--json flag produces JSON output on stdout."""
+        """--json flag produces JSON output on stderr."""
         from io import StringIO
 
         fake_script = str(self._repo_root / ".nanvix" / "z.py")
@@ -144,12 +144,12 @@ class TestIntegrationLifecycle(unittest.TestCase):
 
         # After main(), log mode was set to True. Verify it produces JSON output.
         buf = StringIO()
-        original_stdout = sys.stdout
-        sys.stdout = buf
+        original_stderr = sys.stderr
+        sys.stderr = buf
         try:
             log_mod.info("json-check")
         finally:
-            sys.stdout = original_stdout
+            sys.stderr = original_stderr
             log_mod.set_json_mode(False)
 
         raw: object = json.loads(buf.getvalue().strip())

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -19,21 +19,21 @@ class TestInfo(unittest.TestCase):
 
     def test_basic(self) -> None:
         buf = StringIO()
-        sys.stdout = buf
+        sys.stderr = buf
         try:
             log_mod.info("hello")
         finally:
-            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
         self.assertIn("hello", buf.getvalue())
 
     def test_json_mode(self) -> None:
         log_mod.set_json_mode(True)
         buf = StringIO()
-        sys.stdout = buf
+        sys.stderr = buf
         try:
             log_mod.info("hello json")
         finally:
-            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
             log_mod.set_json_mode(False)
         obj = json.loads(buf.getvalue().strip())
         self.assertEqual(obj["level"], "info")
@@ -48,21 +48,21 @@ class TestSuccess(unittest.TestCase):
 
     def test_basic(self) -> None:
         buf = StringIO()
-        sys.stdout = buf
+        sys.stderr = buf
         try:
             log_mod.success("done")
         finally:
-            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
         self.assertIn("done", buf.getvalue())
 
     def test_json_mode(self) -> None:
         log_mod.set_json_mode(True)
         buf = StringIO()
-        sys.stdout = buf
+        sys.stderr = buf
         try:
             log_mod.success("all good")
         finally:
-            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
             log_mod.set_json_mode(False)
         obj = json.loads(buf.getvalue().strip())
         self.assertEqual(obj["level"], "success")


### PR DESCRIPTION
## Problem

`log.info()` and `log.success()` write to **stdout**, which corrupts structured output when callers pipe stdout to a file. This breaks CI for any consumer with `[dependencies]` in `nanvix.toml` (e.g., SQLite depending on zlib).

**Failure:** `nanvix-zutil resolve >> "$GITHUB_OUTPUT"` in the reusable workflow mixes `info: Downloading nanvix.lock…` messages into the `key=value` output, causing:
```
##[error]Invalid format '\033[36minfo:\033[0m Downloading nanvix.lock from @1.3.1-nanvix-0.12.291…'
```

## Fix

Route `info()` and `success()` to `sys.stderr`, matching `warning()`, `error()`, and `fatal()` which already write to stderr.

## Testing

All 51 existing tests pass. Verified `info()` output goes to stderr and stdout remains clean.