### PR TITLE
Release v0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 permissions:
-  contents: write  # create tags and GitHub releases
-  id-token: write  # OIDC trusted publishing to PyPI
+  contents: write # create tags and GitHub releases
+  id-token: write # OIDC trusted publishing to PyPI
 
 jobs:
   lint-and-typecheck:
@@ -74,6 +74,8 @@ jobs:
     needs: [lint-and-typecheck, test]
     runs-on: ubuntu-latest
     environment: release
+    outputs:
+      version: ${{ steps.version.outputs.value }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -147,3 +149,12 @@ jobs:
       # TODO: PyPI repo not yet set up
       # - name: Publish to PyPI
       #   run: uv publish
+
+  update-consumers:
+    name: Update consumer repos
+    needs: [release]
+    uses: nanvix/workflows/.github/workflows/nanvix-update-zutils.yml@main
+    with:
+      tag: v${{ needs.release.outputs.version }}
+    secrets:
+      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanvix-zutil"
-version = "0.5.1"
+version = "0.6.0"
 description = "Build orchestration utilities for the Nanvix ecosystem"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bumps version from `0.5.1` → `0.6.0` in `pyproject.toml`
- Fixes `release.yml`: replaces broken step-level `uses:` with a proper `update-consumers` job that calls the reusable `nanvix-update-zutils.yml` workflow after the release publishes
- Adds `outputs.version` to the `release` job to pass the tag downstream

## Changes since v0.5.1

- **#46** feat/shell-linters — Shell & YAML linting, pre-push hooks, .editorconfig/.gitattributes
- **#45** fix/bootstrapper-robustness — Venv version checks, .gitignore template
- **#48** feat/resolver-version-fallback — Version extraction helpers, fallback resolver
- **#49** feat/zip-archive-support — Zip archive support with validation, symlink fixes

## Depends on

- nanvix/workflows#17 — must be merged to `main` first so the `@main` ref resolves
- `DISPATCH_TOKEN` secret must be available in the zutils repo's `release` environment