### PR TITLE
[zutils] B: Fix bootstrapper robustness issues from Copilot reviews

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -435,6 +435,19 @@ def version() -> int:
             if src.exists():
                 shutil.copy(src, example / name)
 
+    # Sync .nanvix directory templates into each example.
+    nanvix_templates = [".gitignore"]
+    for example in sorted(examples_dir.iterdir()):
+        if not example.is_dir():
+            continue
+        nanvix_dir = example / ".nanvix"
+        if not nanvix_dir.is_dir():
+            continue
+        for name in nanvix_templates:
+            src = templates_dir / name
+            if src.exists():
+                shutil.copy(src, nanvix_dir / name)
+
     print(f"\nVersion bumped: {current} -> {new}")
     return 0
 

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,0 +1,6 @@
+venv/
+cache/
+sysroot/
+buildroot/
+env.json
+nanvix.lock

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -4,3 +4,4 @@ sysroot/
 buildroot/
 env.json
 nanvix.lock
+__pycache__/

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -39,33 +39,57 @@ function Bootstrap {
     $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
 
     # Discover a Python 3 interpreter.
+    $venvArgs = @("-m", "venv")
+    if (Test-Path $venvDir) { $venvArgs += "--clear" }
+    $venvArgs += $venvDir
+
     if (Get-Command py -ErrorAction SilentlyContinue) {
-        & py -3 -m venv $venvDir
+        & py -3 @venvArgs
     }
     elseif (Get-Command python -ErrorAction SilentlyContinue) {
-        & python -m venv $venvDir
+        & python @venvArgs
     }
     elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
-        & python3 -m venv $venvDir
+        & python3 @venvArgs
     }
     else {
         throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
     }
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "venv creation failed (exit code $LASTEXITCODE)"
+    }
     & $venvPython -m pip install --quiet $wheelUrl
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "pip install failed (exit code $LASTEXITCODE)"
+    }
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
 if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     Bootstrap
