### PR TITLE
Release v0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanvix-zutil"
-version = "0.7.0"
+version = "0.7.1"
 description = "Build orchestration utilities for the Nanvix ecosystem"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Patch release v0.7.1:

- Merge v0.7.0 release back into dev (sync `pyproject.toml` version)
- Bump `nanvix/workflows` refs from v1.2.0/v1.3.0 → **v1.5.0** (`templates/nanvix-ci.yml`, `.github/workflows/release.yml`)
- Bump `pyproject.toml` version to `0.7.1`
- Includes all changes from dev since v0.7.0 (parallel all-builds feature, release template version fix)

### Workflow version changes

| File | Old | New |
|---|---|---|
| `templates/nanvix-ci.yml` | `@v1.2.0` | `@v1.5.0` |
| `.github/workflows/release.yml` | `@v1.3.0` | `@v1.5.0` |

### To finalize release

When ready, rename the branch from `draft-release/v0.7.1` to `release/v0.7.1` to trigger the release workflow.