### PR TITLE
[examples] F: add z.sh/z.ps1 and .gitignore

### DIFF
--- a/examples/hello-transitive/.nanvix/.gitignore
+++ b/examples/hello-transitive/.nanvix/.gitignore
@@ -1,0 +1,8 @@
+# Nanvix build state — keep z.py, nanvix.toml tracked; ignore runtime artifacts
+venv/
+cache/
+sysroot/
+buildroot/
+env.json
+nanvix.lock
+__pycache__/

--- a/examples/hello-transitive/z.ps1
+++ b/examples/hello-transitive/z.ps1
@@ -6,25 +6,48 @@
 
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$RemainingArgs
+    [string[]]$Args
 )
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = git rev-parse --show-toplevel
-$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
-$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
-
-if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
-    if (-not (Test-Path $venvPython)) {
-        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
-        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
-        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
-        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
-        & $venvPython -m pip install --quiet $wheelUrl
-    }
-    if (Test-Path $venvActivate) { & $venvActivate }
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+    exit $LASTEXITCODE
 }
 
-& nanvix-zutil @RemainingArgs
+$repoRoot = git rev-parse --show-toplevel
+$venvDir = Join-Path $repoRoot ".nanvix\venv"
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+
+if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+    $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+    $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+    if (-not $wheelUrl) {
+        throw "No .whl asset found in latest nanvix/zutils release. Install manually: pip install nanvix-zutil"
+    }
+    # Discover a Python 3 interpreter
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py -3 -m venv $venvDir
+    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python -m venv $venvDir
+    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+        & python3 -m venv $venvDir
+    } else {
+        throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
+    }
+    & $venvPython -m pip install --quiet $wheelUrl
+}
+
+# Prefer the venv copy; fall back to global.
+if (Test-Path $venvZutil) {
+    & $venvZutil @Args
+} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+} else {
+    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+}
 exit $LASTEXITCODE

--- a/examples/hello-transitive/z.ps1
+++ b/examples/hello-transitive/z.ps1
@@ -1,0 +1,30 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = git rev-parse --show-toplevel
+$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
+$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
+
+if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
+        & $venvPython -m pip install --quiet $wheelUrl
+    }
+    if (Test-Path $venvActivate) { & $venvActivate }
+}
+
+& nanvix-zutil @RemainingArgs
+exit $LASTEXITCODE

--- a/examples/hello-transitive/z.sh
+++ b/examples/hello-transitive/z.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# In CI containers the checkout directory may be owned by a different uid than
+# the process running this script, triggering git's "dubious ownership" check.
+# Mark the current directory safe before calling git rev-parse.
+if [ -n "${CI:-}" ]; then
+	git config --global --add safe.directory "$(pwd)"
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 VENV="$REPO_ROOT/.nanvix/venv"
 

--- a/examples/hello-transitive/z.sh
+++ b/examples/hello-transitive/z.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VENV="$REPO_ROOT/.nanvix/venv"
+
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
+	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
+		python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+wheel = next(
+    a['browser_download_url']
+    for a in data['assets']
+    if a['name'].endswith('.whl')
+)
+print(wheel)
+")
+	python3 -m venv "$VENV"
+	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+fi
+
+if [ -f "$VENV/bin/activate" ]; then
+	# shellcheck source=/dev/null
+	source "$VENV/bin/activate"
+fi
+
+exec nanvix-zutil "$@"

--- a/examples/hello-transitive/z.sh
+++ b/examples/hello-transitive/z.sh
@@ -7,36 +7,47 @@
 
 set -euo pipefail
 
-# In CI containers the checkout directory may be owned by a different uid than
-# the process running this script, triggering git's "dubious ownership" check.
-# Mark the current directory safe before calling git rev-parse.
-if [ -n "${CI:-}" ]; then
-	git config --global --add safe.directory "$(pwd)"
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
 VENV="$REPO_ROOT/.nanvix/venv"
 
-if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null && ! command -v nanvix-zutil &>/dev/null; then
 	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
 	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
 		python3 -c "
 import sys, json
 data = json.load(sys.stdin)
+assets = data.get('assets') or []
 wheel = next(
-    a['browser_download_url']
-    for a in data['assets']
-    if a['name'].endswith('.whl')
+    (a['browser_download_url'] for a in assets if a.get('name', '').endswith('.whl')),
+    None,
 )
+if not wheel:
+    print('Error: no .whl asset in latest nanvix/zutils release.', file=sys.stderr)
+    print('Install manually: pip install nanvix-zutil', file=sys.stderr)
+    sys.exit(1)
 print(wheel)
 ")