+    if (-not (Test-Path $venvZutil)) {
+        throw "Bootstrap completed but $venvZutil not found."
+    }
     $bin = $venvZutil
 }
 elseif (Test-Path $venvZutil) {
+    $venvVersion = try { & $venvZutil --version 2>$null } catch { $null }
+    if ($venvVersion -ne "nanvix-zutil ${zutilVersion}") {
+        Write-Warning "Venv nanvix-zutil version mismatch. Expected ${zutilVersion}, found ${venvVersion}. Re-bootstrapping..."
+        Bootstrap
+        if (-not (Test-Path $venvZutil)) {
+            throw "Bootstrap completed but $venvZutil not found."
+        }
+    }
     $bin = $venvZutil
 }
 elseif ((Test-Path $venvDir) -and (-not $zutilGlobalVersion)) {
     Write-Warning "Incomplete venv detected (binary missing). Re-running bootstrap..."
     Bootstrap
+    if (-not (Test-Path $venvZutil)) {
+        throw "Bootstrap completed but $venvZutil not found."
+    }
     $bin = $venvZutil
 }
 else {

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -35,24 +35,24 @@ function bootstrap() {
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
 if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
-	bootstrap
-	BIN="$VENV_BIN"
+    bootstrap
+    BIN="$VENV_BIN"
 elif [ -x "$VENV_BIN" ]; then
-	VENV_VERSION="$("$VENV_BIN" --version 2>/dev/null || true)"
-	if [ "$VENV_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
-		echo "Warning: venv nanvix-zutil version mismatch. Expected ${ZUTIL_VERSION}, found ${VENV_VERSION}. Re-bootstrapping..." >&2
-		bootstrap
-	fi
-	BIN="$VENV_BIN"
+    VENV_VERSION="$("$VENV_BIN" --version 2>/dev/null || true)"
+    if [ "$VENV_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+        echo "Warning: venv nanvix-zutil version mismatch. Expected ${ZUTIL_VERSION}, found ${VENV_VERSION}. Re-bootstrapping..." >&2
+        bootstrap
+    fi
+    BIN="$VENV_BIN"
 elif [ -d "$VENV" ] && ! command -v nanvix-zutil &>/dev/null; then
-	echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2
-	bootstrap
-	BIN="$VENV_BIN"
+    echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2
+    bootstrap
+    BIN="$VENV_BIN"
 else
-	BIN="nanvix-zutil"
-	if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
-		echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
-	fi
+    BIN="nanvix-zutil"
+    if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+        echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+    fi
 fi
 
 exec "$BIN" "$@"

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -35,19 +35,24 @@ function bootstrap() {
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
 if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
-    bootstrap
-    BIN="$VENV_BIN"
+	bootstrap
+	BIN="$VENV_BIN"
 elif [ -x "$VENV_BIN" ]; then
-    BIN="$VENV_BIN"
+	VENV_VERSION="$("$VENV_BIN" --version 2>/dev/null || true)"
+	if [ "$VENV_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+		echo "Warning: venv nanvix-zutil version mismatch. Expected ${ZUTIL_VERSION}, found ${VENV_VERSION}. Re-bootstrapping..." >&2
+		bootstrap
+	fi
+	BIN="$VENV_BIN"
 elif [ -d "$VENV" ] && ! command -v nanvix-zutil &>/dev/null; then
-    echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2
-    bootstrap
-    BIN="$VENV_BIN"
+	echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2
+	bootstrap
+	BIN="$VENV_BIN"
 else
-    BIN="nanvix-zutil"
-    if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
-        echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
-    fi
+	BIN="nanvix-zutil"
+	if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+		echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+	fi
 fi
 
 exec "$BIN" "$@"


### PR DESCRIPTION
## Summary

Fixes three issues flagged by GitHub Copilot across six automated "Sync zutils v0.5.1" PRs, plus adds a `.gitignore` template for `.nanvix/` directories.

Closes #44

## Fixes

### 1. Stale venv — no version check before using cached binary

**`z.sh`** and **`z.ps1`** now verify `--version` output against the expected version string before reusing a cached venv. On mismatch, a warning is printed and bootstrap re-runs.

Copilot comments:
- https://github.com/nanvix/zlib/pull/46#discussion_r3023498880
- https://github.com/nanvix/libffi/pull/38#discussion_r3023502225
- https://github.com/nanvix/zlib/pull/46#discussion_r3023498943
- https://github.com/nanvix/libffi/pull/38#discussion_r3023502262

### 2. `z.ps1` bootstrap doesn't use `--clear` on existing venv

Bootstrap now builds a `$venvArgs` array and appends `--clear` when the venv directory already exists. All three Python dispatcher branches use splatting (`@venvArgs`).

Copilot comments:
- https://github.com/nanvix/bzip2/pull/55#discussion_r3023492030
- https://github.com/nanvix/quickjs/pull/15#discussion_r3023509351
- https://github.com/nanvix/cpython/pull/338#discussion_r3023513382

### 3. `z.ps1` missing `$LASTEXITCODE` checks after external commands

Every external command in the Bootstrap function now checks `$LASTEXITCODE` and throws on failure. A post-bootstrap existence check for `$venvZutil` is also added.

Copilot comment:
- https://github.com/nanvix/openssl/pull/31#discussion_r3023500104

### 4. `.gitignore` template for `.nanvix/` directories

New `templates/.gitignore` with standard exclusions. `tasks.py version()` syncs it into `examples/*/.nanvix/` on version bump.

## Downstream impact

Once merged to `dev`, the Update Zutils workflow will propagate these fixes to all downstream repos automatically.

## Affected downstream PRs

| Repo | PR |
|------|----|
| nanvix/openssl | #31 |
| nanvix/cpython | #338 |
| nanvix/quickjs | #15 |
| nanvix/bzip2 | #55 |
| nanvix/libffi | #38 |
| nanvix/zlib | #46 |