### PR TITLE
[ci] Pin update-zutils workflow to @v1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
   update-consumers:
     name: Update consumer repos
     needs: [release]
-    uses: nanvix/workflows/.github/workflows/nanvix-update-zutils.yml@main
+    uses: nanvix/workflows/.github/workflows/nanvix-update-zutils.yml@v1.3.0
     with:
       tag: v${{ needs.release.outputs.version }}
     secrets:


### PR DESCRIPTION
## Summary

Pins the `update-consumers` reusable workflow call from `@main` to `@v1.3.0`, matching the pattern used by all other consumer repos.

## Blocked on

- **nanvix/workflows `v1.3.0` tag** needs to be created first — includes workflow_call support (nanvix/workflows#17), checkout fix (#19), concurrency guard, and injection hardening.

## Context

The v0.6.0 release `update-consumers` job failed because it resolved `@main` to a pre-fix commit. Pinning to a tag avoids this class of issue entirely — the ref is immutable and the `nanvix-update-workflows.yml` cron handles version bumps automatically.