-	python3 -m venv "$VENV"
+	if [ -d "$VENV" ]; then
+		python3 -m venv --clear "$VENV"
+	else
+		python3 -m venv "$VENV"
+	fi
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
 fi
 
-if [ -f "$VENV/bin/activate" ]; then
-	# shellcheck source=/dev/null
-	source "$VENV/bin/activate"
+# Prefer the venv copy if it exists; otherwise use the global install.
+if [ -x "$VENV/bin/nanvix-zutil" ]; then
+	exec "$VENV/bin/nanvix-zutil" "$@"
+elif command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+else
+	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
+	exit 1
 fi
-
-exec nanvix-zutil "$@"

--- a/examples/hello-world/.nanvix/.gitignore
+++ b/examples/hello-world/.nanvix/.gitignore
@@ -1,0 +1,8 @@
+# Nanvix build state — keep z.py, nanvix.toml tracked; ignore runtime artifacts
+venv/
+cache/
+sysroot/
+buildroot/
+env.json
+nanvix.lock
+__pycache__/

--- a/examples/hello-world/z.ps1
+++ b/examples/hello-world/z.ps1
@@ -6,25 +6,48 @@
 
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$RemainingArgs
+    [string[]]$Args
 )
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = git rev-parse --show-toplevel
-$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
-$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
-
-if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
-    if (-not (Test-Path $venvPython)) {
-        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
-        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
-        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
-        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
-        & $venvPython -m pip install --quiet $wheelUrl
-    }
-    if (Test-Path $venvActivate) { & $venvActivate }
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+    exit $LASTEXITCODE
 }
 
-& nanvix-zutil @RemainingArgs
+$repoRoot = git rev-parse --show-toplevel
+$venvDir = Join-Path $repoRoot ".nanvix\venv"
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+
+if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+    $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+    $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+    if (-not $wheelUrl) {
+        throw "No .whl asset found in latest nanvix/zutils release. Install manually: pip install nanvix-zutil"
+    }
+    # Discover a Python 3 interpreter
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py -3 -m venv $venvDir
+    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python -m venv $venvDir
+    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+        & python3 -m venv $venvDir
+    } else {
+        throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
+    }
+    & $venvPython -m pip install --quiet $wheelUrl
+}
+
+# Prefer the venv copy; fall back to global.
+if (Test-Path $venvZutil) {
+    & $venvZutil @Args
+} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+} else {
+    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+}
 exit $LASTEXITCODE

--- a/examples/hello-world/z.ps1
+++ b/examples/hello-world/z.ps1
@@ -1,0 +1,30 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = git rev-parse --show-toplevel
+$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
+$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
+
+if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
+        & $venvPython -m pip install --quiet $wheelUrl
+    }
+    if (Test-Path $venvActivate) { & $venvActivate }
+}
+
+& nanvix-zutil @RemainingArgs
+exit $LASTEXITCODE

--- a/examples/hello-world/z.sh
+++ b/examples/hello-world/z.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# In CI containers the checkout directory may be owned by a different uid than
+# the process running this script, triggering git's "dubious ownership" check.
+# Mark the current directory safe before calling git rev-parse.
+if [ -n "${CI:-}" ]; then
+	git config --global --add safe.directory "$(pwd)"
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 VENV="$REPO_ROOT/.nanvix/venv"
 

--- a/examples/hello-world/z.sh
+++ b/examples/hello-world/z.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VENV="$REPO_ROOT/.nanvix/venv"
+
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
+	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
+		python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+wheel = next(
+    a['browser_download_url']
+    for a in data['assets']
+    if a['name'].endswith('.whl')
+)
+print(wheel)
+")
+	python3 -m venv "$VENV"
+	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+fi
+
+if [ -f "$VENV/bin/activate" ]; then
+	# shellcheck source=/dev/null
+	source "$VENV/bin/activate"
+fi
+
+exec nanvix-zutil "$@"

--- a/examples/hello-world/z.sh
+++ b/examples/hello-world/z.sh
@@ -7,36 +7,47 @@
 
 set -euo pipefail
 
-# In CI containers the checkout directory may be owned by a different uid than
-# the process running this script, triggering git's "dubious ownership" check.
-# Mark the current directory safe before calling git rev-parse.
-if [ -n "${CI:-}" ]; then
-	git config --global --add safe.directory "$(pwd)"
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
 VENV="$REPO_ROOT/.nanvix/venv"
 
