### PR TITLE
fix(templates): z.ps1 here-string and z.sh comment accuracy

### DIFF
--- a/examples/hello-transitive/z.sh
+++ b/examples/hello-transitive/z.sh
@@ -12,7 +12,8 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P
 VENV="$REPO_ROOT/.nanvix/venv"
 
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
-# Must be called after venv creation to pick up the correct paths.
+# Can be called before venv creation to initialize default paths; call it
+# again after venv creation to pick up the actual layout.
 function _resolve_venv_paths() {
     if [ -d "$VENV/Scripts" ]; then
         VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"

--- a/examples/hello-world/z.sh
+++ b/examples/hello-world/z.sh
@@ -12,7 +12,8 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P
 VENV="$REPO_ROOT/.nanvix/venv"
 
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
-# Must be called after venv creation to pick up the correct paths.
+# Can be called before venv creation to initialize default paths; call it
+# again after venv creation to pick up the actual layout.
 function _resolve_venv_paths() {
     if [ -d "$VENV/Scripts" ]; then
         VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"

--- a/examples/hello-zlib/z.sh
+++ b/examples/hello-zlib/z.sh
@@ -12,7 +12,8 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P
 VENV="$REPO_ROOT/.nanvix/venv"
 
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
-# Must be called after venv creation to pick up the correct paths.
+# Can be called before venv creation to initialize default paths; call it
+# again after venv creation to pick up the actual layout.
 function _resolve_venv_paths() {
     if [ -d "$VENV/Scripts" ]; then
         VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -27,8 +27,9 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
-# FIXME: https://github.com/nanvix/zutils/issues/56
-$ShimCode = 'import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())'
+$ShimCode = @'
+import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+'@
 
 $zutilGlobalVersion = try {
     & nanvix-zutil --version 2>$null
@@ -47,7 +48,7 @@ function Bootstrap {
     # Discover a Python 3 interpreter.
     $venvArgs = @("-m", "venv")
     if (Test-Path $venvDir) {
-        $venvArgs += "--clear" 
+        $venvArgs += "--clear"
     }
     $venvArgs += $venvDir
 

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -13,7 +13,8 @@ REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P
 VENV="$REPO_ROOT/.nanvix/venv"
 
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
-# Must be called after venv creation to pick up the correct paths.
+# Can be called before venv creation to initialize default paths; call it
+# again after venv creation to pick up the actual layout.
 function _resolve_venv_paths() {
     if [ -d "$VENV/Scripts" ]; then
         VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"


### PR DESCRIPTION
## Summary

Fixes issues raised in PR reviews:
- [nanvix/zlib#59 comment](https://github.com/nanvix/zlib/pull/59#discussion_r3048314493)
- [nanvix/zlib#59 comment](https://github.com/nanvix/zlib/pull/59#discussion_r3048314509)
- [nanvix/sqlite#54 comment](https://github.com/nanvix/sqlite/pull/54#discussion_r3048322328)

## Changes

- **z.ps1**: Use PowerShell here-string (`@'...'@`) for `$ShimCode` so embedded double quotes are never backslash-escaped when passed to Python.
- **z.ps1**: Remove resolved FIXME comment referencing #56.
- **z.sh** (template + 3 examples): Update `_resolve_venv_paths` comment to accurately reflect that it can be called before venv creation to initialize defaults.

Closes #56