### PR TITLE
[ci] E: Shift cron to 03:00 UTC

### DIFF
--- a/templates/nanvix-ci.yml
+++ b/templates/nanvix-ci.yml
@@ -5,7 +5,7 @@ name: Nanvix CI
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 3 * * *"
   push:
     branches: ["nanvix/**"]
   pull_request:


### PR DESCRIPTION
## Summary
- Shifts the scheduled CI cron in the caller template from midnight (`0 0 * * *`) to 03:00 UTC (`0 3 * * *`), avoiding overlap with the `nanvix-update-zutils` workflow that also runs at 03:00 and will propagate this change to all consumer repos.