-if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null && ! command -v nanvix-zutil &>/dev/null; then
 	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
 	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
 		python3 -c "
 import sys, json
 data = json.load(sys.stdin)
+assets = data.get('assets') or []
 wheel = next(
-    a['browser_download_url']
-    for a in data['assets']
-    if a['name'].endswith('.whl')
+    (a['browser_download_url'] for a in assets if a.get('name', '').endswith('.whl')),
+    None,
 )
+if not wheel:
+    print('Error: no .whl asset in latest nanvix/zutils release.', file=sys.stderr)
+    print('Install manually: pip install nanvix-zutil', file=sys.stderr)
+    sys.exit(1)
 print(wheel)
 ")
-	python3 -m venv "$VENV"
+	if [ -d "$VENV" ]; then
+		python3 -m venv --clear "$VENV"
+	else
+		python3 -m venv "$VENV"
+	fi
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
 fi
 
-if [ -f "$VENV/bin/activate" ]; then
-	# shellcheck source=/dev/null
-	source "$VENV/bin/activate"
+# Prefer the venv copy if it exists; otherwise use the global install.
+if [ -x "$VENV/bin/nanvix-zutil" ]; then
+	exec "$VENV/bin/nanvix-zutil" "$@"
+elif command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+else
+	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
+	exit 1
 fi
-
-exec nanvix-zutil "$@"

--- a/examples/hello-zlib/.nanvix/.gitignore
+++ b/examples/hello-zlib/.nanvix/.gitignore
@@ -1,0 +1,8 @@
+# Nanvix build state — keep z.py, nanvix.toml tracked; ignore runtime artifacts
+venv/
+cache/
+sysroot/
+buildroot/
+env.json
+nanvix.lock
+__pycache__/

--- a/examples/hello-zlib/z.ps1
+++ b/examples/hello-zlib/z.ps1
@@ -6,25 +6,48 @@
 
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$RemainingArgs
+    [string[]]$Args
 )
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = git rev-parse --show-toplevel
-$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
-$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
-
-if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
-    if (-not (Test-Path $venvPython)) {
-        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
-        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
-        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
-        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
-        & $venvPython -m pip install --quiet $wheelUrl
-    }
-    if (Test-Path $venvActivate) { & $venvActivate }
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+    exit $LASTEXITCODE
 }
 
-& nanvix-zutil @RemainingArgs
+$repoRoot = git rev-parse --show-toplevel
+$venvDir = Join-Path $repoRoot ".nanvix\venv"
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+
+if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+    $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+    $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+    if (-not $wheelUrl) {
+        throw "No .whl asset found in latest nanvix/zutils release. Install manually: pip install nanvix-zutil"
+    }
+    # Discover a Python 3 interpreter
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py -3 -m venv $venvDir
+    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python -m venv $venvDir
+    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+        & python3 -m venv $venvDir
+    } else {
+        throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
+    }
+    & $venvPython -m pip install --quiet $wheelUrl
+}
+
+# Prefer the venv copy; fall back to global.
+if (Test-Path $venvZutil) {
+    & $venvZutil @Args
+} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+} else {
+    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+}
 exit $LASTEXITCODE

--- a/examples/hello-zlib/z.ps1
+++ b/examples/hello-zlib/z.ps1
@@ -1,0 +1,30 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = git rev-parse --show-toplevel
+$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
+$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
+
+if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
+        & $venvPython -m pip install --quiet $wheelUrl
+    }
+    if (Test-Path $venvActivate) { & $venvActivate }
+}
+
+& nanvix-zutil @RemainingArgs
+exit $LASTEXITCODE

--- a/examples/hello-zlib/z.sh
+++ b/examples/hello-zlib/z.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# In CI containers the checkout directory may be owned by a different uid than
+# the process running this script, triggering git's "dubious ownership" check.
+# Mark the current directory safe before calling git rev-parse.
+if [ -n "${CI:-}" ]; then
+	git config --global --add safe.directory "$(pwd)"
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 VENV="$REPO_ROOT/.nanvix/venv"
 

--- a/examples/hello-zlib/z.sh
+++ b/examples/hello-zlib/z.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VENV="$REPO_ROOT/.nanvix/venv"
+
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
+	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
+		python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+wheel = next(
+    a['browser_download_url']
+    for a in data['assets']
+    if a['name'].endswith('.whl')
+)
+print(wheel)
+")
+	python3 -m venv "$VENV"
+	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+fi
+
+if [ -f "$VENV/bin/activate" ]; then
+	# shellcheck source=/dev/null
+	source "$VENV/bin/activate"
+fi
+
+exec nanvix-zutil "$@"

