### PR TITLE
Backport CPython cross-mode fallback and Windows Docker support

### DIFF
--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -42,11 +42,14 @@ Public re-exports:
 - :func:`~nanvix_zutil.matrix.expand_matrix` — expand a build matrix to all combos
 - :func:`~nanvix_zutil.matrix.filter_matrix` — filter combos by mode
 - :func:`~nanvix_zutil.matrix.run_all_builds` — run a hook across all combos in parallel
+- :data:`~nanvix_zutil.buildroot.KNOWN_DEPLOYMENT_MODES` — canonical deployment modes for fallback
+- :func:`~nanvix_zutil.docker._is_windows` — Windows platform detection helper
 """
 
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
+    KNOWN_DEPLOYMENT_MODES,
     Ref,
     RefKind,
     extract_nanvix_version,
@@ -71,6 +74,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
+    _is_windows,
     docker_available,
     image_exists,
 )
@@ -131,6 +135,7 @@ __all__ = [
     "EXIT_NETWORK_ERROR",
     "EXIT_SUCCESS",
     "EXIT_TEST_FAILURE",
+    "KNOWN_DEPLOYMENT_MODES",
     "Lockfile",
     "LockfileMetadata",
     "Manifest",
@@ -145,6 +150,7 @@ __all__ = [
     "WORKSPACE_CONTAINER_PATH",
     "Sysroot",
     "ZScript",
+    "_is_windows",
     "docker_available",
     "extract_nanvix_version",
     "extract_nanvix_version_base",

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -42,14 +42,12 @@ Public re-exports:
 - :func:`~nanvix_zutil.matrix.expand_matrix` — expand a build matrix to all combos
 - :func:`~nanvix_zutil.matrix.filter_matrix` — filter combos by mode
 - :func:`~nanvix_zutil.matrix.run_all_builds` — run a hook across all combos in parallel
-- :data:`~nanvix_zutil.buildroot.KNOWN_DEPLOYMENT_MODES` — canonical deployment modes for fallback
 - :func:`~nanvix_zutil.docker.is_windows` — Windows platform detection helper
 """
 
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
-    KNOWN_DEPLOYMENT_MODES,
     Ref,
     RefKind,
     extract_nanvix_version,
