### PR TITLE
Fix Windows compatibility issues across nanvix_zutil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,24 @@ jobs:
 
       - name: Run tests
         run: uv run pytest tests/ -v
+
+  test-windows:
+    name: Tests (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install project and dev dependencies
+        run: uv sync
+
+      - name: Verify import succeeds
+        run: uv run python -c "import nanvix_zutil; print('import OK')"
+
+      - name: Run unit tests
+        run: uv run pytest tests/ -v -k "not test_full_lifecycle"

--- a/examples/hello-transitive/z.ps1
+++ b/examples/hello-transitive/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.5.1"
+    "0.7.1"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly

--- a/examples/hello-transitive/z.sh
+++ b/examples/hello-transitive/z.sh
@@ -7,10 +7,22 @@
 
 set -euo pipefail
 
-ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.5.1}"
+ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.7.1}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
-VENV_BIN="$VENV/bin/nanvix-zutil"
+
+# Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
+# Must be called after venv creation to pick up the correct paths.
+function _resolve_venv_paths() {
+    if [ -d "$VENV/Scripts" ]; then
+        VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"
+        VENV_PYTHON="$VENV/Scripts/python.exe"
+    else
+        VENV_BIN="$VENV/bin/nanvix-zutil"
+        VENV_PYTHON="$VENV/bin/python"
+    fi
+}
+_resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
 function bootstrap() {
@@ -29,7 +41,9 @@ function bootstrap() {
     else
         python3 -m venv "$VENV"
     fi
-    "$VENV/bin/pip" install --quiet "$WHEEL_URL"
+    # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/examples/hello-world/.nanvix/z.py
+++ b/examples/hello-world/.nanvix/z.py
@@ -72,7 +72,13 @@ class HelloWorld(ZScript):
         self.run(cc, *cflags, *ldflags, "-o", "hello.elf", "hello.o", *libs)
 
     def test(self) -> None:
-        """Run the test suite (smoke + integration + functional)."""
+        """Run the test suite (smoke + integration + functional).
+
+        Note:
+            The functional test phase uses ``timeout --foreground`` (GNU
+            coreutils) and KVM. This is Linux-only by design — functional
+            tests require ``/dev/kvm`` inside a Docker container.
+        """
         binary = self.repo_root / "hello.elf"
 
         # Smoke: binary must exist and be non-trivially sized.
@@ -112,9 +118,11 @@ class HelloWorld(ZScript):
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        self.run("rm", "-f", "hello.o", "hello.elf", docker=False)
+        for name in ("hello.o", "hello.elf"):
+            artifact = self.repo_root / name
+            if artifact.exists():
+                artifact.unlink()
 
 
 if __name__ == "__main__":
     HelloWorld.main()
-

--- a/examples/hello-world/z.ps1
+++ b/examples/hello-world/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.5.1"
+    "0.7.1"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly

--- a/examples/hello-world/z.sh
+++ b/examples/hello-world/z.sh
@@ -7,10 +7,22 @@
 
 set -euo pipefail
 
-ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.5.1}"
+ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.7.1}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
-VENV_BIN="$VENV/bin/nanvix-zutil"
+
+# Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
+# Must be called after venv creation to pick up the correct paths.
+function _resolve_venv_paths() {
+    if [ -d "$VENV/Scripts" ]; then
+        VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"
+        VENV_PYTHON="$VENV/Scripts/python.exe"
+    else
+        VENV_BIN="$VENV/bin/nanvix-zutil"
+        VENV_PYTHON="$VENV/bin/python"
+    fi
+}
+_resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
 function bootstrap() {
@@ -29,7 +41,9 @@ function bootstrap() {
     else
         python3 -m venv "$VENV"
     fi
-    "$VENV/bin/pip" install --quiet "$WHEEL_URL"
+    # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/examples/hello-zlib/.nanvix/z.py
+++ b/examples/hello-zlib/.nanvix/z.py
@@ -94,14 +94,21 @@ class HelloZlib(ZScript):
         self.run(cc, *cflags, *ldflags, "-o", "hello-zlib.elf", "hello-zlib.o", *libs)
 
     def test(self) -> None:
-        """Run the test suite (smoke + integration + functional)."""
+        """Run the test suite (smoke + integration + functional).
+
+        Note:
+            The functional test phase uses ``timeout --foreground`` (GNU
+            coreutils) and KVM. This is Linux-only by design — functional
+            tests require ``/dev/kvm`` inside a Docker container.
+        """
         binary = self.repo_root / "hello-zlib.elf"
 
         # Smoke: binary must exist and be non-trivially sized.
         log.info("=== hello-zlib smoke tests ===")
         if not binary.exists():
             log.fatal(
-                f"{binary} not found — run 'nanvix-zutil build' first.", code=EXIT_TEST_FAILURE
+                f"{binary} not found — run 'nanvix-zutil build' first.",
+                code=EXIT_TEST_FAILURE,
             )
         size = binary.stat().st_size
         if size < 1000:
@@ -133,7 +140,10 @@ class HelloZlib(ZScript):
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        self.run("rm", "-f", "hello-zlib.o", "hello-zlib.elf", docker=False)
+        for name in ("hello-zlib.o", "hello-zlib.elf"):
+            artifact = self.repo_root / name
+            if artifact.exists():
+                artifact.unlink()
 
 
 if __name__ == "__main__":

--- a/examples/hello-zlib/z.ps1
+++ b/examples/hello-zlib/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.5.1"
+    "0.7.1"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly

--- a/examples/hello-zlib/z.sh
+++ b/examples/hello-zlib/z.sh
@@ -7,10 +7,22 @@
 
 set -euo pipefail
 
-ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.5.1}"
+ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.7.1}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
-VENV_BIN="$VENV/bin/nanvix-zutil"
+
+# Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
+# Must be called after venv creation to pick up the correct paths.
+function _resolve_venv_paths() {
+    if [ -d "$VENV/Scripts" ]; then
+        VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"
+        VENV_PYTHON="$VENV/Scripts/python.exe"
+    else
+        VENV_BIN="$VENV/bin/nanvix-zutil"
+        VENV_PYTHON="$VENV/bin/python"
+    fi
+}
+_resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
 function bootstrap() {
@@ -29,7 +41,9 @@ function bootstrap() {
     else
         python3 -m venv "$VENV"
     fi
-    "$VENV/bin/pip" install --quiet "$WHEEL_URL"
+    # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -21,28 +21,45 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
+import warnings
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 # ---------------------------------------------------------------------------
 # Well-known container paths
 # ---------------------------------------------------------------------------
 
 #: Container path for the consumer repository root.
-WORKSPACE_CONTAINER_PATH: Path = Path("/mnt/workspace")
+WORKSPACE_CONTAINER_PATH: PurePosixPath = PurePosixPath("/mnt/workspace")
 
 #: Container path for the Nanvix sysroot.
-SYSROOT_CONTAINER_PATH: Path = Path("/mnt/sysroot")
+SYSROOT_CONTAINER_PATH: PurePosixPath = PurePosixPath("/mnt/sysroot")
 
 #: Container path for the build-time dependency root (buildroot).
-BUILDROOT_CONTAINER_PATH: Path = Path("/mnt/buildroot")
+BUILDROOT_CONTAINER_PATH: PurePosixPath = PurePosixPath("/mnt/buildroot")
 
 #: Container path for the Nanvix cross-compilation toolchain.
-TOOLCHAIN_CONTAINER_PATH: Path = Path("/opt/nanvix")
+TOOLCHAIN_CONTAINER_PATH: PurePosixPath = PurePosixPath("/opt/nanvix")
 
 #: Default Docker image used when ``--with-docker`` or
 #: ``--with-minimal-docker`` is requested.
 DEFAULT_DOCKER_IMAGE: str = "nanvix/toolchain:latest-minimal"
+
+
+# ---------------------------------------------------------------------------
+# Platform helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_uid() -> int:
+    """Return the current user ID, or ``0`` on platforms without ``os.getuid``."""
+    return os.getuid() if hasattr(os, "getuid") else 0
+
+
+def _get_gid() -> int:
+    """Return the current group ID, or ``0`` on platforms without ``os.getgid``."""
+    return os.getgid() if hasattr(os, "getgid") else 0
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +80,7 @@ class Mount:
     host_path: Path
     """Absolute host-side path to mount."""
 
-    container_path: Path
+    container_path: PurePosixPath
     """Mount point inside the container."""
 
     readonly: bool = False
@@ -82,8 +99,10 @@ class DockerConfig:
     Attributes:
         image: Docker image name (e.g. ``"nanvix/toolchain:latest-minimal"``).
         mounts: Ordered list of volume mounts.
-        uid: User ID passed to ``--user``.  Defaults to the current process UID.
-        gid: Group ID passed to ``--user``.  Defaults to the current process GID.
+        uid: User ID passed to ``--user``.  Defaults to the current process UID,
+            or ``0`` on platforms where ``os.getuid`` is unavailable (e.g. Windows).
+        gid: Group ID passed to ``--user``.  Defaults to the current process GID,
+            or ``0`` on platforms where ``os.getgid`` is unavailable (e.g. Windows).
         workdir: Container working directory for standard (non-KVM) runs.
             Defaults to :data:`WORKSPACE_CONTAINER_PATH`.
         extra_env: Additional ``-e KEY=VALUE`` pairs forwarded to the container.
@@ -95,13 +114,13 @@ class DockerConfig:
     mounts: list[Mount] = field(default_factory=list)
     """Ordered list of volume mounts."""
 
-    uid: int = field(default_factory=os.getuid)
-    """User ID passed to ``--user`` (defaults to current process UID)."""
+    uid: int = field(default_factory=_get_uid)
+    """User ID passed to ``--user`` (defaults to current process UID, or 0 on Windows)."""
 
-    gid: int = field(default_factory=os.getgid)
-    """Group ID passed to ``--user`` (defaults to current process GID)."""
+    gid: int = field(default_factory=_get_gid)
+    """Group ID passed to ``--user`` (defaults to current process GID, or 0 on Windows)."""
 
-    workdir: Path = field(default_factory=lambda: WORKSPACE_CONTAINER_PATH)
+    workdir: PurePosixPath = field(default_factory=lambda: WORKSPACE_CONTAINER_PATH)
     """Container working directory for standard runs."""
 
     extra_env: dict[str, str] = field(default_factory=dict)
@@ -111,7 +130,7 @@ class DockerConfig:
     # Path translation
     # ------------------------------------------------------------------
 
-    def translate_path(self, host_path: Path) -> Path:
+    def translate_path(self, host_path: Path) -> PurePosixPath | Path:
         """Translate a host path to its container equivalent.
 
         Scans :attr:`mounts` and returns the container-side path for the
@@ -122,8 +141,8 @@ class DockerConfig:
             host_path: An absolute host path to translate.
 
         Returns:
-            Container-side :class:`~pathlib.Path`, or *host_path* if no
-            mount matches.
+            Container-side :class:`~pathlib.PurePosixPath`, or *host_path*
+            if no mount matches.
         """
         resolved = host_path.resolve()
         best_mount: Mount | None = None
@@ -143,7 +162,7 @@ class DockerConfig:
                 best_rel = rel
 
         if best_mount is not None:
-            return best_mount.container_path / best_rel
+            return best_mount.container_path / PurePosixPath(*best_rel.parts)
         return host_path
 
     # ------------------------------------------------------------------
@@ -190,8 +209,8 @@ class DockerConfig:
         * Adds ``--device /dev/kvm`` and ``--group-add <kvm-gid>``.
         * Sets ``--workdir`` to :data:`SYSROOT_CONTAINER_PATH` so that
           ``nanvixd.elf`` can resolve relative paths correctly.
-        * Mounts the sysroot volume as writable (``nanvixd.elf`` needs write
-          access).
+        * Forces the sysroot mount to be writable (``nanvixd.elf`` needs
+          write access); other mounts respect :attr:`Mount.readonly`.
         * Adds ``USER`` to the container environment.
 
         Args:
@@ -201,6 +220,13 @@ class DockerConfig:
             Full ``docker run …`` argument list.
         """
         docker_cmd: list[str] = ["docker", "run", "--rm", "--device", "/dev/kvm"]
+        if sys.platform != "linux":
+            warnings.warn(
+                "KVM is only available on Linux. The generated Docker command "
+                "will include --device /dev/kvm which is not supported on "
+                f"{sys.platform}.",
+                stacklevel=2,
+            )
         docker_cmd += ["--user", f"{self.uid}:{self.gid}"]
 
         kvm_gid = _get_kvm_gid()
@@ -208,13 +234,17 @@ class DockerConfig:
             docker_cmd += ["--group-add", kvm_gid]
 
         for mount in self.mounts:
-            # Sysroot must be writable for functional tests.
+            # Sysroot must be writable for functional tests; other mounts
+            # respect the readonly flag just like build_run_cmd().
             vol = f"{mount.host_path.resolve()}:{mount.container_path}"
+            if mount.readonly and mount.container_path != SYSROOT_CONTAINER_PATH:
+                vol += ":ro"
             docker_cmd += ["-v", vol]
 
         docker_cmd += ["-w", str(SYSROOT_CONTAINER_PATH)]
         docker_cmd += ["-e", "HOME=/tmp"]
-        docker_cmd += ["-e", f"USER={os.environ.get('USER', 'nanvix')}"]
+        user = os.environ.get("USER") or os.environ.get("USERNAME") or "nanvix"
+        docker_cmd += ["-e", f"USER={user}"]
 
         for key, val in self.extra_env.items():
             docker_cmd += ["-e", f"{key}={val}"]

--- a/src/nanvix_zutil/log.py
+++ b/src/nanvix_zutil/log.py
@@ -11,8 +11,60 @@ message is emitted as a single-line JSON object with ``level``, ``code``,
 from __future__ import annotations
 
 import json
+import os
 import sys
 from typing import NoReturn
+
+# ---------------------------------------------------------------------------
+# Windows ANSI support
+# ---------------------------------------------------------------------------
+
+
+def _enable_ansi_on_windows() -> None:
+    """Enable ANSI escape sequences on Windows terminals.
+
+    On Windows 10 1607+ this activates Virtual Terminal Processing.
+    On older Windows versions this is a silent no-op — ANSI codes will
+    render as raw text but the program will not crash.
+    """
+    if os.name != "nt":
+        return
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+        get_std_handle = kernel32.GetStdHandle
+        get_std_handle.argtypes = [wintypes.DWORD]
+        get_std_handle.restype = wintypes.HANDLE
+
+        get_console_mode = kernel32.GetConsoleMode
+        get_console_mode.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+        get_console_mode.restype = wintypes.BOOL
+
+        set_console_mode = kernel32.SetConsoleMode
+        set_console_mode.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+        set_console_mode.restype = wintypes.BOOL
+
+        invalid_handle = ctypes.c_void_p(-1).value
+        enable_vt_processing = 0x0004
+
+        # STD_ERROR_HANDLE = -12
+        handle = get_std_handle(wintypes.DWORD(-12))
+        if handle in (None, 0, invalid_handle):
+            return
+
+        mode = wintypes.DWORD()
+        if not get_console_mode(handle, ctypes.byref(mode)):
+            return
+
+        set_console_mode(handle, mode.value | enable_vt_processing)
+    except (AttributeError, OSError, ValueError):
+        pass
+
+
+_enable_ansi_on_windows()
 
 # ---------------------------------------------------------------------------
 # Module-level state

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -30,7 +30,7 @@ import os
 import shutil
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import log
 from nanvix_zutil.buildroot import Buildroot, Dependency, suffix_dep
@@ -249,7 +249,7 @@ class ZScript:
     # Path translation helper
     # ------------------------------------------------------------------
 
-    def translate_path(self, host_path: Path) -> Path:
+    def translate_path(self, host_path: Path) -> PurePosixPath | Path:
         """Translate *host_path* to its container equivalent if Docker is active.
 
         When Docker mode is not active, returns *host_path* unchanged.
@@ -258,7 +258,7 @@ class ZScript:
             host_path: An absolute host-side path.
 
         Returns:
-            Container-side :class:`~pathlib.Path` when Docker is active,
+            Container-side :class:`~pathlib.PurePosixPath` when Docker is active,
             otherwise *host_path*.
         """
         if self.docker is not None:

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -11,7 +11,19 @@ PINNED_VERSION="{{ZUTIL_VERSION}}"
 ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
-VENV_BIN="$VENV/bin/nanvix-zutil"
+
+# Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
+# Must be called after venv creation to pick up the correct paths.
+function _resolve_venv_paths() {
+    if [ -d "$VENV/Scripts" ]; then
+        VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"
+        VENV_PYTHON="$VENV/Scripts/python.exe"
+    else
+        VENV_BIN="$VENV/bin/nanvix-zutil"
+        VENV_PYTHON="$VENV/bin/python"
+    fi
+}
+_resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
 function bootstrap() {
@@ -30,7 +42,9 @@ function bootstrap() {
     else
         python3 -m venv "$VENV"
     fi
-    "$VENV/bin/pip" install --quiet "$WHEEL_URL"
+    # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -5,10 +5,11 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import tempfile
 import unittest
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest.mock import patch
 
 from nanvix_zutil.docker import (
@@ -28,21 +29,26 @@ class TestMount(unittest.TestCase):
     """Tests for the Mount dataclass."""
 
     def test_default_not_readonly(self) -> None:
-        m = Mount(host_path=Path("/host/path"), container_path=Path("/container/path"))
+        m = Mount(
+            host_path=Path("/host/path"),
+            container_path=PurePosixPath("/container/path"),
+        )
         self.assertFalse(m.readonly)
 
     def test_readonly_flag(self) -> None:
         m = Mount(
             host_path=Path("/host/path"),
-            container_path=Path("/container/path"),
+            container_path=PurePosixPath("/container/path"),
             readonly=True,
         )
         self.assertTrue(m.readonly)
 
     def test_fields_stored(self) -> None:
-        m = Mount(host_path=Path("/a"), container_path=Path("/b"), readonly=True)
+        m = Mount(
+            host_path=Path("/a"), container_path=PurePosixPath("/b"), readonly=True
+        )
         self.assertEqual(m.host_path, Path("/a"))
-        self.assertEqual(m.container_path, Path("/b"))
+        self.assertEqual(m.container_path, PurePosixPath("/b"))
 
 
 class TestDockerConfigTranslatePath(unittest.TestCase):
@@ -242,11 +248,72 @@ class TestDockerConfigBuildKvmRunCmd(unittest.TestCase):
         sysroot_ro = f"{self._sysroot.resolve()}:{SYSROOT_CONTAINER_PATH}:ro"
         self.assertNotIn(sysroot_ro, cmd)
 
+    def test_non_sysroot_readonly_mount_preserved(self) -> None:
+        """Non-sysroot readonly mounts keep :ro in KVM mode."""
+        buildroot = self._workspace / "buildroot"
+        buildroot.mkdir()
+        cfg = DockerConfig(
+            image="test-image",
+            mounts=[
+                Mount(
+                    host_path=self._workspace,
+                    container_path=WORKSPACE_CONTAINER_PATH,
+                    readonly=False,
+                ),
+                Mount(
+                    host_path=self._sysroot,
+                    container_path=SYSROOT_CONTAINER_PATH,
+                    readonly=True,
+                ),
+                Mount(
+                    host_path=buildroot,
+                    container_path=BUILDROOT_CONTAINER_PATH,
+                    readonly=True,
+                ),
+            ],
+            uid=1000,
+            gid=1000,
+        )
+        cmd = cfg.build_kvm_run_cmd("echo")
+        cmd_str = " ".join(cmd)
+        # Buildroot readonly mount should have :ro
+        self.assertIn(f"{buildroot.resolve()}:{BUILDROOT_CONTAINER_PATH}:ro", cmd_str)
+        # Sysroot readonly mount should NOT have :ro (forced writable)
+        self.assertNotIn(
+            f"{self._sysroot.resolve()}:{SYSROOT_CONTAINER_PATH}:ro", cmd_str
+        )
+        # Workspace (non-readonly) should not have :ro
+        self.assertNotIn(
+            f"{self._workspace.resolve()}:{WORKSPACE_CONTAINER_PATH}:ro", cmd_str
+        )
+
     def test_user_env_set(self) -> None:
         cfg = self._make_config()
         cmd = cfg.build_kvm_run_cmd("echo")
         user_entries = [e for e in cmd if e.startswith("USER=")]
         self.assertTrue(user_entries, "USER env var should be present in KVM run")
+
+    def test_user_env_falls_back_to_username(self) -> None:
+        """On Windows, USER is absent; USERNAME should be used."""
+        cfg = self._make_config()
+        env = os.environ.copy()
+        env.pop("USER", None)
+        env["USERNAME"] = "winuser"
+        with patch.dict(os.environ, env, clear=True):
+            cmd = cfg.build_kvm_run_cmd("echo")
+        user_entries = [e for e in cmd if e.startswith("USER=")]
+        self.assertTrue(any("winuser" in e for e in user_entries))
+
+    def test_user_env_defaults_to_nanvix(self) -> None:
+        """When neither USER nor USERNAME is set, falls back to 'nanvix'."""
+        cfg = self._make_config()
+        env = os.environ.copy()
+        env.pop("USER", None)
+        env.pop("USERNAME", None)
+        with patch.dict(os.environ, env, clear=True):
+            cmd = cfg.build_kvm_run_cmd("echo")
+        user_entries = [e for e in cmd if e.startswith("USER=")]
+        self.assertTrue(any("nanvix" in e for e in user_entries))
 
     def test_inner_command_appended(self) -> None:
         cfg = self._make_config()
@@ -337,23 +404,105 @@ class TestKvmGidInKvmRunCmd(unittest.TestCase):
         self.assertEqual(cmd[gid_idx + 1], "42")
 
 
+class TestKvmPlatformWarning(unittest.TestCase):
+    """Tests for KVM platform warning in build_kvm_run_cmd."""
+
+    def test_warns_on_non_linux(self) -> None:
+        """build_kvm_run_cmd warns when not running on Linux."""
+        cfg = DockerConfig(image="test-image", mounts=[], uid=0, gid=0)
+        with patch("nanvix_zutil.docker.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with self.assertWarns(UserWarning) as ctx:
+                cfg.build_kvm_run_cmd("echo")
+            self.assertIn("KVM is only available on Linux", str(ctx.warning))
+
+    def test_no_warning_on_linux(self) -> None:
+        """build_kvm_run_cmd does not warn on Linux."""
+        import warnings as _warnings
+
+        cfg = DockerConfig(image="test-image", mounts=[], uid=0, gid=0)
+        with patch("nanvix_zutil.docker.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with _warnings.catch_warnings(record=True) as w:
+                _warnings.simplefilter("always")
+                cfg.build_kvm_run_cmd("echo")
+            kvm_warnings = [x for x in w if "KVM" in str(x.message)]
+            self.assertEqual(len(kvm_warnings), 0)
+
+
 class TestWellKnownPaths(unittest.TestCase):
     """Verify the well-known container path constants."""
 
     def test_workspace_path(self) -> None:
-        self.assertEqual(WORKSPACE_CONTAINER_PATH, Path("/mnt/workspace"))
+        self.assertEqual(WORKSPACE_CONTAINER_PATH, PurePosixPath("/mnt/workspace"))
 
     def test_sysroot_path(self) -> None:
-        self.assertEqual(SYSROOT_CONTAINER_PATH, Path("/mnt/sysroot"))
+        self.assertEqual(SYSROOT_CONTAINER_PATH, PurePosixPath("/mnt/sysroot"))
 
     def test_buildroot_path(self) -> None:
-        self.assertEqual(BUILDROOT_CONTAINER_PATH, Path("/mnt/buildroot"))
+        self.assertEqual(BUILDROOT_CONTAINER_PATH, PurePosixPath("/mnt/buildroot"))
 
     def test_toolchain_path(self) -> None:
-        self.assertEqual(TOOLCHAIN_CONTAINER_PATH, Path("/opt/nanvix"))
+        self.assertEqual(TOOLCHAIN_CONTAINER_PATH, PurePosixPath("/opt/nanvix"))
 
     def test_default_image(self) -> None:
         self.assertEqual(DEFAULT_DOCKER_IMAGE, "nanvix/toolchain:latest-minimal")
+
+
+class TestPlatformUidGid(unittest.TestCase):
+    """Tests for platform-aware UID/GID helpers."""
+
+    def test_get_uid_returns_int(self) -> None:
+        """_get_uid() always returns an int matching os.getuid on Linux."""
+        from nanvix_zutil.docker import _get_uid  # pyright: ignore[reportPrivateUsage]
+
+        result = _get_uid()
+        self.assertIsInstance(result, int)
+        if hasattr(os, "getuid"):
+            self.assertEqual(result, os.getuid())
+
+    def test_get_gid_returns_int(self) -> None:
+        """_get_gid() always returns an int matching os.getgid on Linux."""
+        from nanvix_zutil.docker import _get_gid  # pyright: ignore[reportPrivateUsage]
+
+        result = _get_gid()
+        self.assertIsInstance(result, int)
+        if hasattr(os, "getgid"):
+            self.assertEqual(result, os.getgid())
+
+    def test_get_uid_fallback_when_no_getuid(self) -> None:
+        """_get_uid() returns 0 when os.getuid is absent (Windows simulation)."""
+        from nanvix_zutil.docker import _get_uid  # pyright: ignore[reportPrivateUsage]
+
+        saved = getattr(os, "getuid", None)
+        try:
+            if saved is not None:
+                delattr(os, "getuid")
+            self.assertEqual(_get_uid(), 0)
+        finally:
+            if saved is not None:
+                os.getuid = saved  # type: ignore[attr-defined]
+
+    def test_get_gid_fallback_when_no_getgid(self) -> None:
+        """_get_gid() returns 0 when os.getgid is absent (Windows simulation)."""
+        from nanvix_zutil.docker import _get_gid  # pyright: ignore[reportPrivateUsage]
+
+        saved = getattr(os, "getgid", None)
+        try:
+            if saved is not None:
+                delattr(os, "getgid")
+            self.assertEqual(_get_gid(), 0)
+        finally:
+            if saved is not None:
+                os.getgid = saved  # type: ignore[attr-defined]
+
+    def test_docker_config_default_uid_gid(self) -> None:
+        """DockerConfig without explicit uid/gid uses _get_uid/_get_gid."""
+        cfg = DockerConfig(image="test-image")
+        if hasattr(os, "getuid"):
+            self.assertEqual(cfg.uid, os.getuid())
+        if hasattr(os, "getgid"):
+            self.assertEqual(cfg.gid, os.getgid())
 
 
 if __name__ == "__main__":

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -50,7 +50,9 @@ def _has_nanvix_toolchain() -> bool:
 
 
 def _has_kvm() -> bool:
-    """Return True if /dev/kvm is accessible."""
+    """Return True if /dev/kvm is accessible (Linux only)."""
+    if sys.platform != "linux":
+        return False
     return os.access("/dev/kvm", os.R_OK | os.W_OK)
 
 

--- a/tests/test_example_zlib.py
+++ b/tests/test_example_zlib.py
@@ -50,7 +50,9 @@ def _has_nanvix_toolchain() -> bool:
 
 
 def _has_kvm() -> bool:
-    """Return True if /dev/kvm is accessible."""
+    """Return True if /dev/kvm is accessible (Linux only)."""
+    if sys.platform != "linux":
+        return False
     return os.access("/dev/kvm", os.R_OK | os.W_OK)
 
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -168,5 +168,18 @@ class TestFatal(unittest.TestCase):
         self.assertEqual(obj["hint"], "check logs")
 
 
+class TestAnsiWindowsEnablement(unittest.TestCase):
+    """Tests for Windows ANSI VT processing enablement."""
+
+    def test_no_crash_on_any_platform(self) -> None:
+        """_enable_ansi_on_windows should never raise."""
+        from nanvix_zutil.log import (
+            _enable_ansi_on_windows,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        # Should be a no-op on Linux, no crash on Windows.
+        _enable_ansi_on_windows()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -261,7 +261,7 @@ class TestRunAllBuilds(unittest.TestCase):
         for combo, result in results.items():
             self.assertTrue(result.success, f"{combo} should succeed")
             self.assertIsNone(result.error)
-            self.assertGreater(result.duration_seconds, 0.0)
+            self.assertGreaterEqual(result.duration_seconds, 0.0)
 
     def test_hook_chain_runs_prerequisites(self) -> None:
         """'build' runs setup then build via _HOOK_CHAIN."""

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -30,7 +30,7 @@ def _make_source_tree(root: Path) -> None:
                 data.bin
     """
     root.mkdir(parents=True, exist_ok=True)
-    (root / "hello.txt").write_text("hello world\n")
+    (root / "hello.txt").write_bytes(b"hello world\n")
     sub = root / "sub"
     sub.mkdir()
     (sub / "data.bin").write_bytes(b"\x00\x01\x02\x03")

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -322,7 +322,10 @@ class TestZScriptDistclean(unittest.TestCase):
         target = self._nanvix() / "real_sysroot"
         target.mkdir()
         link = self._nanvix() / "sysroot"
-        link.symlink_to(target)
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlinks not supported on this platform")
         self._make_script().distclean()
         self.assertFalse(link.exists())
 


### PR DESCRIPTION
## Summary

Fixes Windows compatibility across the library, addressing #57 and #56.

- **P0:** Fix `os.getuid()`/`os.getgid()` crash at import time (platform-aware helpers)
- **P0:** Use `PurePosixPath` for container paths (prevents backslash corruption)
- **P1:** Fix `USER`/`USERNAME` env var lookup for Windows
- **P1:** Add platform warning when KVM used on non-Linux
- **P1:** Replace `rm -f` with `pathlib.unlink()` in example `clean()` methods
- **P1:** Add Windows CI job (import smoke test + unit tests)
- **P2:** Enable ANSI color support on Windows via ctypes VT processing
- **P2:** Fix `z.sh` venv path detection (`Scripts/` vs `bin/`)
- **P2:** Add explicit Linux guard to `_has_kvm()` in tests

## Validation

- `basedpyright` strict: 0 errors, 0 warnings
- `pytest`: 429 passed, 2 skipped
- Lint: clean (pre-existing yamllint warnings in `release.yml` only)