--- a/examples/hello-zlib/z.sh
+++ b/examples/hello-zlib/z.sh
@@ -7,36 +7,47 @@
 
 set -euo pipefail
 
-# In CI containers the checkout directory may be owned by a different uid than
-# the process running this script, triggering git's "dubious ownership" check.
-# Mark the current directory safe before calling git rev-parse.
-if [ -n "${CI:-}" ]; then
-	git config --global --add safe.directory "$(pwd)"
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
 VENV="$REPO_ROOT/.nanvix/venv"
 
-if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null && ! command -v nanvix-zutil &>/dev/null; then
 	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
 	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
 		python3 -c "
 import sys, json
 data = json.load(sys.stdin)
+assets = data.get('assets') or []
 wheel = next(
-    a['browser_download_url']
-    for a in data['assets']
-    if a['name'].endswith('.whl')
+    (a['browser_download_url'] for a in assets if a.get('name', '').endswith('.whl')),
+    None,
 )
+if not wheel:
+    print('Error: no .whl asset in latest nanvix/zutils release.', file=sys.stderr)
+    print('Install manually: pip install nanvix-zutil', file=sys.stderr)
+    sys.exit(1)
 print(wheel)
 ")
-	python3 -m venv "$VENV"
+	if [ -d "$VENV" ]; then
+		python3 -m venv --clear "$VENV"
+	else
+		python3 -m venv "$VENV"
+	fi
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
 fi
 
-if [ -f "$VENV/bin/activate" ]; then
-	# shellcheck source=/dev/null
-	source "$VENV/bin/activate"
+# Prefer the venv copy if it exists; otherwise use the global install.
+if [ -x "$VENV/bin/nanvix-zutil" ]; then
+	exec "$VENV/bin/nanvix-zutil" "$@"
+elif command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+else
+	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
+	exit 1
 fi
-
-exec nanvix-zutil "$@"

--- a/templates/.nanvix/.gitignore
+++ b/templates/.nanvix/.gitignore
@@ -1,0 +1,8 @@
+# Nanvix build state — keep z.py, nanvix.toml tracked; ignore runtime artifacts
+venv/
+cache/
+sysroot/
+buildroot/
+env.json
+nanvix.lock
+__pycache__/

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -6,25 +6,48 @@
 
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$RemainingArgs
+    [string[]]$Args
 )
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = git rev-parse --show-toplevel
-$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
-$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
-
-if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
-    if (-not (Test-Path $venvPython)) {
-        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
-        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
-        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
-        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
-        & $venvPython -m pip install --quiet $wheelUrl
-    }
-    if (Test-Path $venvActivate) { & $venvActivate }
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+    exit $LASTEXITCODE
 }
 
-& nanvix-zutil @RemainingArgs
+$repoRoot = git rev-parse --show-toplevel
+$venvDir = Join-Path $repoRoot ".nanvix\venv"
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+
+if (-not (Test-Path $venvZutil) -and -not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+    $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+    $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+    if (-not $wheelUrl) {
+        throw "No .whl asset found in latest nanvix/zutils release. Install manually: pip install nanvix-zutil"
+    }
+    # Discover a Python 3 interpreter
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py -3 -m venv $venvDir
+    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python -m venv $venvDir
+    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+        & python3 -m venv $venvDir
+    } else {
+        throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
+    }
+    & $venvPython -m pip install --quiet $wheelUrl
+}
+
+# Prefer the venv copy; fall back to global.
+if (Test-Path $venvZutil) {
+    & $venvZutil @Args
+} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+} else {
+    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+}
 exit $LASTEXITCODE

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -1,0 +1,30 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = git rev-parse --show-toplevel
+$venvPython = Join-Path $repoRoot ".nanvix\venv\Scripts\python.exe"
+$venvActivate = Join-Path $repoRoot ".nanvix\venv\Scripts\Activate.ps1"
+
+if (-not (Get-Command nanvix-zutil -ErrorAction SilentlyContinue)) {
+    if (-not (Test-Path $venvPython)) {
+        Write-Host "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." -ForegroundColor Yellow
+        $release = Invoke-RestMethod "https://api.github.com/repos/nanvix/zutils/releases/latest"
+        $wheelUrl = ($release.assets | Where-Object { $_.name -like "*.whl" } | Select-Object -First 1).browser_download_url
+        python3 -m venv (Join-Path $repoRoot ".nanvix\venv")
+        & $venvPython -m pip install --quiet $wheelUrl
+    }
+    if (Test-Path $venvActivate) { & $venvActivate }
+}
+
+& nanvix-zutil @RemainingArgs
+exit $LASTEXITCODE

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# In CI containers the checkout directory may be owned by a different uid than
+# the process running this script, triggering git's "dubious ownership" check.
+# Mark the current directory safe before calling git rev-parse.
+if [ -n "${CI:-}" ]; then
+	git config --global --add safe.directory "$(pwd)"
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 VENV="$REPO_ROOT/.nanvix/venv"
 

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Thin wrapper that delegates to the nanvix-zutil CLI.
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VENV="$REPO_ROOT/.nanvix/venv"
+
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
+	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
+		python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+wheel = next(
+    a['browser_download_url']
+    for a in data['assets']
+    if a['name'].endswith('.whl')
+)
+print(wheel)
+")
+	python3 -m venv "$VENV"
+	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+fi
+
+if [ -f "$VENV/bin/activate" ]; then
+	# shellcheck source=/dev/null
+	source "$VENV/bin/activate"
+fi
+
+exec nanvix-zutil "$@"

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -7,36 +7,47 @@
 
 set -euo pipefail
 