@@ -135,7 +133,6 @@ __all__ = [
     "EXIT_NETWORK_ERROR",
     "EXIT_SUCCESS",
     "EXIT_TEST_FAILURE",
-    "KNOWN_DEPLOYMENT_MODES",
     "Lockfile",
     "LockfileMetadata",
     "Manifest",

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -43,7 +43,7 @@ Public re-exports:
 - :func:`~nanvix_zutil.matrix.filter_matrix` — filter combos by mode
 - :func:`~nanvix_zutil.matrix.run_all_builds` — run a hook across all combos in parallel
 - :data:`~nanvix_zutil.buildroot.KNOWN_DEPLOYMENT_MODES` — canonical deployment modes for fallback
-- :func:`~nanvix_zutil.docker._is_windows` — Windows platform detection helper
+- :func:`~nanvix_zutil.docker.is_windows` — Windows platform detection helper
 """
 
 from nanvix_zutil.buildroot import (
@@ -74,7 +74,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
-    _is_windows,
+    is_windows,
     docker_available,
     image_exists,
 )
@@ -150,7 +150,7 @@ __all__ = [
     "WORKSPACE_CONTAINER_PATH",
     "Sysroot",
     "ZScript",
-    "_is_windows",
+    "is_windows",
     "docker_available",
     "extract_nanvix_version",
     "extract_nanvix_version_base",

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -29,14 +29,6 @@ from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 
 _DEFAULT_BUILDROOT_DIR = Path(".nanvix") / "buildroot"
 
-#: Canonical deployment modes for cross-mode asset fallback.
-#: Order determines fallback priority when the exact mode is not found.
-KNOWN_DEPLOYMENT_MODES: tuple[str, ...] = (
-    "standalone",
-    "single-process",
-    "multi-process",
-)
-
 
 # ---------------------------------------------------------------------------
 # Tarball path helpers
@@ -260,7 +252,6 @@ class Buildroot:
         memory_size: str = DEFAULT_MEMORY_SIZE,
         gh_token: str | None = None,
         *,
-        fallback_modes: bool = False,
         _release: dict[str, object] | None = None,
     ) -> None:
         """Download a dependency release and install its libraries and headers.
@@ -269,18 +260,12 @@ class Buildroot:
         extracted.  Selected ``.a`` and ``.h`` files are copied into
         ``<buildroot>/lib/`` and ``<buildroot>/include/`` respectively.
 
-        When *fallback_modes* is ``True`` and the primary asset is not
-        found, alternate deployment modes from
-        :data:`KNOWN_DEPLOYMENT_MODES` are tried in order.
-
         Args:
             dep: The :class:`Dependency` descriptor.
             machine: Target machine identifier.
             deployment_mode: Deployment mode string.
             memory_size: Memory size string.
             gh_token: Optional GitHub token.
-            fallback_modes: When ``True``, try alternate deployment modes
-                if the primary asset is missing.
             _release: Pre-resolved release metadata dictionary.  When
                 provided, the release resolution step is skipped (avoids
                 redundant GitHub API calls when the caller has already
@@ -295,60 +280,14 @@ class Buildroot:
 
         cache_dir = self.path.parent / "cache"
 
-        asset_path: Path | None
-        if fallback_modes:
-            asset_path = github.download_release_asset(
-                repo=dep.repo,
-                version_specifier=dep.ref.value,
-                asset_name=asset_name,
-                dest=cache_dir,
-                gh_token=gh_token,
-                _release=_release,
-                allow_missing=True,
-            )
-            if asset_path is None:
-                for mode in KNOWN_DEPLOYMENT_MODES:
-                    if mode == deployment_mode:
-                        continue
-                    fallback_name = dep.artifact_pattern.format(
-                        name=dep.name,
-                        machine=machine,
-                        mode=mode,
-                        mem=memory_size,
-                    )
-                    asset_path = github.download_release_asset(
-                        repo=dep.repo,
-                        version_specifier=dep.ref.value,
-                        asset_name=fallback_name,
-                        dest=cache_dir,
-                        gh_token=gh_token,
-                        _release=_release,
-                        allow_missing=True,
-                    )
-                    if asset_path is not None:
-                        log.info(
-                            f"Using fallback asset {fallback_name} "
-                            f"(mode={mode}) for {dep.name}"
-                        )
-                        asset_name = fallback_name
-                        break
-
-            if asset_path is None:
-                log.fatal(
-                    f"Asset '{asset_name}' not found in release "
-                    f"{dep.repo}@{dep.ref.value} (tried all deployment modes)",
-                    code=EXIT_MISSING_DEP,
-                    hint="Check the release tag and asset name.",
-                )
-        else:
-            asset_path = github.download_release_asset(
-                repo=dep.repo,
-                version_specifier=dep.ref.value,
-                asset_name=asset_name,
-                dest=cache_dir,
-                gh_token=gh_token,
-                _release=_release,
-            )
+        asset_path = github.download_release_asset(
+            repo=dep.repo,
+            version_specifier=dep.ref.value,
+            asset_name=asset_name,
+            dest=cache_dir,
+            gh_token=gh_token,
+            _release=_release,
+        )
 
         log.info(f"Extracting {asset_name}...")
         with tarfile.open(asset_path, "r:bz2") as tf:

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -29,6 +29,14 @@ from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 
 _DEFAULT_BUILDROOT_DIR = Path(".nanvix") / "buildroot"
 
+#: Canonical deployment modes for cross-mode asset fallback.
+#: Order determines fallback priority when the exact mode is not found.
+KNOWN_DEPLOYMENT_MODES: tuple[str, ...] = (
+    "standalone",
+    "single-process",
+    "multi-process",
+)
+
 
 # ---------------------------------------------------------------------------
 # Tarball path helpers
@@ -251,6 +259,9 @@ class Buildroot:
         deployment_mode: str = DEFAULT_DEPLOYMENT_MODE,
         memory_size: str = DEFAULT_MEMORY_SIZE,
         gh_token: str | None = None,
+        *,
+        fallback_modes: bool = False,
+        _release: dict[str, object] | None = None,
     ) -> None:
         """Download a dependency release and install its libraries and headers.
 
@@ -258,12 +269,22 @@ class Buildroot:
         extracted.  Selected ``.a`` and ``.h`` files are copied into
         ``<buildroot>/lib/`` and ``<buildroot>/include/`` respectively.
 
+        When *fallback_modes* is ``True`` and the primary asset is not
+        found, alternate deployment modes from
+        :data:`KNOWN_DEPLOYMENT_MODES` are tried in order.
+
         Args:
             dep: The :class:`Dependency` descriptor.
             machine: Target machine identifier.
             deployment_mode: Deployment mode string.
             memory_size: Memory size string.
             gh_token: Optional GitHub token.
+            fallback_modes: When ``True``, try alternate deployment modes
+                if the primary asset is missing.
+            _release: Pre-resolved release metadata dictionary.  When
+                provided, the release resolution step is skipped (avoids
+                redundant GitHub API calls when the caller has already
+                resolved the release).
         """
         asset_name = dep.artifact_pattern.format(
             name=dep.name,
@@ -274,13 +295,60 @@ class Buildroot:
 
         cache_dir = self.path.parent / "cache"
 
-        asset_path = github.download_release_asset(
-            repo=dep.repo,
-            version_specifier=dep.ref.value,
-            asset_name=asset_name,
-            dest=cache_dir,
-            gh_token=gh_token,
-        )
+        asset_path: Path | None
+        if fallback_modes:
+            asset_path = github.download_release_asset(
+                repo=dep.repo,
+                version_specifier=dep.ref.value,
+                asset_name=asset_name,
+                dest=cache_dir,
+                gh_token=gh_token,
+                _release=_release,
+                allow_missing=True,
+            )
+            if asset_path is None:
+                for mode in KNOWN_DEPLOYMENT_MODES:
+                    if mode == deployment_mode:
+                        continue
+                    fallback_name = dep.artifact_pattern.format(
+                        name=dep.name,
+                        machine=machine,
+                        mode=mode,
+                        mem=memory_size,
+                    )
+                    asset_path = github.download_release_asset(
+                        repo=dep.repo,
+                        version_specifier=dep.ref.value,
+                        asset_name=fallback_name,
+                        dest=cache_dir,
+                        gh_token=gh_token,
+                        _release=_release,
+                        allow_missing=True,
+                    )
+                    if asset_path is not None:
+                        log.info(
+                            f"Using fallback asset {fallback_name} "
+                            f"(mode={mode}) for {dep.name}"
+                        )
+                        asset_name = fallback_name
+                        break
+
+            if asset_path is None:
+                log.fatal(
+                    f"Asset '{asset_name}' not found in release "
+                    f"{dep.repo}@{dep.ref.value} (tried all deployment modes)",
+                    code=EXIT_MISSING_DEP,
+                    hint="Check the release tag and asset name.",
+                )
+        else:
+            asset_path = github.download_release_asset(
+                repo=dep.repo,
+                version_specifier=dep.ref.value,
+                asset_name=asset_name,
+                dest=cache_dir,
+                gh_token=gh_token,
+                _release=_release,
+            )
 
         log.info(f"Extracting {asset_name}...")
         with tarfile.open(asset_path, "r:bz2") as tf:

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -19,6 +19,7 @@ Typical usage (via :class:`~nanvix_zutil.ZScript` — not used directly)::
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -285,14 +286,17 @@ class DockerConfig:
     def build_windows_run_cmd(self, *cmd: str) -> list[str]:
         """Build a ``docker run`` command using tar-based source copying.
 
-        Instead of bind-mounting the workspace (which suffers severe I/O
-        penalties on Windows Docker Desktop via VirtioFS/9p), this method:
+        Instead of building directly from the mounted workspace (which suffers
+        severe I/O penalties on Windows Docker Desktop via VirtioFS/9p), this
+        method:
 
-        1. Mounts the host workspace read-only at a staging path.
-        2. Copies sources via ``tar`` into a container-local build dir.
+        1. Uses the configured container mounts as provided, typically including
+           the host workspace at ``/mnt/workspace``.
+        2. Copies sources via ``tar`` from the mounted workspace into a
+           container-local build dir.
         3. Normalizes CRLF line endings in configured files.
-        4. Runs the inner command.
-        5. Copies output files back to the host workspace.
+        4. Runs the inner command from the container-local build dir.
+        5. Copies configured output files back to the mounted workspace.
 
         Args:
             *cmd: Inner command and arguments to wrap.
@@ -301,20 +305,21 @@ class DockerConfig:
             Full ``docker run …`` argument list ready for
             :func:`subprocess.run`.
         """
-        ws_mount = "/mnt/workspace"
+        ws_mount = str(WORKSPACE_CONTAINER_PATH)
         build_dir = self.container_build_dir
 
         # Build tar exclude args.
-        excludes = " ".join(f"--exclude={e}" for e in self.tar_excludes)
+        excludes = " ".join(f"--exclude={shlex.quote(e)}" for e in self.tar_excludes)
 
         # CRLF normalization script.
         crlf_script = ""
         if self.crlf_files:
             crlf_cmds: list[str] = []
             for f in self.crlf_files:
+                qf = shlex.quote(f)
                 crlf_cmds.append(
-                    f'[ -f "{f}" ] && sed "s/\\r$//" "{f}" > /tmp/_crlf.tmp '
-                    f'&& cat /tmp/_crlf.tmp > "{f}"'
+                    f'[ -f {qf} ] && sed "s/\\r$//" {qf} > /tmp/_crlf.tmp '
+                    f"&& cat /tmp/_crlf.tmp > {qf}"
                 )
             crlf_script = " && ".join(crlf_cmds) + " && "
 
@@ -322,12 +327,12 @@ class DockerConfig:
         output_script = ""
         if self.output_files:
             copy_cmds = [
-                f"[ -f {build_dir}/{f} ] && cp -f {build_dir}/{f} {ws_mount}/{f}"
+                f"[ -f {shlex.quote(f'{build_dir}/{f}')} ] && cp -f {shlex.quote(f'{build_dir}/{f}')} {shlex.quote(f'{ws_mount}/{f}')}"
                 for f in self.output_files
             ]
             output_script = "; " + "; ".join(copy_cmds)
 
-        inner_cmd = " ".join(cmd)
+        inner_cmd = " ".join(shlex.quote(c) for c in cmd)
         shell_script = (
             f"mkdir -p {build_dir} && "
             f"tar -cf - -C {ws_mount} {excludes} . "

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -62,7 +62,7 @@ def _get_gid() -> int:
     return os.getgid() if hasattr(os, "getgid") else 0
 
 
-def _is_windows() -> bool:
+def is_windows() -> bool:
     """Return ``True`` when running on Windows.
 
     Extracted to a named function so tests can mock it without

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -62,6 +62,15 @@ def _get_gid() -> int:
     return os.getgid() if hasattr(os, "getgid") else 0
 
 
+def _is_windows() -> bool:
+    """Return ``True`` when running on Windows.
+
+    Extracted to a named function so tests can mock it without
+    patching ``sys.platform`` globally.
+    """
+    return sys.platform == "win32"
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
@@ -125,6 +134,26 @@ class DockerConfig:
 
     extra_env: dict[str, str] = field(default_factory=dict)
     """Additional ``-e KEY=VALUE`` pairs forwarded to the container."""
+
+    crlf_files: list[str] = field(default_factory=list)
+    """Files requiring CRLF→LF normalization inside the container."""
+
+    output_files: list[str] = field(default_factory=list)
+    """Build output files to copy back from the container to the host."""
+
+    tar_excludes: list[str] = field(
+        default_factory=lambda: [
+            ".git",
+            ".nanvix/venv",
+            ".nanvix/cache",
+            ".nanvix/sysroot",
+            ".nanvix/buildroot",
+        ]
+    )
+    """Directories/files to exclude from tar-based source copy."""
+
+    container_build_dir: str = "/tmp/build"
+    """Working directory inside the container for Windows tar-copy mode."""
 
     # ------------------------------------------------------------------
     # Path translation
@@ -251,6 +280,79 @@ class DockerConfig:
 
         docker_cmd.append(self.image)
         docker_cmd.extend(cmd)
+        return docker_cmd
+
+    def build_windows_run_cmd(self, *cmd: str) -> list[str]:
+        """Build a ``docker run`` command using tar-based source copying.
+
+        Instead of bind-mounting the workspace (which suffers severe I/O
+        penalties on Windows Docker Desktop via VirtioFS/9p), this method:
+
+        1. Mounts the host workspace read-only at a staging path.
+        2. Copies sources via ``tar`` into a container-local build dir.
+        3. Normalizes CRLF line endings in configured files.
+        4. Runs the inner command.
+        5. Copies output files back to the host workspace.
+
+        Args:
+            *cmd: Inner command and arguments to wrap.
+
+        Returns:
+            Full ``docker run …`` argument list ready for
+            :func:`subprocess.run`.
+        """
+        ws_mount = "/mnt/workspace"
+        build_dir = self.container_build_dir
+
+        # Build tar exclude args.
+        excludes = " ".join(f"--exclude={e}" for e in self.tar_excludes)
+
+        # CRLF normalization script.
+        crlf_script = ""
+        if self.crlf_files:
+            crlf_cmds: list[str] = []
+            for f in self.crlf_files:
+                crlf_cmds.append(
+                    f'[ -f "{f}" ] && sed "s/\\r$//" "{f}" > /tmp/_crlf.tmp '
+                    f'&& cat /tmp/_crlf.tmp > "{f}"'
+                )
+            crlf_script = " && ".join(crlf_cmds) + " && "
+
+        # Output copy-back script.
+        output_script = ""
+        if self.output_files:
+            copy_cmds = [
+                f"[ -f {build_dir}/{f} ] && cp -f {build_dir}/{f} {ws_mount}/{f}"
+                for f in self.output_files
+            ]
+            output_script = "; " + "; ".join(copy_cmds)
+
+        inner_cmd = " ".join(cmd)
+        shell_script = (
+            f"mkdir -p {build_dir} && "
+            f"tar -cf - -C {ws_mount} {excludes} . "
+            f"| tar -xf - -C {build_dir} && "
+            f"cd {build_dir} && "
+            f"{crlf_script}"
+            f"{inner_cmd}; rc=$?{output_script}; exit $rc"
+        )
+
+        docker_cmd: list[str] = ["docker", "run", "--rm"]
+
+        for mount in self.mounts:
+            vol = f"{mount.host_path.resolve()}:{mount.container_path}"
+            if mount.readonly:
+                vol += ":ro"
+            docker_cmd += ["-v", vol]
+
+        docker_cmd += ["-w", build_dir]
+        docker_cmd += ["-e", "HOME=/tmp"]
+
+        for key, val in self.extra_env.items():
+            docker_cmd += ["-e", f"{key}={val}"]
+
+        docker_cmd.append(self.image)
+        docker_cmd += ["sh", "-c", shell_script]
         return docker_cmd
 
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -36,6 +36,7 @@ from nanvix_zutil import log
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
+    extract_nanvix_version,
     extract_nanvix_version_base,
     suffix_dep,
 )
@@ -327,12 +328,20 @@ class ZScript:
                     release: dict[str, object] | None = None
                     base_version = extract_nanvix_version_base(str(dep.ref.value))
                     if base_version is not None:
-                        release, _fb_ver = resolve_release_with_fallback(
+                        release, fb_ver = resolve_release_with_fallback(
                             repo=dep.repo,
                             version_specifier=str(dep.ref.value),
                             base_version=base_version,
                             gh_token=self.config.get(CFG_GH_TOKEN),
                         )
+                        # Log when version fallback was used.
+                        requested_ver = extract_nanvix_version(str(dep.ref.value))
+                        if fb_ver != requested_ver:
+                            log.info(
+                                f"Version fallback for {dep.name}: "
+                                f"requested nanvix-{requested_ver}, "
+                                f"resolved nanvix-{fb_ver}"
+                            )
                     else:
                         release = resolve_release(
                             repo=dep.repo,

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -355,7 +355,6 @@ class ZScript:
                         deployment_mode=self.config.deployment_mode,
                         memory_size=self.config.memory_size,
                         gh_token=self.config.get(CFG_GH_TOKEN),
-                        fallback_modes=True,
                         _release=release,
                     )
                 except SystemExit:

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -48,6 +48,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
+    _is_windows,
     docker_available,
     image_exists,
 )
@@ -450,8 +451,18 @@ class ZScript:
     def clean(self) -> None:
         """Remove build artifacts.
 
-        Override to clean generated files.
+        On Windows, common build artifacts are removed directly without
+        invoking the build system (which would require Docker).  Override
+        to customise the files cleaned.
         """
+        if _is_windows():
+            # Common artifacts that consumers may produce.
+            # Subclasses can override to add project-specific files.
+            for name in (".nanvix-configured",):
+                p = self.repo_root / name
+                if p.is_file():
+                    p.unlink()
+                    log.info(f"Removed {name}")
 
     # ------------------------------------------------------------------
     # Subprocess helper
@@ -503,7 +514,15 @@ class ZScript:
                 merged = {**cfg.extra_env, **combo_and_explicit}
                 cfg = dataclasses.replace(cfg, extra_env=merged)
             if kvm:
+                if _is_windows():
+                    log.fatal(
+                        "KVM mode is not available on Windows",
+                        code=EXIT_BUILD_FAILURE,
+                        hint="KVM requires a Linux host with /dev/kvm access.",
+                    )
                 cmd = cfg.build_kvm_run_cmd(*args)
+            elif _is_windows() and (cfg.crlf_files or cfg.output_files):
+                cmd = cfg.build_windows_run_cmd(*args)
             else:
                 cmd = cfg.build_run_cmd(*args)
             working_dir = self.repo_root

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -33,7 +33,12 @@ import sys
 from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import log
-from nanvix_zutil.buildroot import Buildroot, Dependency, suffix_dep
+from nanvix_zutil.buildroot import (
+    Buildroot,
+    Dependency,
+    extract_nanvix_version_base,
+    suffix_dep,
+)
 from nanvix_zutil.cli import build_parser
 from nanvix_zutil.config import CFG_GH_TOKEN, CFG_SYSROOT, Config
 from nanvix_zutil.docker import (
@@ -52,6 +57,7 @@ from nanvix_zutil.exitcodes import (
     EXIT_MISSING_DEP,
     EXIT_TEST_FAILURE,
 )
+from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.matrix import (
@@ -314,12 +320,33 @@ class ZScript:
             self.buildroot = Buildroot.create(self.nanvix_dir / "buildroot")
             for dep in deps:
                 try:
+                    # Resolve release with version fallback for nanvix-suffixed
+                    # deps, then pass the pre-resolved release and enable
+                    # cross-mode asset fallback in install_dep().
+                    release: dict[str, object] | None = None
+                    base_version = extract_nanvix_version_base(str(dep.ref.value))
+                    if base_version is not None:
+                        release, _fb_ver = resolve_release_with_fallback(
+                            repo=dep.repo,
+                            version_specifier=str(dep.ref.value),
+                            base_version=base_version,
+                            gh_token=self.config.get(CFG_GH_TOKEN),
+                        )
+                    else:
+                        release = resolve_release(
+                            repo=dep.repo,
+                            version_specifier=dep.ref.value,
+                            gh_token=self.config.get(CFG_GH_TOKEN),
+                        )
+
                     self.buildroot.install_dep(
                         dep=dep,
                         machine=self.config.machine,
                         deployment_mode=self.config.deployment_mode,
                         memory_size=self.config.memory_size,
                         gh_token=self.config.get(CFG_GH_TOKEN),
+                        fallback_modes=True,
+                        _release=release,
                     )
                 except SystemExit:
                     log.note(

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -335,8 +335,10 @@ class ZScript:
                             gh_token=self.config.get(CFG_GH_TOKEN),
                         )
                         # Log when version fallback was used.
-                        requested_ver = extract_nanvix_version(str(dep.ref.value))
-                        if fb_ver != requested_ver:
+                        # fb_ver is None when the exact tag was found;
+                        # non-None means a fallback release was used.
+                        if fb_ver is not None:
+                            requested_ver = extract_nanvix_version(str(dep.ref.value))
                             log.info(
                                 f"Version fallback for {dep.name}: "
                                 f"requested nanvix-{requested_ver}, "

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -48,7 +48,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
-    _is_windows,
+    is_windows,
     docker_available,
     image_exists,
 )
@@ -455,7 +455,7 @@ class ZScript:
         invoking the build system (which would require Docker).  Override
         to customise the files cleaned.
         """
-        if _is_windows():
+        if is_windows():
             # Common artifacts that consumers may produce.
             # Subclasses can override to add project-specific files.
             for name in (".nanvix-configured",):
@@ -514,14 +514,14 @@ class ZScript:
                 merged = {**cfg.extra_env, **combo_and_explicit}
                 cfg = dataclasses.replace(cfg, extra_env=merged)
             if kvm:
-                if _is_windows():
+                if is_windows():
                     log.fatal(
                         "KVM mode is not available on Windows",
                         code=EXIT_BUILD_FAILURE,
                         hint="KVM requires a Linux host with /dev/kvm access.",
                     )
                 cmd = cfg.build_kvm_run_cmd(*args)
-            elif _is_windows() and (cfg.crlf_files or cfg.output_files):
+            elif is_windows() and (cfg.crlf_files or cfg.output_files):
                 cmd = cfg.build_windows_run_cmd(*args)
             else:
                 cmd = cfg.build_run_cmd(*args)

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -14,7 +14,6 @@ import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
-    KNOWN_DEPLOYMENT_MODES,
     Ref,
     RefKind,
     extract_nanvix_version,
@@ -415,26 +414,8 @@ class TestParseSemverTuple(unittest.TestCase):
         self.assertLess(parse_semver_tuple("0.12.291"), parse_semver_tuple("0.12.337"))
 
 
-class TestKnownDeploymentModes(unittest.TestCase):
-    """Tests for the KNOWN_DEPLOYMENT_MODES constant."""
-
-    def test_is_tuple(self) -> None:
-        self.assertIsInstance(KNOWN_DEPLOYMENT_MODES, tuple)
-
-    def test_contains_expected_modes(self) -> None:
-        self.assertIn("standalone", KNOWN_DEPLOYMENT_MODES)
-        self.assertIn("single-process", KNOWN_DEPLOYMENT_MODES)
-        self.assertIn("multi-process", KNOWN_DEPLOYMENT_MODES)
-
-    def test_order_matches_schema(self) -> None:
-        self.assertEqual(
-            KNOWN_DEPLOYMENT_MODES,
-            ("standalone", "single-process", "multi-process"),
-        )
-
-
-class TestInstallDepFallbackModes(unittest.TestCase):
-    """Buildroot.install_dep with fallback_modes=True."""
+class TestInstallDepPreResolvedRelease(unittest.TestCase):
+    """Buildroot.install_dep with _release pre-resolved."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -455,159 +436,6 @@ class TestInstallDepFallbackModes(unittest.TestCase):
                 "sysroot/include/zlib.h": b"header-content",
             }
         )
-
-    def test_fallback_to_alternate_mode(self) -> None:
-        """When primary mode asset is missing, try alternate modes."""
-        br = self._setup_buildroot()
-        archive = self._make_archive()
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
-        archive_path.write_bytes(archive)
-
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-        )
-
-        call_count = 0
-
-        def fake_download(
-            repo: str,
-            version_specifier: str | int,
-            asset_name: str,
-            dest: Path,
-            gh_token: str | None = None,
-            *,
-            match_prefix: bool = False,
-            semver: bool = False,
-            _release: dict[str, object] | None = None,
-            allow_missing: bool = False,
-        ) -> Path | None:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                # Primary fails.
-                return None
-            # First fallback succeeds.
-            return archive_path
-
-        with patch(
-            "nanvix_zutil.buildroot.github.download_release_asset",
-            side_effect=fake_download,
-        ):
-            br.install_dep(
-                dep,
-                deployment_mode="multi-process",
-                fallback_modes=True,
-            )
-
-        self.assertTrue((br.path / "lib" / "libz.a").exists())
-        # 1 primary + 1 fallback = 2
-        self.assertEqual(call_count, 2)
-
-    def test_no_fallback_when_disabled(self) -> None:
-        """When fallback_modes=False (default), don't try alternates."""
-        br = self._setup_buildroot()
-        archive = self._make_archive()
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
-        archive_path.write_bytes(archive)
-
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-        )
-
-        with patch(
-            "nanvix_zutil.buildroot.github.download_release_asset",
-            return_value=archive_path,
-        ):
-            br.install_dep(dep)
-
-        self.assertTrue((br.path / "lib" / "libz.a").exists())
-
-    def test_fallback_skips_requested_mode(self) -> None:
-        """Don't retry the same mode that already failed."""
-        br = self._setup_buildroot()
-        archive = self._make_archive()
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
-        archive_path.write_bytes(archive)
-
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-        )
-
-        tried_modes: list[str] = []
-
-        def fake_download(
-            repo: str,
-            version_specifier: str | int,
-            asset_name: str,
-            dest: Path,
-            gh_token: str | None = None,
-            *,
-            match_prefix: bool = False,
-            semver: bool = False,
-            _release: dict[str, object] | None = None,
-            allow_missing: bool = False,
-        ) -> Path | None:
-            # Extract mode from asset name pattern.
-            for mode in KNOWN_DEPLOYMENT_MODES:
-                if mode in asset_name:
-                    tried_modes.append(mode)
-                    break
-            if len(tried_modes) <= 1:
-                return None  # Primary fails.
-            return archive_path  # Fallback succeeds.
-
-        with patch(
-            "nanvix_zutil.buildroot.github.download_release_asset",
-            side_effect=fake_download,
-        ):
-            br.install_dep(
-                dep,
-                deployment_mode="standalone",
-                fallback_modes=True,
-            )
-
-        # "standalone" should appear only once (the primary attempt), not again.
-        self.assertEqual(tried_modes.count("standalone"), 1)
-
-    def test_fallback_fatal_when_all_modes_fail(self) -> None:
-        """Fatal error if no mode produces an asset."""
-        br = self._setup_buildroot()
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-        )
-
-        def fake_download(
-            repo: str,
-            version_specifier: str | int,
-            asset_name: str,
-            dest: Path,
-            gh_token: str | None = None,
-            *,
-            match_prefix: bool = False,
-            semver: bool = False,
-            _release: dict[str, object] | None = None,
-            allow_missing: bool = False,
-        ) -> Path | None:
-            return None  # All modes fail.
-
-        with (
-            patch(
-                "nanvix_zutil.buildroot.github.download_release_asset",
-                side_effect=fake_download,
-            ),
-            self.assertRaises(SystemExit) as ctx,
-        ):
-            br.install_dep(dep, fallback_modes=True)
-
-        self.assertEqual(ctx.exception.code, 3)
 
     def test_pre_resolved_release_passed_through(self) -> None:
         """When _release is provided, it's forwarded to download_release_asset."""

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -14,6 +14,7 @@ import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
+    KNOWN_DEPLOYMENT_MODES,
     Ref,
     RefKind,
     extract_nanvix_version,
