### PR TITLE
[zutils] Strip v-prefix from sysroot version when suffixing dependency refs

### DIFF
--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -372,12 +372,15 @@ def load_manifest(path: Path) -> Manifest:
     # Auto-suffix VERSION refs with the nanvix sysroot version.
     # When the sysroot is "latest", suffixing is deferred to the resolver
     # (which resolves the sysroot first and knows the actual version).
-    if sysroot_ref.value != "latest":
+    # Strip the leading "v" from the sysroot version to match the release
+    # tag format used by nanvix-zutil (e.g. "1.3.1-nanvix-0.12.291").
+    if sysroot_ref.value != "latest" and isinstance(sysroot_ref.value, str):
+        version_suffix = sysroot_ref.value.removeprefix("v")
         for dep in [*dependencies, *system_dependencies]:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
                 dep.ref = Ref(
                     kind=dep.ref.kind,
-                    value=f"{dep.ref.value}-nanvix-{sysroot_ref.value}",
+                    value=f"{dep.ref.value}-nanvix-{version_suffix}",
                 )
 
     return Manifest(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -549,6 +549,24 @@ class TestLoadManifestEnvOverride(unittest.TestCase):
         self.assertEqual(m.sysroot_ref.value, "override_sha")
         self.assertEqual(m.dependencies[0].ref.value, "1.0.0-nanvix-override_sha")
 
+    def test_nanvix_version_v_prefix_stripped_in_suffix(self) -> None:
+        """NANVIX_VERSION with 'v' prefix must strip it for dep suffix."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "latest"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "v0.12.291"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.value, "v0.12.291")
+        self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-0.12.291")
+
     def test_nanvix_version_dep_overrides_dep(self) -> None:
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(


### PR DESCRIPTION
When `NANVIX_VERSION` is set to a git tag like `v0.12.291` (as the reusable CI workflow does), the `v` prefix was included in the dependency suffix, producing `1.3.1-nanvix-v0.12.291`. However, release tags use the bare version without the `v` prefix (e.g., `1.3.1-nanvix-0.12.291`).

This caused dependency resolution to fail with HTTP 404 for any port that declares dependencies in `nanvix.toml`. SQLite is the first such port, exposed by nanvix/sqlite#35.

**Root cause**: `manifest.py` used `sysroot_ref.value` directly as the suffix, while `resolver.py` (line 254) and `resolve_cmd.py` (line 102) both strip the `v` prefix.

**Fix**: Call `removeprefix("v")` on the sysroot version before constructing the dependency suffix in `manifest.py`, aligning it with the resolver and resolve command.

**Test**: Added test case verifying `NANVIX_VERSION=v0.12.291` produces suffix `1.3.1-nanvix-0.12.291` (without `v`).