### PR TITLE
Add resilient version fallback to resolver

### DIFF
--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -26,11 +26,23 @@ Public re-exports:
 - :func:`~nanvix_zutil.docker.image_exists` — check local image availability
 - :class:`~nanvix_zutil.info.NanvixInfo` — resolved Nanvix release information
 - :func:`~nanvix_zutil.info.get_nanvix_info` — query Nanvix release info
-- ``BUILDROOT_CONTAINER_PATH``, ``SYSROOT_CONTAINER_PATH``, ``WORKSPACE_CONTAINER_PATH``, ``TOOLCHAIN_CONTAINER_PATH`` — well-known container paths
+- :func:`~nanvix_zutil.buildroot.suffix_dep` — suffix a dep's VERSION ref with a nanvix version
+- :func:`~nanvix_zutil.buildroot.extract_nanvix_version` — extract nanvix version from a suffixed tag
+- :func:`~nanvix_zutil.buildroot.extract_nanvix_version_base` — extract base version from a suffixed tag
+- :func:`~nanvix_zutil.buildroot.parse_semver_tuple` — parse semver string to tuple for comparison
 - :mod:`nanvix_zutil.log` — structured logging helpers
 """
 
-from nanvix_zutil.buildroot import Buildroot, Dependency, Ref, RefKind, suffix_dep
+from nanvix_zutil.buildroot import (
+    Buildroot,
+    Dependency,
+    Ref,
+    RefKind,
+    extract_nanvix_version,
+    extract_nanvix_version_base,
+    parse_semver_tuple,
+    suffix_dep,
+)
 from nanvix_zutil.config import (
     CFG_GH_TOKEN,
     CFG_SYSROOT,
@@ -104,10 +116,13 @@ __all__ = [
     "Sysroot",
     "ZScript",
     "docker_available",
+    "extract_nanvix_version",
+    "extract_nanvix_version_base",
     "get_nanvix_info",
     "image_exists",
     "is_stale",
     "load_manifest",
+    "parse_semver_tuple",
     "read_lockfile",
     "resolve",
     "resolve_release",

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -26,6 +26,8 @@ Public re-exports:
 - :func:`~nanvix_zutil.docker.image_exists` — check local image availability
 - :class:`~nanvix_zutil.info.NanvixInfo` — resolved Nanvix release information
 - :func:`~nanvix_zutil.info.get_nanvix_info` — query Nanvix release info
+- :func:`~nanvix_zutil.github.resolve_release` — resolve a release by version specifier
+- :func:`~nanvix_zutil.github.resolve_release_with_fallback` — resolve a release with fallback to best available
 - :func:`~nanvix_zutil.buildroot.suffix_dep` — suffix a dep's VERSION ref with a nanvix version
 - :func:`~nanvix_zutil.buildroot.extract_nanvix_version` — extract nanvix version from a suffixed tag
 - :func:`~nanvix_zutil.buildroot.extract_nanvix_version_base` — extract base version from a suffixed tag
@@ -69,7 +71,7 @@ from nanvix_zutil.exitcodes import (
     EXIT_SUCCESS,
     EXIT_TEST_FAILURE,
 )
-from nanvix_zutil.github import resolve_release
+from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
 from nanvix_zutil.info import NanvixInfo, get_nanvix_info
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -126,6 +128,7 @@ __all__ = [
     "read_lockfile",
     "resolve",
     "resolve_release",
+    "resolve_release_with_fallback",
     "suffix_dep",
     "write_lockfile",
 ]

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -139,6 +139,59 @@ def suffix_dep(dep: Dependency, version: str) -> Dependency:
     return dep
 
 
+def extract_nanvix_version(suffixed_tag: str) -> str | None:
+    """Extract the nanvix version from a suffixed tag.
+
+    Given a tag like ``"1.3.1-nanvix-0.12.291"``, returns ``"0.12.291"``.
+    Returns ``None`` if the tag does not contain the ``-nanvix-`` infix.
+
+    Args:
+        suffixed_tag: A release tag that may contain ``-nanvix-{version}``.
+
+    Returns:
+        The nanvix version string, or ``None``.
+    """
+    marker = "-nanvix-"
+    idx = suffixed_tag.find(marker)
+    if idx == -1:
+        return None
+    return suffixed_tag[idx + len(marker) :]
+
+
+def extract_nanvix_version_base(suffixed_value: str) -> str | None:
+    """Extract the base package version from a suffixed ref value.
+
+    Given ``"1.3.1-nanvix-0.12.291"``, returns ``"1.3.1"``.
+    Returns ``None`` if the value does not contain ``-nanvix-``.
+
+    Args:
+        suffixed_value: A ref value that may contain ``-nanvix-{version}``.
+
+    Returns:
+        The base package version string, or ``None``.
+    """
+    marker = "-nanvix-"
+    idx = suffixed_value.find(marker)
+    if idx == -1:
+        return None
+    return suffixed_value[:idx]
+
+
+def parse_semver_tuple(version: str) -> tuple[int, ...]:
+    """Parse a semver string into a tuple of integers for comparison.
+
+    Args:
+        version: A dotted version string (e.g. ``"0.12.291"``).
+
+    Returns:
+        Tuple of integer parts (e.g. ``(0, 12, 291)``).
+
+    Raises:
+        ValueError: If any part is not an integer.
+    """
+    return tuple(int(p) for p in version.split("."))
+
+
 # ---------------------------------------------------------------------------
 # Buildroot
 # ---------------------------------------------------------------------------

--- a/src/nanvix_zutil/github.py
+++ b/src/nanvix_zutil/github.py
@@ -214,6 +214,32 @@ def _try_fetch_release_by_tag(
     return _fetch_release_by_url(repo, tag, url, headers, allow_404=True)
 
 
+def _find_best_release(
+    repo: str,
+    tag_prefix: str,
+    headers: dict[str, str],
+) -> dict[str, object] | None:
+    """Find the newest release whose tag starts with *tag_prefix*.
+
+    Scans releases in reverse-chronological order (GitHub API default)
+    and returns the first match. Because GitHub lists releases newest
+    first, the first match is the most recent.
+
+    Args:
+        repo: Repository in ``owner/name`` format.
+        tag_prefix: Tag prefix to match (e.g. ``"1.3.1-nanvix-"``).
+        headers: HTTP headers.
+
+    Returns:
+        The release metadata dictionary, or ``None`` if no match.
+    """
+    for release in _list_releases(repo, headers):
+        tag = release.get("tag_name")
+        if isinstance(tag, str) and tag.startswith(tag_prefix):
+            return release
+    return None
+
+
 def _list_releases(
     repo: str,
     headers: dict[str, str],
@@ -420,6 +446,76 @@ def resolve_release(
     result = _resolve_release(repo, version_specifier, headers, semver=semver)
     assert result is not None  # allow_missing defaults to False
     return result
+
+
+def resolve_release_with_fallback(
+    repo: str,
+    version_specifier: str,
+    base_version: str,
+    gh_token: str | None = None,
+) -> tuple[dict[str, object], str | None]:
+    """Resolve a release, falling back to the best available on 404.
+
+    Tries to fetch the release by exact tag. If the tag does not exist
+    (HTTP 404), scans the repo's releases for the newest tag matching
+    ``{base_version}-nanvix-*``.
+
+    Args:
+        repo: Repository in ``owner/name`` format.
+        version_specifier: Exact tag to try first
+            (e.g. ``"1.3.1-nanvix-0.12.337"``).
+        base_version: The base package version without nanvix suffix
+            (e.g. ``"1.3.1"``). Used to construct the fallback prefix.
+        gh_token: Optional GitHub personal access token.
+
+    Returns:
+        A tuple of (release_dict, fallback_nanvix_version). The second
+        element is ``None`` when the exact tag was found, or the nanvix
+        version string from the fallback tag (e.g. ``"0.12.291"``) when
+        a fallback was used.
+
+    Raises:
+        SystemExit: If no matching release is found at all.
+    """
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    if gh_token:
+        headers["Authorization"] = f"Bearer {gh_token}"
+
+    # Try exact tag first.
+    result = _resolve_release(repo, version_specifier, headers, allow_missing=True)
+    if result is not None:
+        return result, None
+
+    # Fallback: scan for best available release matching the base version.
+    prefix = f"{base_version}-nanvix-"
+    best = _find_best_release(repo, prefix, headers)
+    if best is None:
+        log.fatal(
+            f"No release found for {repo}@{version_specifier} and no "
+            f"fallback release matching '{prefix}*' exists",
+            code=EXIT_MISSING_DEP,
+            hint=f"Ensure {repo} has at least one release tagged "
+            f"'{base_version}-nanvix-<version>'.",
+        )
+
+    tag = best.get("tag_name")
+    if not isinstance(tag, str):
+        log.fatal(
+            f"Fallback release for {repo} has no tag_name",
+            code=EXIT_NETWORK_ERROR,
+        )
+
+    from nanvix_zutil.buildroot import extract_nanvix_version
+
+    nanvix_ver = extract_nanvix_version(tag)
+    if nanvix_ver is None:
+        log.fatal(
+            f"Fallback release tag '{tag}' for {repo} does not contain "
+            f"a nanvix version suffix",
+            code=EXIT_NETWORK_ERROR,
+        )
+
+    return best, nanvix_ver
 
 
 @overload

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -20,7 +20,14 @@ from pathlib import Path
 from typing import cast
 
 from nanvix_zutil import github, log
-from nanvix_zutil.buildroot import Dependency, suffix_dep
+from nanvix_zutil.buildroot import (
+    Dependency,
+    Ref,
+    RefKind,
+    extract_nanvix_version_base,
+    parse_semver_tuple,
+    suffix_dep,
+)
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_NETWORK_ERROR
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -156,6 +163,32 @@ def _detect_cycles(packages: list[ResolvedPackage]) -> None:
             dfs(node)
 
 
+def _unsuffix_deps(deps: list[Dependency]) -> list[Dependency]:
+    """Return copies of *deps* with nanvix suffixes stripped from VERSION refs.
+
+    For deps whose ref kind is VERSION and whose value contains
+    ``-nanvix-``, strips the suffix so the dep can be re-suffixed with
+    a different version.
+    """
+    result: list[Dependency] = []
+    for dep in deps:
+        if (
+            dep.ref.kind == RefKind.VERSION
+            and isinstance(dep.ref.value, str)
+            and "-nanvix-" in dep.ref.value
+        ):
+            base = dep.ref.value.split("-nanvix-")[0]
+            result.append(
+                _dc_replace(
+                    dep,
+                    ref=Ref(kind=dep.ref.kind, value=base),
+                )
+            )
+        else:
+            result.append(dep)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -265,6 +298,9 @@ def _resolve_inner(
                 code=EXIT_NETWORK_ERROR,
             )
 
+        original_deps = list(manifest.dependencies)
+        original_sys_deps = list(manifest.system_dependencies)
+
         manifest = _dc_replace(
             manifest,
             dependencies=[
@@ -274,6 +310,73 @@ def _resolve_inner(
                 suffix_dep(d, resolved_version) for d in manifest.system_dependencies
             ],
         )
+
+        # --- Fallback probe (only when sysroot is "latest") ---
+        fallback_versions: list[str] = []
+        all_probe_deps = list(manifest.dependencies) + list(
+            manifest.system_dependencies
+        )
+        for dep in all_probe_deps:
+            if dep.ref.kind != RefKind.VERSION or not isinstance(dep.ref.value, str):
+                continue
+            # dep.ref.value is already suffixed, e.g. "1.3.1-nanvix-0.12.337"
+            base_ver = extract_nanvix_version_base(dep.ref.value)
+            if base_ver is None:
+                continue
+            _, fallback_ver = github.resolve_release_with_fallback(
+                dep.repo,
+                dep.ref.value,
+                base_ver,
+                gh_token=gh_token,
+            )
+            if fallback_ver is not None:
+                fallback_versions.append(fallback_ver)
+
+        if fallback_versions:
+            min_ver = min(fallback_versions, key=parse_semver_tuple)
+            log.warning(
+                f"nanvix v{resolved_version} is latest but dependencies "
+                f"only available up to v{min_ver}; falling back to "
+                f"v{min_ver}"
+            )
+
+            # Re-resolve sysroot at the downgraded version.
+            try:
+                sysroot_release = github.resolve_release(
+                    "nanvix/nanvix",
+                    min_ver,
+                    gh_token=gh_token,
+                    semver=True,
+                )
+            except SystemExit:
+                log.note(f"while re-resolving sysroot at downgraded version v{min_ver}")
+                raise
+            tag, commitish, rel_id = _extract_release_fields(sysroot_release)
+            sysroot_pkg = ResolvedPackage(
+                name="nanvix",
+                repo="nanvix/nanvix",
+                kind="sysroot",
+                ref=manifest.sysroot_ref,
+                resolved_tag=tag,
+                resolved_commitish=commitish,
+                release_id=rel_id,
+            )
+            resolved["nanvix"] = sysroot_pkg
+            releases["nanvix"] = sysroot_release
+
+            # Re-suffix deps with downgraded version.
+            resolved_version = min_ver
+            manifest = _dc_replace(
+                manifest,
+                dependencies=[
+                    suffix_dep(d, resolved_version)
+                    for d in _unsuffix_deps(original_deps)
+                ],
+                system_dependencies=[
+                    suffix_dep(d, resolved_version)
+                    for d in _unsuffix_deps(original_sys_deps)
+                ],
+            )
 
     # 2. Seed queue with direct deps
     queue: deque[_QueueItem] = deque()

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -312,7 +312,10 @@ def _resolve_inner(
         )
 
         # --- Fallback probe (only when sysroot is "latest") ---
+        # Probe each VERSION dep once.  Cache the release dict so the
+        # BFS can reuse it instead of making a second API call.
         fallback_versions: list[str] = []
+        probe_cache: dict[str, dict[str, object]] = {}
         all_probe_deps = list(manifest.dependencies) + list(
             manifest.system_dependencies
         )
@@ -323,7 +326,7 @@ def _resolve_inner(
             base_ver = extract_nanvix_version_base(dep.ref.value)
             if base_ver is None:
                 continue
-            _, fallback_ver = github.resolve_release_with_fallback(
+            rel, fallback_ver = github.resolve_release_with_fallback(
                 dep.repo,
                 dep.ref.value,
                 base_ver,
@@ -331,8 +334,15 @@ def _resolve_inner(
             )
             if fallback_ver is not None:
                 fallback_versions.append(fallback_ver)
+            else:
+                # Exact tag matched — cache for BFS reuse.
+                probe_cache[dep.name] = rel
 
         if fallback_versions:
+            # Tags will change after re-suffix — cached releases are
+            # stale, so discard them.
+            probe_cache.clear()
+
             min_ver = min(fallback_versions, key=parse_semver_tuple)
             log.warning(
                 f"nanvix v{resolved_version} is latest but dependencies "
@@ -377,6 +387,26 @@ def _resolve_inner(
                     for d in _unsuffix_deps(original_sys_deps)
                 ],
             )
+
+        # Pre-populate resolved/releases from the probe cache so the
+        # BFS skips these deps instead of re-fetching them.
+        all_deps_after = list(manifest.dependencies) + list(
+            manifest.system_dependencies
+        )
+        for dep in all_deps_after:
+            if dep.name in probe_cache:
+                rel = probe_cache[dep.name]
+                d_tag, d_commitish, d_rel_id = _extract_release_fields(rel)
+                resolved[dep.name] = ResolvedPackage(
+                    name=dep.name,
+                    repo=dep.repo,
+                    kind="dependency",
+                    ref=dep.ref,
+                    resolved_tag=d_tag,
+                    resolved_commitish=d_commitish,
+                    release_id=d_rel_id,
+                )
+                releases[dep.name] = rel
 
     # 2. Seed queue with direct deps
     queue: deque[_QueueItem] = deque()

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -11,7 +11,15 @@ from pathlib import Path
 from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
-from nanvix_zutil.buildroot import Buildroot, Dependency, Ref, RefKind
+from nanvix_zutil.buildroot import (
+    Buildroot,
+    Dependency,
+    Ref,
+    RefKind,
+    extract_nanvix_version,
+    extract_nanvix_version_base,
+    parse_semver_tuple,
+)
 
 
 def _make_tar_bz2(members: dict[str, bytes]) -> bytes:
@@ -365,6 +373,39 @@ class TestBuildrootInstallDep(unittest.TestCase):
 
         self.assertTrue((br.path / "lib" / "libz.a").exists())
         self.assertTrue((br.path / "include" / "zlib.h").exists())
+
+
+class TestExtractNanvixVersion(unittest.TestCase):
+    """Tests for extract_nanvix_version()."""
+
+    def test_extracts_version(self) -> None:
+        self.assertEqual(extract_nanvix_version("1.3.1-nanvix-0.12.291"), "0.12.291")
+
+    def test_returns_none_without_marker(self) -> None:
+        self.assertIsNone(extract_nanvix_version("v1.3.1"))
+
+    def test_extracts_from_complex_base(self) -> None:
+        self.assertEqual(extract_nanvix_version("3.12.3-nanvix-0.12.291"), "0.12.291")
+
+
+class TestExtractNanvixVersionBase(unittest.TestCase):
+    """Tests for extract_nanvix_version_base()."""
+
+    def test_extracts_base(self) -> None:
+        self.assertEqual(extract_nanvix_version_base("1.3.1-nanvix-0.12.291"), "1.3.1")
+
+    def test_returns_none_without_marker(self) -> None:
+        self.assertIsNone(extract_nanvix_version_base("v1.3.1"))
+
+
+class TestParseSemverTuple(unittest.TestCase):
+    """Tests for parse_semver_tuple()."""
+
+    def test_parses_semver(self) -> None:
+        self.assertEqual(parse_semver_tuple("0.12.291"), (0, 12, 291))
+
+    def test_ordering(self) -> None:
+        self.assertLess(parse_semver_tuple("0.12.291"), parse_semver_tuple("0.12.337"))
 
 
 if __name__ == "__main__":

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -5,6 +5,7 @@
 
 """Tests for nanvix_zutil.github."""
 
+import collections.abc
 import json
 import tempfile
 import unittest
@@ -1072,6 +1073,121 @@ class TestResolveReleaseSemverGating(unittest.TestCase):
         assert result is not None
         self.assertEqual(result["tag_name"], "v1.2.3")
         self.assertIn("/releases/tags/v1.2.3", captured[0].full_url)
+
+
+class TestFindBestRelease(unittest.TestCase):
+    """Tests for _find_best_release()."""
+
+    def setUp(self) -> None:
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        log_mod.set_json_mode(False)
+
+    def test_finds_matching_release(self) -> None:
+        """First release whose tag matches the prefix is returned."""
+        releases = [
+            {"tag_name": "1.3.1-nanvix-0.12.320"},
+            {"tag_name": "1.3.1-nanvix-0.12.291"},
+            {"tag_name": "1.2.0-nanvix-0.12.291"},
+        ]
+        with patch.object(github_mod, "_list_releases", return_value=iter(releases)):
+            result = github_mod._find_best_release("nanvix/zlib", "1.3.1-nanvix-", {})
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["tag_name"], "1.3.1-nanvix-0.12.320")
+
+    def test_returns_none_when_no_match(self) -> None:
+        """Returns None when no tags match the prefix."""
+        releases = [
+            {"tag_name": "2.0.0-nanvix-0.12.320"},
+            {"tag_name": "1.2.0-nanvix-0.12.291"},
+        ]
+        with patch.object(github_mod, "_list_releases", return_value=iter(releases)):
+            result = github_mod._find_best_release("nanvix/zlib", "1.3.1-nanvix-", {})
+        self.assertIsNone(result)
+
+    def test_short_circuits_on_first_match(self) -> None:
+        """Generator stops iterating after the first match."""
+        call_count = 0
+
+        def counting_gen(
+            repo: str, headers: dict[str, str]
+        ) -> collections.abc.Generator[dict[str, object], None, None]:
+            nonlocal call_count
+            items: list[dict[str, object]] = [
+                {"tag_name": "1.3.1-nanvix-0.12.320"},
+                {"tag_name": "1.3.1-nanvix-0.12.291"},
+            ]
+            for rel in items:
+                call_count += 1
+                yield rel
+
+        with patch.object(github_mod, "_list_releases", side_effect=counting_gen):
+            result = github_mod._find_best_release("nanvix/zlib", "1.3.1-nanvix-", {})
+        self.assertIsNotNone(result)
+        # The generator yielded 1 item and then the function returned.
+        # Python generators only advance when next() is called, and
+        # _find_best_release returns on the first match before calling
+        # next() again.  So call_count should be 1.
+        self.assertEqual(call_count, 1)
+
+
+class TestResolveReleaseWithFallback(unittest.TestCase):
+    """Tests for resolve_release_with_fallback()."""
+
+    def setUp(self) -> None:
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        log_mod.set_json_mode(False)
+
+    @patch.object(github_mod, "_find_best_release")
+    @patch.object(github_mod, "_resolve_release")
+    def test_exact_tag_found_no_fallback(
+        self, mock_resolve: MagicMock, mock_best: MagicMock
+    ) -> None:
+        """When the exact tag exists, returns (release, None)."""
+        release: dict[str, object] = {"tag_name": "1.3.1-nanvix-0.12.337"}
+        mock_resolve.return_value = release
+
+        result, fallback_ver = github_mod.resolve_release_with_fallback(
+            "nanvix/zlib", "1.3.1-nanvix-0.12.337", "1.3.1"
+        )
+        self.assertEqual(result, release)
+        self.assertIsNone(fallback_ver)
+        mock_best.assert_not_called()
+
+    @patch.object(github_mod, "_find_best_release")
+    @patch.object(github_mod, "_resolve_release")
+    def test_404_triggers_fallback(
+        self, mock_resolve: MagicMock, mock_best: MagicMock
+    ) -> None:
+        """When exact tag 404s, scans releases and returns fallback."""
+        mock_resolve.return_value = None  # allow_missing=True returns None
+        fallback_release: dict[str, object] = {"tag_name": "1.3.1-nanvix-0.12.291"}
+        mock_best.return_value = fallback_release
+
+        result, fallback_ver = github_mod.resolve_release_with_fallback(
+            "nanvix/zlib", "1.3.1-nanvix-0.12.337", "1.3.1"
+        )
+        self.assertEqual(result, fallback_release)
+        self.assertEqual(fallback_ver, "0.12.291")
+
+    @patch.object(github_mod, "_find_best_release")
+    @patch.object(github_mod, "_resolve_release")
+    def test_no_fallback_release_exits(
+        self, mock_resolve: MagicMock, mock_best: MagicMock
+    ) -> None:
+        """When both exact and scan fail, exits with code 3."""
+        mock_resolve.return_value = None
+        mock_best.return_value = None
+
+        with self.assertRaises(SystemExit) as ctx:
+            github_mod.resolve_release_with_fallback(
+                "nanvix/zlib", "1.3.1-nanvix-0.12.337", "1.3.1"
+            )
+        self.assertEqual(ctx.exception.code, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -571,7 +571,9 @@ class TestResolveLatestSysroot(unittest.TestCase):
             release_id=200,
             assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
-        mock_resolve.side_effect = [sysroot_release, zlib_release]
+        # resolve_release is only called for sysroot — zlib is served
+        # from the probe cache, eliminating a duplicate API call.
+        mock_resolve.side_effect = [sysroot_release]
         # Fallback probe: exact tag found, no fallback needed.
         mock_fallback.return_value = (zlib_release, None)
         mock_download.return_value = None
@@ -600,9 +602,16 @@ class TestResolveLatestSysroot(unittest.TestCase):
         # Verify dep was suffixed with resolved version
         zlib_pkg = next(p for p in lockfile.packages if p.name == "zlib")
         self.assertEqual(zlib_pkg.ref.value, "1.3.1-nanvix-0.12.277")
-        # Verify resolve_release was called with suffixed value
-        mock_resolve.assert_any_call(
-            "nanvix/zlib", "1.3.1-nanvix-0.12.277", gh_token=None
+        # zlib resolved via probe cache — resolve_release NOT called for it.
+        mock_resolve.assert_called_once_with(
+            "nanvix/nanvix", "latest", gh_token=None, semver=True
+        )
+        # Probe was called with the suffixed tag.
+        mock_fallback.assert_called_once_with(
+            "nanvix/zlib",
+            "1.3.1-nanvix-0.12.277",
+            "1.3.1",
+            gh_token=None,
         )
 
 
@@ -852,7 +861,9 @@ class TestResolveVersionFallback(unittest.TestCase):
             release_id=200,
             assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
-        mock_resolve.side_effect = [sysroot_release, zlib_release]
+        # resolve_release only called for sysroot — zlib served from
+        # probe cache.
+        mock_resolve.side_effect = [sysroot_release]
         # Fallback probe: exact tag found, no fallback.
         mock_fallback.return_value = (zlib_release, None)
         mock_download.return_value = None

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,8 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# pyright: reportPrivateUsage=false
+
 """Tests for nanvix_zutil.resolver."""
 
 import tempfile
@@ -16,7 +18,7 @@ from nanvix_zutil.lockfile import (
     ResolvedPackage,
 )
 from nanvix_zutil.manifest import Manifest
-from nanvix_zutil.resolver import is_stale, resolve
+from nanvix_zutil.resolver import _unsuffix_deps, is_stale, resolve
 
 
 def _make_release(
@@ -533,6 +535,7 @@ class TestIsStale(unittest.TestCase):
 
 @patch("nanvix_zutil.resolver.download_lockfile_asset")
 @patch("nanvix_zutil.resolver.github.resolve_release")
+@patch("nanvix_zutil.resolver.github.resolve_release_with_fallback")
 class TestResolveLatestSysroot(unittest.TestCase):
     """Resolver with 'latest' sysroot and a VERSION dep."""
 
@@ -555,6 +558,7 @@ class TestResolveLatestSysroot(unittest.TestCase):
 
     def test_latest_sysroot_deferred_suffix(
         self,
+        mock_fallback: MagicMock,
         mock_resolve: MagicMock,
         mock_download: MagicMock,
     ) -> None:
@@ -568,6 +572,8 @@ class TestResolveLatestSysroot(unittest.TestCase):
             assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
         mock_resolve.side_effect = [sysroot_release, zlib_release]
+        # Fallback probe: exact tag found, no fallback needed.
+        mock_fallback.return_value = (zlib_release, None)
         mock_download.return_value = None
 
         manifest = _make_manifest(
@@ -653,6 +659,280 @@ class TestAssetFiltering(unittest.TestCase):
         sysroot_pkg = lockfile.packages[0]
         self.assertEqual(len(sysroot_pkg.assets), 1)
         self.assertTrue(sysroot_pkg.assets[0].name.endswith(".tar.bz2"))
+
+
+class TestUnsuffixDeps(unittest.TestCase):
+    """Tests for _unsuffix_deps()."""
+
+    def test_strips_suffix(self) -> None:
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.VERSION, value="1.3.1-nanvix-0.12.337"),
+        )
+        result = _unsuffix_deps([dep])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].ref.value, "1.3.1")
+
+    def test_preserves_non_version_refs(self) -> None:
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.3.1-nanvix-0.12.337"),
+        )
+        result = _unsuffix_deps([dep])
+        self.assertEqual(result[0].ref.value, "v1.3.1-nanvix-0.12.337")
+
+    def test_preserves_unsuffixed(self) -> None:
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
+        )
+        result = _unsuffix_deps([dep])
+        self.assertEqual(result[0].ref.value, "1.3.1")
+
+
+@patch("nanvix_zutil.resolver.download_lockfile_asset")
+@patch("nanvix_zutil.resolver.github.resolve_release")
+@patch("nanvix_zutil.resolver.github.resolve_release_with_fallback")
+class TestResolveVersionFallback(unittest.TestCase):
+    """Tests for fallback version downgrade in the resolver."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
+        self._manifest_dir.mkdir(parents=True)
+        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path.write_text(
+            '[package]\nname = "test"\nversion = "0.1.0"\n'
+            'nanvix-version = "latest"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        )
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_fallback_downgrades_sysroot(
+        self,
+        mock_fallback: MagicMock,
+        mock_resolve: MagicMock,
+        mock_download: MagicMock,
+    ) -> None:
+        """Sysroot is downgraded when dep 404s and fallback finds older version."""
+        latest_sysroot = _make_release(
+            tag="v0.12.337", commitish="aaa111", release_id=100
+        )
+        downgraded_sysroot = _make_release(
+            tag="v0.12.291", commitish="bbb222", release_id=101
+        )
+        zlib_release = _make_release(
+            tag="v1.3.1-nanvix-0.12.291",
+            commitish="ccc333",
+            release_id=200,
+            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+        )
+        # resolve_release: (1) sysroot@latest, (2) sysroot@0.12.291, (3) zlib
+        mock_resolve.side_effect = [latest_sysroot, downgraded_sysroot, zlib_release]
+        # Fallback probe: zlib 404 → fallback to 0.12.291
+        mock_fallback.return_value = (zlib_release, "0.12.291")
+        mock_download.return_value = None
+
+        manifest = _make_manifest(
+            deps=[
+                Dependency(
+                    name="zlib",
+                    repo="nanvix/zlib",
+                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
+                )
+            ],
+            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
+        )
+
+        lockfile = resolve(
+            manifest,
+            cache_dir=Path(self._tmpdir.name) / "cache",
+            manifest_path=self._manifest_path,
+        )
+
+        # Sysroot should be downgraded to 0.12.291
+        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
+        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.291")
+        # zlib should use the downgraded suffix
+        zlib_pkg = next(p for p in lockfile.packages if p.name == "zlib")
+        self.assertEqual(zlib_pkg.ref.value, "1.3.1-nanvix-0.12.291")
+
+    def test_fallback_uses_minimum_across_deps(
+        self,
+        mock_fallback: MagicMock,
+        mock_resolve: MagicMock,
+        mock_download: MagicMock,
+    ) -> None:
+        """When multiple deps fall back, sysroot uses the minimum version."""
+        self._manifest_path.write_text(
+            '[package]\nname = "test"\nversion = "0.1.0"\n'
+            'nanvix-version = "latest"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+            'sqlite = "3.49.0"\n'
+        )
+        latest_sysroot = _make_release(
+            tag="v0.12.337", commitish="aaa111", release_id=100
+        )
+        downgraded_sysroot = _make_release(
+            tag="v0.12.291", commitish="bbb222", release_id=101
+        )
+        zlib_release = _make_release(
+            tag="v1.3.1-nanvix-0.12.291",
+            commitish="ccc333",
+            release_id=200,
+        )
+        sqlite_release = _make_release(
+            tag="v3.49.0-nanvix-0.12.291",
+            commitish="ddd444",
+            release_id=300,
+        )
+        # resolve_release: (1) sysroot@latest, (2) sysroot@0.12.291,
+        # (3) zlib, (4) sqlite
+        mock_resolve.side_effect = [
+            latest_sysroot,
+            downgraded_sysroot,
+            zlib_release,
+            sqlite_release,
+        ]
+        # Fallback probe: zlib → 0.12.291, sqlite → 0.12.320
+        mock_fallback.side_effect = [
+            (zlib_release, "0.12.291"),
+            (sqlite_release, "0.12.320"),
+        ]
+        mock_download.return_value = None
+
+        manifest = _make_manifest(
+            deps=[
+                Dependency(
+                    name="zlib",
+                    repo="nanvix/zlib",
+                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
+                ),
+                Dependency(
+                    name="sqlite",
+                    repo="nanvix/sqlite",
+                    ref=Ref(kind=RefKind.VERSION, value="3.49.0"),
+                ),
+            ],
+            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
+        )
+
+        lockfile = resolve(
+            manifest,
+            cache_dir=Path(self._tmpdir.name) / "cache",
+            manifest_path=self._manifest_path,
+        )
+
+        # Sysroot should use the minimum: 0.12.291
+        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
+        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.291")
+
+    def test_no_fallback_when_all_deps_available(
+        self,
+        mock_fallback: MagicMock,
+        mock_resolve: MagicMock,
+        mock_download: MagicMock,
+    ) -> None:
+        """No warning when all deps resolve on first try."""
+        sysroot_release = _make_release(
+            tag="v0.12.337", commitish="aaa111", release_id=100
+        )
+        zlib_release = _make_release(
+            tag="v1.3.1-nanvix-0.12.337",
+            commitish="ccc333",
+            release_id=200,
+            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+        )
+        mock_resolve.side_effect = [sysroot_release, zlib_release]
+        # Fallback probe: exact tag found, no fallback.
+        mock_fallback.return_value = (zlib_release, None)
+        mock_download.return_value = None
+
+        manifest = _make_manifest(
+            deps=[
+                Dependency(
+                    name="zlib",
+                    repo="nanvix/zlib",
+                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
+                )
+            ],
+            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
+        )
+
+        lockfile = resolve(
+            manifest,
+            cache_dir=Path(self._tmpdir.name) / "cache",
+            manifest_path=self._manifest_path,
+        )
+
+        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
+        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.337")
+
+
+@patch("nanvix_zutil.resolver.download_lockfile_asset")
+@patch("nanvix_zutil.resolver.github.resolve_release")
+class TestNoFallbackWhenPinned(unittest.TestCase):
+    """Pinned sysroot preserves hard-fail behavior."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
+        self._manifest_dir.mkdir(parents=True)
+        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path.write_text(
+            '[package]\nname = "test"\nversion = "0.1.0"\n'
+            'nanvix-version = "0.12.337"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        )
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_no_fallback_when_pinned(
+        self,
+        mock_resolve: MagicMock,
+        mock_download: MagicMock,
+    ) -> None:
+        """Pinned version hard-fails on 404 (no fallback)."""
+        sysroot_release = _make_release(
+            tag="v0.12.337", commitish="aaa111", release_id=100
+        )
+        mock_resolve.side_effect = [sysroot_release, SystemExit(3)]
+        mock_download.return_value = None
+
+        manifest = _make_manifest(
+            deps=[
+                Dependency(
+                    name="zlib",
+                    repo="nanvix/zlib",
+                    ref=Ref(
+                        kind=RefKind.VERSION,
+                        value="1.3.1-nanvix-0.12.337",
+                    ),
+                )
+            ],
+            sysroot_ref=Ref(kind=RefKind.TAG, value="0.12.337"),
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            resolve(
+                manifest,
+                cache_dir=Path(self._tmpdir.name) / "cache",
+                manifest_path=self._manifest_path,
+            )
+        self.assertEqual(ctx.exception.code, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- When `nanvix-version = "latest"`, the resolver now probes each dependency for release availability and falls back to the best available version if any dependency lacks a release matching the resolved sysroot version.
- Adds `extract_nanvix_version()`, `extract_nanvix_version_base()`, `parse_semver_tuple()` helpers to `buildroot.py` and `resolve_release_with_fallback()` + `_find_best_release()` to `github.py`.
- Integrates the fallback probe into `_resolve_inner()` with a `_unsuffix_deps()` helper that strips stale suffixes before re-suffixing at the downgraded version.
- Adds 20 new unit tests covering all new helpers, the fallback integration path, and the pinned-version no-fallback guard.