@@ -406,6 +407,240 @@ class TestParseSemverTuple(unittest.TestCase):
 
     def test_ordering(self) -> None:
         self.assertLess(parse_semver_tuple("0.12.291"), parse_semver_tuple("0.12.337"))
+
+
+class TestKnownDeploymentModes(unittest.TestCase):
+    """Tests for the KNOWN_DEPLOYMENT_MODES constant."""
+
+    def test_is_tuple(self) -> None:
+        self.assertIsInstance(KNOWN_DEPLOYMENT_MODES, tuple)
+
+    def test_contains_expected_modes(self) -> None:
+        self.assertIn("standalone", KNOWN_DEPLOYMENT_MODES)
+        self.assertIn("single-process", KNOWN_DEPLOYMENT_MODES)
+        self.assertIn("multi-process", KNOWN_DEPLOYMENT_MODES)
+
+    def test_order_matches_schema(self) -> None:
+        self.assertEqual(
+            KNOWN_DEPLOYMENT_MODES,
+            ("standalone", "single-process", "multi-process"),
+        )
+
+
+class TestInstallDepFallbackModes(unittest.TestCase):
+    """Buildroot.install_dep with fallback_modes=True."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def _setup_buildroot(self) -> Buildroot:
+        dest = Path(self._tmpdir.name) / "br"
+        return Buildroot.create(dest=dest)
+
+    def _make_archive(self) -> bytes:
+        return _make_tar_bz2(
+            {
+                "sysroot/lib/libz.a": b"lib-content",
+                "sysroot/include/zlib.h": b"header-content",
+            }
+        )
+
+    def test_fallback_to_alternate_mode(self) -> None:
+        """When primary mode asset is missing, try alternate modes."""
+        br = self._setup_buildroot()
+        archive = self._make_archive()
+        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path.write_bytes(archive)
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+        )
+
+        call_count = 0
+
+        def fake_download(
+            repo: str,
+            version_specifier: str | int,
+            asset_name: str,
+            dest: Path,
+            gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
+        ) -> Path | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Primary fails.
+                return None
+            # First fallback succeeds.
+            return archive_path
+
+        with patch(
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
+        ):
+            br.install_dep(
+                dep,
+                deployment_mode="multi-process",
+                fallback_modes=True,
+            )
+
+        self.assertTrue((br.path / "lib" / "libz.a").exists())
+        # 1 primary + 1 fallback = 2
+        self.assertEqual(call_count, 2)
+
+    def test_no_fallback_when_disabled(self) -> None:
+        """When fallback_modes=False (default), don't try alternates."""
+        br = self._setup_buildroot()
+        archive = self._make_archive()
+        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path.write_bytes(archive)
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+        )
+
+        with patch(
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            return_value=archive_path,
+        ):
+            br.install_dep(dep)
+
+        self.assertTrue((br.path / "lib" / "libz.a").exists())
+
+    def test_fallback_skips_requested_mode(self) -> None:
+        """Don't retry the same mode that already failed."""
+        br = self._setup_buildroot()
+        archive = self._make_archive()
+        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path.write_bytes(archive)
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+        )
+
+        tried_modes: list[str] = []
+
+        def fake_download(
+            repo: str,
+            version_specifier: str | int,
+            asset_name: str,
+            dest: Path,
+            gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
+        ) -> Path | None:
+            # Extract mode from asset name pattern.
+            for mode in KNOWN_DEPLOYMENT_MODES:
+                if mode in asset_name:
+                    tried_modes.append(mode)
+                    break
+            if len(tried_modes) <= 1:
+                return None  # Primary fails.
+            return archive_path  # Fallback succeeds.
+
+        with patch(
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
+        ):
+            br.install_dep(
+                dep,
+                deployment_mode="standalone",
+                fallback_modes=True,
+            )
+
+        # "standalone" should appear only once (the primary attempt), not again.
+        self.assertEqual(tried_modes.count("standalone"), 1)
+
+    def test_fallback_fatal_when_all_modes_fail(self) -> None:
+        """Fatal error if no mode produces an asset."""
+        br = self._setup_buildroot()
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+        )
+
+        def fake_download(
+            repo: str,
+            version_specifier: str | int,
+            asset_name: str,
+            dest: Path,
+            gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
+        ) -> Path | None:
+            return None  # All modes fail.
+
+        with (
+            patch(
+                "nanvix_zutil.buildroot.github.download_release_asset",
+                side_effect=fake_download,
+            ),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            br.install_dep(dep, fallback_modes=True)
+
+        self.assertEqual(ctx.exception.code, 3)
+
+    def test_pre_resolved_release_passed_through(self) -> None:
+        """When _release is provided, it's forwarded to download_release_asset."""
+        br = self._setup_buildroot()
+        archive = self._make_archive()
+        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path.write_bytes(archive)
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+        )
+
+        fake_release: dict[str, object] = {"id": 42, "tag_name": "v1.0.0"}
+        captured_releases: list[dict[str, object] | None] = []
+
+        def fake_download(
+            repo: str,
+            version_specifier: str | int,
+            asset_name: str,
+            dest: Path,
+            gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
+        ) -> Path:
+            captured_releases.append(_release)
+            return archive_path
+
+        with patch(
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
+        ):
+            br.install_dep(dep, _release=fake_release)
+
+        self.assertEqual(captured_releases[0], fake_release)
 
 
 if __name__ == "__main__":

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -277,12 +277,18 @@ class TestBuildrootInstallDep(unittest.TestCase):
             asset_name: str,
             dest: Path,
             gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
         ) -> Path:
             captured.append(asset_name)
             return archive_path
 
         with patch(
-            "nanvix_zutil.github.download_release_asset", side_effect=fake_download
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
         ):
             br.install_dep(
                 dep,

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -20,6 +20,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
+    _is_windows,
     docker_available,
     image_exists,
 )
