### PR TITLE
Isolate parallel combo workspaces

### DIFF
--- a/src/nanvix_zutil/matrix.py
+++ b/src/nanvix_zutil/matrix.py
@@ -9,6 +9,7 @@ import dataclasses
 import itertools
 import json
 import os
+import shutil
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -43,6 +44,9 @@ _HOOK_CHAIN: dict[str, tuple[str, ...]] = {
     "distclean": ("distclean",),
 }
 """Prerequisite hook chains for each lifecycle subcommand."""
+
+_BUILDS_DIR: str = "_builds"
+"""Subdirectory under ``.nanvix/`` for per-combo workspace copies."""
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -136,6 +140,59 @@ def filter_matrix(
 # Execution engine
 # ---------------------------------------------------------------------------
 
+
+def _copy_workspace(src: Path, dst: Path) -> None:
+    """Create a lightweight copy of the workspace for parallel isolation.
+
+    Hardlinks source-tree files (fast, near-zero disk) but *copies* files
+    under ``.nanvix/`` so that mutable state (``env.json``, etc.) is
+    write-isolated between combos.  If hardlinks are not supported (e.g.
+    cross-device mount, Windows) the per-file fallback transparently uses
+    ``shutil.copy2`` instead.
+
+    Excludes ``.nanvix/sysroot``, ``.nanvix/buildroot``,
+    ``.nanvix/_builds``, and ``.nanvix/venv`` from the copy — these are
+    large directories that are either recreated by ``setup()`` or are our
+    own build dirs / host-specific state.
+
+    Args:
+        src: Source workspace root.
+        dst: Destination directory (must not exist).
+    """
+    _nanvix = Path(".nanvix")
+    _exclude: set[Path] = {
+        _nanvix / "sysroot",
+        _nanvix / "buildroot",
+        _nanvix / _BUILDS_DIR,
+        _nanvix / "venv",
+    }
+
+    def _ignore(directory: str, contents: list[str]) -> set[str]:
+        rel = Path(directory).relative_to(src)
+        return {name for name in contents if (rel / name) in _exclude}
+
+    def _link_or_copy(src_file: str, dst_file: str) -> None:
+        """Hardlink source-tree files; copy mutable ``.nanvix/`` state."""
+        try:
+            rel = Path(src_file).relative_to(src)
+        except ValueError:
+            shutil.copy2(src_file, dst_file)
+            return
+        if rel.parts[:1] == (".nanvix",):
+            # Mutable state — always copy so combos are write-isolated.
+            shutil.copy2(src_file, dst_file)
+        else:
+            try:
+                os.link(src_file, dst_file)
+            except OSError:
+                # Hardlinks unsupported (cross-device, Windows, etc.).
+                shutil.copy2(src_file, dst_file)
+
+    shutil.copytree(
+        src, dst, ignore=_ignore, copy_function=_link_or_copy, dirs_exist_ok=False
+    )
+
+
 #: Lock used to guard the env-set → ZScript-instantiate → env-restore sequence
 #: in :func:`run_all_builds` workers so that concurrent threads do not clobber
 #: each other's ``os.environ`` values.
@@ -180,7 +237,17 @@ def run_all_builds(
         env_keys = list(_DIMENSION_ENV_MAP.values())
         saved: dict[str, str | None] = {}
 
+        # Build a deterministic slug for the per-combo workspace copy.
+        combo_slug = f"{combo.platform}-{combo.mode}-{combo.memory}"
+        builds_dir = repo_root / ".nanvix" / _BUILDS_DIR
+        builds_dir.mkdir(parents=True, exist_ok=True)
+        combo_workspace = builds_dir / combo_slug
+
         try:
+            # Create an isolated workspace copy so parallel Docker
+            # containers do not share /mnt/workspace.
+            _copy_workspace(repo_root, combo_workspace)
+
             # --- Lock-guarded: set env → instantiate → restore env ----------
             with _env_lock:
                 try:
@@ -194,7 +261,7 @@ def run_all_builds(
 
                     # Instantiation reads env vars via Config.__init__; the
                     # captured Config object retains its values after restore.
-                    instance = script_cls(repo_root)
+                    instance = script_cls(combo_workspace)
                 finally:
                     # Always restore env vars so other threads are not affected,
                     # even if instantiation fails.
@@ -258,6 +325,10 @@ def run_all_builds(
                 duration_seconds=elapsed,
                 error=str(exc),
             )
+        finally:
+            # Clean up the per-combo workspace copy.
+            if combo_workspace.exists():
+                shutil.rmtree(combo_workspace, ignore_errors=True)
 
         return BuildResult(
             combo=combo,

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -49,9 +49,9 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
-    is_windows,
     docker_available,
     image_exists,
+    is_windows,
 )
 from nanvix_zutil.exitcodes import (
     EXIT_BUILD_FAILURE,
@@ -387,6 +387,7 @@ class ZScript:
             "env.json",
             "venv",
             "__pycache__",
+            "_builds",
         ):
             path = self.nanvix_dir / artifact
             if not path.exists() and not path.is_symlink():

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -346,6 +346,109 @@ class TestRunAllBuilds(unittest.TestCase):
         os.environ.pop("NANVIX_DEPLOYMENT_MODE", None)
         os.environ.pop("NANVIX_MEMORY_SIZE", None)
 
+    def test_parallel_combos_have_isolated_workspaces(self) -> None:
+        """Each combo gets its own workspace copy, not the shared repo root."""
+        from unittest.mock import patch
+
+        from nanvix_zutil.matrix import run_all_builds
+        from nanvix_zutil.script import ZScript
+
+        instantiated_roots: list[Path] = []
+        original_init = ZScript.__init__
+
+        def tracking_init(
+            self_inner: ZScript, repo_root: Path, *a: object, **kw: object
+        ) -> None:
+            instantiated_roots.append(repo_root)
+            original_init(self_inner, repo_root)
+
+        combos = [
+            BuildCombo(platform="microvm", mode="standalone", memory="256mb"),
+            BuildCombo(platform="microvm", mode="multi-process", memory="256mb"),
+        ]
+
+        with patch.object(ZScript, "__init__", tracking_init):
+            run_all_builds(
+                script_cls=self._stub_cls,
+                combos=combos,
+                hook="clean",
+                targets=[],
+                docker_image=None,
+                repo_root=self._repo_root,
+            )
+
+        # Each combo should have been instantiated with a DIFFERENT root.
+        self.assertEqual(len(instantiated_roots), 2)
+        self.assertNotEqual(instantiated_roots[0], instantiated_roots[1])
+        # Neither should be the original repo_root.
+        for root in instantiated_roots:
+            self.assertNotEqual(root, self._repo_root)
+
+    def test_workspace_cleanup_on_success(self) -> None:
+        """Per-combo workspaces are cleaned up after successful build."""
+        from nanvix_zutil.matrix import run_all_builds
+
+        combos = [
+            BuildCombo(platform="microvm", mode="standalone", memory="256mb"),
+            BuildCombo(platform="microvm", mode="multi-process", memory="256mb"),
+        ]
+
+        results = run_all_builds(
+            script_cls=self._stub_cls,
+            combos=combos,
+            hook="clean",
+            targets=[],
+            docker_image=None,
+            repo_root=self._repo_root,
+        )
+
+        # All combos should succeed.
+        for result in results.values():
+            self.assertTrue(result.success)
+
+        # After run_all_builds completes, _builds/ should be empty or gone.
+        builds_dir = self._repo_root / ".nanvix" / "_builds"
+        self.assertFalse(
+            builds_dir.exists() and any(builds_dir.iterdir()),
+            "Per-combo workspaces should be cleaned up after success",
+        )
+
+    def test_workspace_cleanup_on_failure(self) -> None:
+        """Per-combo workspaces are cleaned up even when a combo fails."""
+        from nanvix_zutil.matrix import run_all_builds
+        from nanvix_zutil.script import ZScript
+
+        class _Failing(ZScript):
+            def setup(self) -> None:
+                pass
+
+            def build(self) -> None:
+                raise SystemExit(5)
+
+        combos = [
+            BuildCombo(platform="microvm", mode="standalone", memory="256mb"),
+        ]
+
+        results = run_all_builds(
+            script_cls=_Failing,
+            combos=combos,
+            hook="build",
+            targets=[],
+            docker_image=None,
+            repo_root=self._repo_root,
+        )
+
+        # The combo should fail.
+        result = results[combos[0]]
+        self.assertFalse(result.success)
+
+        # But the workspace copy must still be cleaned up.
+        builds_dir = self._repo_root / ".nanvix" / "_builds"
+        self.assertFalse(
+            builds_dir.exists() and any(builds_dir.iterdir()),
+            "Per-combo workspaces should be cleaned up even on failure",
+        )
+
 
 class TestUnsupportedAllBuilds(unittest.TestCase):
     """Tests for the --all-builds hook allowlist guard in ZScript.main()."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -304,6 +304,13 @@ class TestZScriptDistclean(unittest.TestCase):
         self._make_script().distclean()
         self.assertFalse(cache_dir.exists())
 
+    def test_distclean_removes_builds(self) -> None:
+        builds_dir = self._nanvix() / "_builds"
+        builds_dir.mkdir()
+        (builds_dir / "microvm-standalone-256mb").mkdir()
+        self._make_script().distclean()
+        self.assertFalse(builds_dir.exists())
+
     def test_distclean_preserves_manifest(self) -> None:
         manifest = self._nanvix() / "nanvix.toml"
         self.assertTrue(manifest.exists())


### PR DESCRIPTION
## Summary

Fixes #66 — parallel `--all-builds` combos clobbered each other because every
Docker container mounted the **same host workspace** at `/mnt/workspace`.

Each combo now gets its own lightweight workspace copy under
`.nanvix/_builds/<combo-slug>`, so `./configure` and `make` outputs are
fully isolated.

## Changes

- **`matrix.py`** — Add `_copy_workspace()` helper (hardlink copy via
  `shutil.copytree(copy_function=os.link)` with regular-copy fallback),
  `_BUILDS_DIR` constant, per-combo workspace creation in `_run_combo()`,
  and cleanup in a `finally` block.
- **`script.py`** — Add `_builds` to `distclean()` artifact list so stale
  workspace copies from crashed runs are cleaned up. Updated docstring.
- **`test_matrix.py`** — 3 new tests: workspace isolation, cleanup on
  success, cleanup on failure.
- **`test_script.py`** — 1 new test: `distclean()` removes `_builds/`.

## How it works

```
_run_combo() for combo (microvm, standalone, 128mb):
  1. combo_workspace = .nanvix/_builds/128mb-microvm-standalone
  2. shutil.copytree(repo_root, combo_workspace, copy_function=os.link)
  3. instance = script_cls(combo_workspace)   # NOT repo_root
  4. docker_config() mounts combo_workspace → /mnt/workspace
  5. Run hook chain
  6. finally: shutil.rmtree(combo_workspace)
```

## Verification

- `uv run tasks.py lint` ✅
- `uv run tasks.py typecheck` ✅ (0 errors, 0 warnings)
- `uv run tasks.py test` ✅ (468 passed, 2 skipped)