### PR TITLE
[zutils] B: Guard os.getuid/getgid for Windows

### DIFF
--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -46,6 +46,21 @@ DEFAULT_DOCKER_IMAGE: str = "nanvix/toolchain:latest-minimal"
 
 
 # ---------------------------------------------------------------------------
+# Platform helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_uid() -> int:
+    """Return the current user ID, or ``0`` on platforms without ``os.getuid``."""
+    return os.getuid() if hasattr(os, "getuid") else 0
+
+
+def _get_gid() -> int:
+    """Return the current group ID, or ``0`` on platforms without ``os.getgid``."""
+    return os.getgid() if hasattr(os, "getgid") else 0
+
+
+# ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
 
@@ -82,8 +97,10 @@ class DockerConfig:
     Attributes:
         image: Docker image name (e.g. ``"nanvix/toolchain:latest-minimal"``).
         mounts: Ordered list of volume mounts.
-        uid: User ID passed to ``--user``.  Defaults to the current process UID.
-        gid: Group ID passed to ``--user``.  Defaults to the current process GID.
+        uid: User ID passed to ``--user``.  Defaults to the current process UID,
+            or ``0`` on platforms where ``os.getuid`` is unavailable (e.g. Windows).
+        gid: Group ID passed to ``--user``.  Defaults to the current process GID,
+            or ``0`` on platforms where ``os.getgid`` is unavailable (e.g. Windows).
         workdir: Container working directory for standard (non-KVM) runs.
             Defaults to :data:`WORKSPACE_CONTAINER_PATH`.
         extra_env: Additional ``-e KEY=VALUE`` pairs forwarded to the container.
@@ -95,11 +112,11 @@ class DockerConfig:
     mounts: list[Mount] = field(default_factory=list)
     """Ordered list of volume mounts."""
 
-    uid: int = field(default_factory=os.getuid)
-    """User ID passed to ``--user`` (defaults to current process UID)."""
+    uid: int = field(default_factory=_get_uid)
+    """User ID passed to ``--user`` (defaults to current process UID, or 0 on Windows)."""
 
-    gid: int = field(default_factory=os.getgid)
-    """Group ID passed to ``--user`` (defaults to current process GID)."""
+    gid: int = field(default_factory=_get_gid)
+    """Group ID passed to ``--user`` (defaults to current process GID, or 0 on Windows)."""
 
     workdir: Path = field(default_factory=lambda: WORKSPACE_CONTAINER_PATH)
     """Container working directory for standard runs."""

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import tempfile
 import unittest
@@ -354,6 +355,48 @@ class TestWellKnownPaths(unittest.TestCase):
 
     def test_default_image(self) -> None:
         self.assertEqual(DEFAULT_DOCKER_IMAGE, "nanvix/toolchain:latest-minimal")
+
+
+class TestPlatformUidGid(unittest.TestCase):
+    """Tests for platform-aware UID/GID helpers."""
+
+    def test_get_uid_returns_int(self) -> None:
+        """_get_uid() always returns an int."""
+        from nanvix_zutil.docker import _get_uid  # pyright: ignore[reportPrivateUsage]
+
+        self.assertIsInstance(_get_uid(), int)
+
+    def test_get_gid_returns_int(self) -> None:
+        """_get_gid() always returns an int."""
+        from nanvix_zutil.docker import _get_gid  # pyright: ignore[reportPrivateUsage]
+
+        self.assertIsInstance(_get_gid(), int)
+
+    def test_get_uid_fallback_when_no_getuid(self) -> None:
+        """_get_uid() returns 0 when os.getuid is absent (Windows simulation)."""
+        from nanvix_zutil.docker import _get_uid  # pyright: ignore[reportPrivateUsage]
+
+        saved = getattr(os, "getuid", None)
+        try:
+            if saved is not None:
+                delattr(os, "getuid")
+            self.assertEqual(_get_uid(), 0)
+        finally:
+            if saved is not None:
+                os.getuid = saved  # type: ignore[attr-defined]
+
+    def test_get_gid_fallback_when_no_getgid(self) -> None:
+        """_get_gid() returns 0 when os.getgid is absent (Windows simulation)."""
+        from nanvix_zutil.docker import _get_gid  # pyright: ignore[reportPrivateUsage]
+
+        saved = getattr(os, "getgid", None)
+        try:
+            if saved is not None:
+                delattr(os, "getgid")
+            self.assertEqual(_get_gid(), 0)
+        finally:
+            if saved is not None:
+                os.getgid = saved  # type: ignore[attr-defined]
 
 
 if __name__ == "__main__":

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -398,6 +398,20 @@ class TestPlatformUidGid(unittest.TestCase):
             if saved is not None:
                 os.getgid = saved  # type: ignore[attr-defined]
 
+    def test_uid_defaults_to_process_uid_on_unix(self) -> None:
+        """On Unix, DockerConfig.uid defaults to os.getuid()."""
+        if not hasattr(os, "getuid"):
+            self.skipTest("os.getuid not available on this platform")
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.uid, os.getuid())
+
+    def test_gid_defaults_to_process_gid_on_unix(self) -> None:
+        """On Unix, DockerConfig.gid defaults to os.getgid()."""
+        if not hasattr(os, "getgid"):
+            self.skipTest("os.getgid not available on this platform")
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.gid, os.getgid())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Guard `os.getuid()` / `os.getgid()` with `getattr` fallback to `0` on platforms where they are unavailable (Windows)
- Removes the need for downstream compatibility shims (e.g. the one in `cpython/z.ps1`)

Closes #56