@@ -503,6 +504,145 @@ class TestPlatformUidGid(unittest.TestCase):
             self.assertEqual(cfg.uid, os.getuid())
         if hasattr(os, "getgid"):
             self.assertEqual(cfg.gid, os.getgid())
+
+
+class TestIsWindows(unittest.TestCase):
+    """Tests for _is_windows() helper."""
+
+    def test_returns_bool(self) -> None:
+        self.assertIsInstance(_is_windows(), bool)
+
+    def test_false_on_linux(self) -> None:
+        with patch("nanvix_zutil.docker.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            self.assertFalse(_is_windows())
+
+    def test_true_on_win32(self) -> None:
+        with patch("nanvix_zutil.docker.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            self.assertTrue(_is_windows())
+
+
+class TestDockerConfigWindowsFields(unittest.TestCase):
+    """DockerConfig Windows-specific field defaults."""
+
+    def test_crlf_files_default_empty(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.crlf_files, [])
+
+    def test_output_files_default_empty(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.output_files, [])
+
+    def test_tar_excludes_has_defaults(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertIn(".git", cfg.tar_excludes)
+        self.assertIn(".nanvix/venv", cfg.tar_excludes)
+
+    def test_container_build_dir_default(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.container_build_dir, "/tmp/build")
+
+
+class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
+    """Tests for DockerConfig.build_windows_run_cmd()."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._workspace = Path(self._tmpdir.name) / "workspace"
+        self._workspace.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_config(
+        self,
+        crlf_files: list[str] | None = None,
+        output_files: list[str] | None = None,
+    ) -> DockerConfig:
+        return DockerConfig(
+            image="nanvix/toolchain:latest-minimal",
+            mounts=[
+                Mount(
+                    host_path=self._workspace,
+                    container_path=WORKSPACE_CONTAINER_PATH,
+                    readonly=False,
+                ),
+            ],
+            uid=1000,
+            gid=1000,
+            crlf_files=crlf_files or [],
+            output_files=output_files or [],
+        )
+
+    def test_tar_copy_command_structure(self) -> None:
+        """Windows run command uses tar instead of bind mounts."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        self.assertEqual(cmd[:3], ["docker", "run", "--rm"])
+        # Should use sh -c wrapping.
+        self.assertIn("sh", cmd)
+        self.assertIn("-c", cmd)
+
+    def test_contains_tar_in_shell_script(self) -> None:
+        """The shell script should include tar commands."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        shell_script = cmd[-1]  # Last arg after sh -c
+        self.assertIn("tar -cf", shell_script)
+        self.assertIn("tar -xf", shell_script)
+
+    def test_crlf_normalization_included(self) -> None:
+        """CRLF files are normalized in the shell script."""
+        cfg = self._make_config(crlf_files=["Makefile", "configure"])
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        shell_script = cmd[-1]
+        self.assertIn("Makefile", shell_script)
+        self.assertIn("configure", shell_script)
+        self.assertIn("sed", shell_script)
+
+    def test_output_files_copied_back(self) -> None:
+        """Output files are copied from container to host."""
+        cfg = self._make_config(output_files=["build/output.elf", "result.bin"])
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        shell_script = cmd[-1]
+        self.assertIn("build/output.elf", shell_script)
+        self.assertIn("result.bin", shell_script)
+        self.assertIn("cp -f", shell_script)
+
+    def test_inner_command_in_script(self) -> None:
+        """The inner command appears in the shell script."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("make", "-j4", "all")
+        shell_script = cmd[-1]
+        self.assertIn("make -j4 all", shell_script)
+
+    def test_workdir_is_build_dir(self) -> None:
+        """Working directory is set to container_build_dir."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("echo")
+        w_idx = cmd.index("-w")
+        self.assertEqual(cmd[w_idx + 1], "/tmp/build")
+
+    def test_tar_excludes_in_command(self) -> None:
+        """Tar excludes appear in the shell script."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("echo")
+        shell_script = cmd[-1]
+        self.assertIn("--exclude=.git", shell_script)
+
+    def test_no_user_flag(self) -> None:
+        """Windows run cmd does not include --user flag."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("echo")
+        self.assertNotIn("--user", cmd)
+
+    def test_extra_env_forwarded(self) -> None:
+        """Extra env vars are forwarded to the container."""
+        cfg = self._make_config()
+        cfg.extra_env["MY_VAR"] = "hello"
+        cmd = cfg.build_windows_run_cmd("echo")
+        self.assertIn("MY_VAR=hello", cmd)
 
 
 if __name__ == "__main__":

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -20,7 +20,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
-    _is_windows,
+    is_windows,
     docker_available,
     image_exists,
 )
@@ -507,20 +507,20 @@ class TestPlatformUidGid(unittest.TestCase):
 
 
 class TestIsWindows(unittest.TestCase):
-    """Tests for _is_windows() helper."""
+    """Tests for is_windows() helper."""
 
     def test_returns_bool(self) -> None:
-        self.assertIsInstance(_is_windows(), bool)
+        self.assertIsInstance(is_windows(), bool)
 
     def test_false_on_linux(self) -> None:
         with patch("nanvix_zutil.docker.sys") as mock_sys:
             mock_sys.platform = "linux"
-            self.assertFalse(_is_windows())
+            self.assertFalse(is_windows())
 
     def test_true_on_win32(self) -> None:
         with patch("nanvix_zutil.docker.sys") as mock_sys:
             mock_sys.platform = "win32"
-            self.assertTrue(_is_windows())
+            self.assertTrue(is_windows())
 
 
 class TestDockerConfigWindowsFields(unittest.TestCase):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -421,6 +421,58 @@ class TestZScriptRun(unittest.TestCase):
         finally:
             log_mod.set_json_mode(False)
 
+    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    def test_run_kvm_fatal_on_windows(self, _mock: object) -> None:
+        """run() with kvm=True exits fatally on Windows."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.docker = DockerConfig(
+            image="test-image",
+            mounts=[],
+            uid=0,
+            gid=0,
+        )
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                script.run("echo", kvm=True)
+            self.assertEqual(ctx.exception.code, 5)
+        finally:
+            log_mod.set_json_mode(False)
+
+    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    def test_run_uses_windows_cmd_when_configured(self, _mock: object) -> None:
+        """run() delegates to build_windows_run_cmd on Windows with crlf/output files."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.docker = DockerConfig(
+            image="nanvix/toolchain:latest-minimal",
+            mounts=[
+                Mount(
+                    host_path=script.repo_root,
+                    container_path=WORKSPACE_CONTAINER_PATH,
+                )
+            ],
+            uid=1000,
+            gid=1000,
+            crlf_files=["Makefile"],
+            output_files=["output.elf"],
+        )
+        captured_cmds: list[list[str]] = []
+
+        import subprocess as sp
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured_cmds.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.run("make", "all")
+
+        self.assertTrue(captured_cmds)
+        cmd = captured_cmds[0]
+        # Should use sh -c (Windows tar-copy mode).
+        self.assertIn("sh", cmd)
+        self.assertIn("-c", cmd)
+
 
 class TestZScriptSysrootRequiredFiles(unittest.TestCase):
     """sysroot_required_files() varies by deployment mode."""
@@ -657,6 +709,38 @@ class TestZScriptDockerIntegration(unittest.TestCase):
         # -e MY_VAR=hello must appear in the docker run command
         self.assertIn("-e", cmd)
         self.assertIn("MY_VAR=hello", cmd)
+
+
+class TestZScriptCleanWindows(unittest.TestCase):
+    """ZScript.clean() Windows behavior."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    def test_clean_removes_configured_artifact(self, _mock: object) -> None:
+        """clean() removes .nanvix-configured on Windows."""
+        script = ZScript(Path(self._tmpdir.name))
+        artifact = script.repo_root / ".nanvix-configured"
+        artifact.write_text("marker")
+        script.clean()
+        self.assertFalse(artifact.exists())
+
+    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    def test_clean_noop_when_no_artifacts(self, _mock: object) -> None:
+        """clean() does not raise when no artifacts exist on Windows."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.clean()  # Should not raise.
+
+    @patch("nanvix_zutil.docker._is_windows", return_value=False)
+    def test_clean_noop_on_linux(self, _mock: object) -> None:
+        """clean() is a no-op on Linux (base class)."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.clean()  # Should not raise.
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -130,12 +130,17 @@ class TestZScriptAutoSetup(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
 
         fake_buildroot = MagicMock()
+        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.1.0"}
 
         with (
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             patch(
                 "nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot
             ) as mock_create,
+            patch(
+                "nanvix_zutil.script.resolve_release_with_fallback",
+                return_value=(fake_release, "0.1.0"),
+            ),
         ):
             script = ZScript(Path(self._tmpdir.name))
             script.setup()
@@ -195,10 +200,15 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
         fake_sysroot.tag = "v0.12.277"
 
         fake_buildroot = MagicMock()
+        fake_release: dict[str, object] = {"tag_name": "1.3.1-nanvix-0.12.277"}
 
         with (
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
+            patch(
+                "nanvix_zutil.script.resolve_release_with_fallback",
+                return_value=(fake_release, "0.12.277"),
+            ),
         ):
             script = ZScript(Path(self._tmpdir.name))
             script.setup()
@@ -421,7 +431,7 @@ class TestZScriptRun(unittest.TestCase):
         finally:
             log_mod.set_json_mode(False)
 
-    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_run_kvm_fatal_on_windows(self, _mock: object) -> None:
         """run() with kvm=True exits fatally on Windows."""
         script = ZScript(Path(self._tmpdir.name))
@@ -439,7 +449,7 @@ class TestZScriptRun(unittest.TestCase):
         finally:
             log_mod.set_json_mode(False)
 
-    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_run_uses_windows_cmd_when_configured(self, _mock: object) -> None:
         """run() delegates to build_windows_run_cmd on Windows with crlf/output files."""
         script = ZScript(Path(self._tmpdir.name))
@@ -721,7 +731,7 @@ class TestZScriptCleanWindows(unittest.TestCase):
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
 
-    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_clean_removes_configured_artifact(self, _mock: object) -> None:
         """clean() removes .nanvix-configured on Windows."""
         script = ZScript(Path(self._tmpdir.name))
@@ -730,13 +740,13 @@ class TestZScriptCleanWindows(unittest.TestCase):
         script.clean()
         self.assertFalse(artifact.exists())
 
-    @patch("nanvix_zutil.docker._is_windows", return_value=True)
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_clean_noop_when_no_artifacts(self, _mock: object) -> None:
         """clean() does not raise when no artifacts exist on Windows."""
         script = ZScript(Path(self._tmpdir.name))
         script.clean()  # Should not raise.
 
-    @patch("nanvix_zutil.docker._is_windows", return_value=False)
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
     def test_clean_noop_on_linux(self, _mock: object) -> None:
         """clean() is a no-op on Linux (base class)."""
         script = ZScript(Path(self._tmpdir.name))


### PR DESCRIPTION
## Summary

Backports two features from CPython's `.nanvix/z.py` into the upstream `nanvix_zutil` library:

1. **Cross-mode asset fallback** — When `Buildroot.install_dep()` can't find an asset for the requested deployment mode, tries alternate modes (standalone → single-process → multi-process) before fatally erroring. Also adds version-based release resolution with fallback via `resolve_release_with_fallback()`.

2. **Windows Docker host-mode** — Adds `is_windows()` helper, new `DockerConfig` fields (`crlf_files`, `output_files`, `tar_excludes`, `container_build_dir`), and `build_windows_run_cmd()` method for tar-based source copying instead of bind mounts on Windows to avoid VirtioFS/9p I/O penalties and CRLF corruption.

## Changes

### Source
- `buildroot.py` — `KNOWN_DEPLOYMENT_MODES`, `fallback_modes`/`_release` params on `install_dep()`
- `docker.py` — `is_windows()`, new `DockerConfig` fields, `build_windows_run_cmd()`
- `script.py` — `setup()` version fallback, `run()` Windows detection, `clean()` Windows path
- `__init__.py` — Re-exports for new public symbols

### Tests
- `test_buildroot.py` — `TestKnownDeploymentModes`, `TestInstallDepFallbackModes`
- `test_docker.py` — `TestIsWindows`, `TestDockerConfigWindowsFields`, `TestDockerConfigBuildWindowsRunCmd`
- `test_script.py` — Windows run/clean tests, fixed setup test mocks

## Validation
- ✅ `uv run tasks.py lint` (black, yamllint)
- ✅ `uv run tasks.py typecheck` (basedpyright strict — 0 errors)
- ✅ `uv run tasks.py test` (493 passed, 2 skipped)

Closes #69