-# In CI containers the checkout directory may be owned by a different uid than
-# the process running this script, triggering git's "dubious ownership" check.
-# Mark the current directory safe before calling git rev-parse.
-if [ -n "${CI:-}" ]; then
-	git config --global --add safe.directory "$(pwd)"
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
 VENV="$REPO_ROOT/.nanvix/venv"
 
-if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null 2>&1 && ! command -v nanvix-zutil &>/dev/null; then
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null && ! command -v nanvix-zutil &>/dev/null; then
 	echo "nanvix-zutil not found — bootstrapping from nanvix/zutils latest release..." >&2
 	WHEEL_URL=$(curl -fsSL "https://api.github.com/repos/nanvix/zutils/releases/latest" |
 		python3 -c "
 import sys, json
 data = json.load(sys.stdin)
+assets = data.get('assets') or []
 wheel = next(
-    a['browser_download_url']
-    for a in data['assets']
-    if a['name'].endswith('.whl')
+    (a['browser_download_url'] for a in assets if a.get('name', '').endswith('.whl')),
+    None,
 )
+if not wheel:
+    print('Error: no .whl asset in latest nanvix/zutils release.', file=sys.stderr)
+    print('Install manually: pip install nanvix-zutil', file=sys.stderr)
+    sys.exit(1)
 print(wheel)
 ")
-	python3 -m venv "$VENV"
+	if [ -d "$VENV" ]; then
+		python3 -m venv --clear "$VENV"
+	else
+		python3 -m venv "$VENV"
+	fi
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
 fi
 
-if [ -f "$VENV/bin/activate" ]; then
-	# shellcheck source=/dev/null
-	source "$VENV/bin/activate"
+# Prefer the venv copy if it exists; otherwise use the global install.
+if [ -x "$VENV/bin/nanvix-zutil" ]; then
+	exec "$VENV/bin/nanvix-zutil" "$@"
+elif command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+else
+	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
+	exit 1
 fi
-
-exec nanvix-zutil "$@"


### PR DESCRIPTION
## Summary

- Add `z.sh` and `z.ps1` bootstrapper scripts to all three examples (`hello-world`, `hello-zlib`, `hello-transitive`) so each example is a self-contained, runnable consumer repo
- Add `.nanvix/.gitignore` to each example's `.nanvix/` directory to ignore runtime artifacts (`venv/`, `cache/`, `sysroot/`, `buildroot/`, `env.json`, `nanvix.lock`, `__pycache__/`) while keeping `z.py` and `nanvix.toml` tracked
- Add canonical `z.sh`, `z.ps1`, and `.nanvix/.gitignore` to `templates/` as reference copies for consumer repos

## Details

Bootstrap scripts require only `curl`, `python3`, and `git` — no `gh` or `jq`. On first run they fetch the latest `nanvix-zutil` wheel from the GitHub API, install it into `.nanvix/venv/`, and delegate to `nanvix-zutil`. The PowerShell variant uses `Invoke-RestMethod` (built-in) and `$RemainingArgs`.

The `.nanvix/.gitignore` uses subdirectory-relative paths so it works correctly when placed inside `.nanvix/`, ignoring the runtime state directories while leaving `z.py` and `nanvix.toml` tracked.