### PR TITLE
Add `matrix` CLI subcommand

### DIFF
--- a/src/nanvix_zutil/__main__.py
+++ b/src/nanvix_zutil/__main__.py
@@ -34,7 +34,7 @@ _CONSUMER_COMMANDS: frozenset[str] = frozenset(
 )
 
 # Subcommands handled directly (standalone).
-_STANDALONE_COMMANDS: frozenset[str] = frozenset({"info", "resolve"})
+_STANDALONE_COMMANDS: frozenset[str] = frozenset({"info", "resolve", "matrix"})
 
 
 def discover_script_class(z_py: Path) -> type[ZScript]:
@@ -132,6 +132,13 @@ def main() -> None:
 
         sys.argv = ["nanvix-zutil resolve", *args[args.index("resolve") + 1 :]]
         resolve_main()
+        return
+
+    if subcmd == "matrix":
+        from nanvix_zutil.matrix_cmd import main as matrix_main
+
+        sys.argv = ["nanvix-zutil matrix", *args[args.index("matrix") + 1 :]]
+        matrix_main()
         return
 
     # --- Consumer commands ---

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -56,21 +56,6 @@ class BuildMatrix:
 
 
 @dataclass
-class BuildMatrix:
-    """Parsed contents of the ``[builds]`` section.
-
-    Attributes:
-        dimensions: Mapping of dimension name to list of values
-            (e.g. ``{"platforms": ["hyperlight", "microvm"]}``.
-        exclude: List of dictionaries describing combinations to exclude
-            from the matrix.
-    """
-
-    dimensions: dict[str, list[str]] = field(default_factory=dict)
-    exclude: list[dict[str, str]] = field(default_factory=list)
-
-
-@dataclass
 class Manifest:
     """Parsed contents of a ``nanvix.toml`` manifest file.
 
@@ -81,7 +66,6 @@ class Manifest:
         builds: Build matrix from the required ``[builds]`` section.
         dependencies: Build-time dependencies as :class:`Dependency` objects.
         system_dependencies: Runtime dependencies as :class:`Dependency` objects.
-        builds: Build matrix configuration from the ``[builds]`` section.
     """
 
     name: str
@@ -90,7 +74,6 @@ class Manifest:
     builds: BuildMatrix
     dependencies: list[Dependency] = field(default_factory=list)
     system_dependencies: list[Dependency] = field(default_factory=list)
-    builds: BuildMatrix = field(default_factory=BuildMatrix)
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +246,12 @@ def parse_builds_section(
 ) -> BuildMatrix:
     """Parse a ``[builds]`` table into a :class:`BuildMatrix`.
 
+    Validates that ``[builds.matrix]`` contains exactly the required
+    dimensions (``platforms``, ``modes``, ``memory``), each as a
+    non-empty list of strings.  Exclude entries use singular field
+    names (``platform``, ``mode``, ``memory``) and are validated
+    against the known set — unknown keys are rejected.
+
     Args:
         raw: The raw TOML table for the ``[builds]`` section.
         path: Manifest file path (for error messages).
@@ -401,68 +390,6 @@ def _parse_dependencies(
     return deps
 
 
-def _parse_builds_section(
-    raw: dict[str, object],
-    path: Path,
-) -> BuildMatrix:
-    """Parse the ``[builds]`` section of a manifest.
-
-    Expects an optional ``[builds.matrix]`` table with string-list
-    dimensions (``platforms``, ``modes``, ``memory``) and an optional
-    ``[[builds.exclude]]`` array of tables.
-
-    Args:
-        raw: The raw TOML table for the ``[builds]`` section.
-        path: Manifest file path (for error messages).
-
-    Returns:
-        A :class:`BuildMatrix` instance.
-    """
-    matrix_raw: object = raw.get("matrix", {})
-    if not isinstance(matrix_raw, dict):
-        log.fatal(
-            f"{path}: [builds.matrix] must be a TOML table",
-            code=EXIT_INVALID_ARGS,
-        )
-
-    dimensions: dict[str, list[str]] = {}
-    for key, value in cast("dict[str, object]", matrix_raw).items():
-        if not isinstance(value, list) or not all(
-            isinstance(item, str) for item in cast("list[object]", value)
-        ):
-            log.fatal(
-                f"{path}: [builds.matrix].{key} must be an array of strings",
-                code=EXIT_INVALID_ARGS,
-            )
-        dimensions[key] = cast("list[str]", value)
-
-    exclude_raw: object = raw.get("exclude", [])
-    if not isinstance(exclude_raw, list):
-        log.fatal(
-            f"{path}: [[builds.exclude]] must be an array of tables",
-            code=EXIT_INVALID_ARGS,
-        )
-
-    exclude: list[dict[str, str]] = []
-    for entry in cast("list[object]", exclude_raw):
-        if not isinstance(entry, dict):
-            log.fatal(
-                f"{path}: each [[builds.exclude]] entry must be a table"
-                " of string key-value pairs",
-                code=EXIT_INVALID_ARGS,
-            )
-        typed_entry = cast("dict[str, object]", entry)
-        if not all(isinstance(val, str) for val in typed_entry.values()):
-            log.fatal(
-                f"{path}: each [[builds.exclude]] entry must be a table"
-                " of string key-value pairs",
-                code=EXIT_INVALID_ARGS,
-            )
-        exclude.append(cast("dict[str, str]", entry))
-
-    return BuildMatrix(dimensions=dimensions, exclude=exclude)
-
-
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -599,15 +526,6 @@ def load_manifest(path: Path) -> Manifest:
                     value=f"{dep.ref.value}-nanvix-{version_suffix}",
                 )
 
-    # --- [builds] (optional) ---
-    builds_raw: object = data.get("builds", {})
-    if not isinstance(builds_raw, dict):
-        log.fatal(
-            f"{path}: [builds] must be a TOML table",
-            code=EXIT_INVALID_ARGS,
-        )
-    builds = _parse_builds_section(cast("dict[str, object]", builds_raw), path)
-
     return Manifest(
         name=pkg_name,
         version=pkg_version,
@@ -615,5 +533,4 @@ def load_manifest(path: Path) -> Manifest:
         builds=builds,
         dependencies=dependencies,
         system_dependencies=system_dependencies,
-        builds=builds,
     )

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -56,6 +56,21 @@ class BuildMatrix:
 
 
 @dataclass
+class BuildMatrix:
+    """Parsed contents of the ``[builds]`` section.
+
+    Attributes:
+        dimensions: Mapping of dimension name to list of values
+            (e.g. ``{"platforms": ["hyperlight", "microvm"]}``.
+        exclude: List of dictionaries describing combinations to exclude
+            from the matrix.
+    """
+
+    dimensions: dict[str, list[str]] = field(default_factory=dict)
+    exclude: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
 class Manifest:
     """Parsed contents of a ``nanvix.toml`` manifest file.
 
@@ -66,6 +81,7 @@ class Manifest:
         builds: Build matrix from the required ``[builds]`` section.
         dependencies: Build-time dependencies as :class:`Dependency` objects.
         system_dependencies: Runtime dependencies as :class:`Dependency` objects.
+        builds: Build matrix configuration from the ``[builds]`` section.
     """
 
     name: str
@@ -74,6 +90,7 @@ class Manifest:
     builds: BuildMatrix
     dependencies: list[Dependency] = field(default_factory=list)
     system_dependencies: list[Dependency] = field(default_factory=list)
+    builds: BuildMatrix = field(default_factory=BuildMatrix)
 
 
 # ---------------------------------------------------------------------------
@@ -384,6 +401,68 @@ def _parse_dependencies(
     return deps
 
 
+def _parse_builds_section(
+    raw: dict[str, object],
+    path: Path,
+) -> BuildMatrix:
+    """Parse the ``[builds]`` section of a manifest.
+
+    Expects an optional ``[builds.matrix]`` table with string-list
+    dimensions (``platforms``, ``modes``, ``memory``) and an optional
+    ``[[builds.exclude]]`` array of tables.
+
+    Args:
+        raw: The raw TOML table for the ``[builds]`` section.
+        path: Manifest file path (for error messages).
+
+    Returns:
+        A :class:`BuildMatrix` instance.
+    """
+    matrix_raw: object = raw.get("matrix", {})
+    if not isinstance(matrix_raw, dict):
+        log.fatal(
+            f"{path}: [builds.matrix] must be a TOML table",
+            code=EXIT_INVALID_ARGS,
+        )
+
+    dimensions: dict[str, list[str]] = {}
+    for key, value in cast("dict[str, object]", matrix_raw).items():
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) for item in cast("list[object]", value)
+        ):
+            log.fatal(
+                f"{path}: [builds.matrix].{key} must be an array of strings",
+                code=EXIT_INVALID_ARGS,
+            )
+        dimensions[key] = cast("list[str]", value)
+
+    exclude_raw: object = raw.get("exclude", [])
+    if not isinstance(exclude_raw, list):
+        log.fatal(
+            f"{path}: [[builds.exclude]] must be an array of tables",
+            code=EXIT_INVALID_ARGS,
+        )
+
+    exclude: list[dict[str, str]] = []
+    for entry in cast("list[object]", exclude_raw):
+        if not isinstance(entry, dict):
+            log.fatal(
+                f"{path}: each [[builds.exclude]] entry must be a table"
+                " of string key-value pairs",
+                code=EXIT_INVALID_ARGS,
+            )
+        typed_entry = cast("dict[str, object]", entry)
+        if not all(isinstance(val, str) for val in typed_entry.values()):
+            log.fatal(
+                f"{path}: each [[builds.exclude]] entry must be a table"
+                " of string key-value pairs",
+                code=EXIT_INVALID_ARGS,
+            )
+        exclude.append(cast("dict[str, str]", entry))
+
+    return BuildMatrix(dimensions=dimensions, exclude=exclude)
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -520,6 +599,15 @@ def load_manifest(path: Path) -> Manifest:
                     value=f"{dep.ref.value}-nanvix-{version_suffix}",
                 )
 
+    # --- [builds] (optional) ---
+    builds_raw: object = data.get("builds", {})
+    if not isinstance(builds_raw, dict):
+        log.fatal(
+            f"{path}: [builds] must be a TOML table",
+            code=EXIT_INVALID_ARGS,
+        )
+    builds = _parse_builds_section(cast("dict[str, object]", builds_raw), path)
+
     return Manifest(
         name=pkg_name,
         version=pkg_version,
@@ -527,4 +615,5 @@ def load_manifest(path: Path) -> Manifest:
         builds=builds,
         dependencies=dependencies,
         system_dependencies=system_dependencies,
+        builds=builds,
     )

--- a/src/nanvix_zutil/matrix_cmd.py
+++ b/src/nanvix_zutil/matrix_cmd.py
@@ -1,0 +1,79 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""``nanvix-zutil matrix`` — emit the build matrix as CI-ready JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from nanvix_zutil import log
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP, EXIT_SUCCESS
+from nanvix_zutil.manifest import load_manifest
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the argument parser for ``nanvix-zutil matrix``.
+
+    Returns:
+        Configured :class:`argparse.ArgumentParser`.
+    """
+    parser = argparse.ArgumentParser(
+        prog="nanvix-zutil matrix",
+        description=(
+            "Read the [builds] section from .nanvix/nanvix.toml and emit "
+            "the build matrix as a JSON object suitable for GitHub Actions."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        default=".nanvix/nanvix.toml",
+        metavar="PATH",
+        help="Path to the nanvix.toml manifest (default: .nanvix/nanvix.toml)",
+    )
+    return parser
+
+
+def _matrix_to_json(manifest_path: Path) -> dict[str, object]:
+    """Load the manifest and convert the build matrix to a JSON-ready dict.
+
+    Args:
+        manifest_path: Path to the ``nanvix.toml`` file.
+
+    Returns:
+        Dictionary with ``platforms``, ``modes``, ``memory``, and
+        optionally ``exclude`` keys.
+    """
+    manifest = load_manifest(manifest_path)
+    builds = manifest.builds
+
+    result: dict[str, object] = {}
+    result["platforms"] = builds.dimensions.get("platforms", [])
+    result["modes"] = builds.dimensions.get("modes", [])
+    result["memory"] = builds.dimensions.get("memory", [])
+    if builds.exclude:
+        result["exclude"] = builds.exclude
+
+    return result
+
+
+def main() -> None:
+    """Entry point for ``nanvix-zutil matrix``."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.exists():
+        log.fatal(
+            f"Manifest not found: {manifest_path}",
+            code=EXIT_MISSING_DEP,
+            hint="Run from a Nanvix consumer repo root, or pass --manifest.",
+        )
+
+    result = _matrix_to_json(manifest_path)
+    print(json.dumps(result))
+
+    sys.exit(EXIT_SUCCESS)

--- a/src/nanvix_zutil/matrix_cmd.py
+++ b/src/nanvix_zutil/matrix_cmd.py
@@ -44,16 +44,13 @@ def _matrix_to_json(manifest_path: Path) -> dict[str, object]:
         manifest_path: Path to the ``nanvix.toml`` file.
 
     Returns:
-        Dictionary with ``platforms``, ``modes``, ``memory``, and
-        optionally ``exclude`` keys.
+        Dictionary with all dimension keys from ``[builds.matrix]`` and
+        optionally an ``exclude`` key.
     """
     manifest = load_manifest(manifest_path)
     builds = manifest.builds
 
-    result: dict[str, object] = {}
-    result["platforms"] = builds.dimensions.get("platforms", [])
-    result["modes"] = builds.dimensions.get("modes", [])
-    result["memory"] = builds.dimensions.get("memory", [])
+    result: dict[str, object] = dict(builds.dimensions)
     if builds.exclude:
         result["exclude"] = builds.exclude
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,6 +45,7 @@ class TestHelpFlag(unittest.TestCase):
         self.assertIn("nanvix-zutil", output)
         self.assertIn("info", output)
         self.assertIn("resolve", output)
+        self.assertIn("matrix", output)
 
     def test_no_subcommand_prints_help(self) -> None:
         buf = StringIO()

--- a/tests/test_matrix_cmd.py
+++ b/tests/test_matrix_cmd.py
@@ -1,0 +1,249 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Tests for nanvix_zutil.matrix_cmd."""
+
+import json
+import sys
+import tempfile
+import textwrap
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from nanvix_zutil.buildroot import Ref, RefKind
+from nanvix_zutil.manifest import BuildMatrix, Manifest
+from nanvix_zutil.matrix_cmd import main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest() -> Manifest:
+    """Return a minimal Manifest with a known BuildMatrix."""
+    return Manifest(
+        name="test",
+        version="0.1.0",
+        sysroot_ref=Ref(kind=RefKind.TAG, value="0.12.266"),
+        builds=BuildMatrix(
+            dimensions={
+                "platforms": ["hyperlight", "microvm"],
+                "modes": ["standalone", "single-process", "multi-process"],
+                "memory": ["128mb"],
+            },
+            exclude=[{"platform": "hyperlight", "mode": "standalone"}],
+        ),
+    )
+
+
+def _make_manifest_no_excludes() -> Manifest:
+    """Return a Manifest with an empty exclude list."""
+    return Manifest(
+        name="test",
+        version="0.1.0",
+        sysroot_ref=Ref(kind=RefKind.TAG, value="0.12.266"),
+        builds=BuildMatrix(
+            dimensions={
+                "platforms": ["hyperlight"],
+                "modes": ["standalone"],
+                "memory": ["128mb"],
+            },
+            exclude=[],
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatrixJsonOutput(unittest.TestCase):
+    """``nanvix-zutil matrix`` emits correct JSON to stdout."""
+
+    @patch("nanvix_zutil.matrix_cmd.load_manifest")
+    def test_json_output_structure(self, mock_load: MagicMock) -> None:
+        """JSON output contains expected keys and values."""
+        mock_load.return_value = _make_manifest()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "nanvix.toml"
+            manifest.write_text(
+                '[package]\nname = "test"\nversion = "0.1.0"\n'
+                'nanvix-version = "0.12.266"\n'
+            )
+
+            buf = StringIO()
+            sys.stdout = buf
+            try:
+                with (
+                    patch(
+                        "sys.argv",
+                        ["nanvix-zutil matrix", f"--manifest={manifest}"],
+                    ),
+                    self.assertRaises(SystemExit) as ctx,
+                ):
+                    main()
+            finally:
+                sys.stdout = sys.__stdout__
+
+            self.assertEqual(ctx.exception.code, 0)
+            obj = json.loads(buf.getvalue().strip())
+            self.assertEqual(obj["platforms"], ["hyperlight", "microvm"])
+            self.assertEqual(
+                obj["modes"],
+                ["standalone", "single-process", "multi-process"],
+            )
+            self.assertEqual(obj["memory"], ["128mb"])
+            self.assertEqual(
+                obj["exclude"],
+                [{"platform": "hyperlight", "mode": "standalone"}],
+            )
+
+    @patch("nanvix_zutil.matrix_cmd.load_manifest")
+    def test_no_excludes_omits_key(self, mock_load: MagicMock) -> None:
+        """When exclude list is empty, 'exclude' key is absent."""
+        mock_load.return_value = _make_manifest_no_excludes()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "nanvix.toml"
+            manifest.write_text(
+                '[package]\nname = "test"\nversion = "0.1.0"\n'
+                'nanvix-version = "0.12.266"\n'
+            )
+
+            buf = StringIO()
+            sys.stdout = buf
+            try:
+                with (
+                    patch(
+                        "sys.argv",
+                        ["nanvix-zutil matrix", f"--manifest={manifest}"],
+                    ),
+                    self.assertRaises(SystemExit) as ctx,
+                ):
+                    main()
+            finally:
+                sys.stdout = sys.__stdout__
+
+            self.assertEqual(ctx.exception.code, 0)
+            obj = json.loads(buf.getvalue().strip())
+            self.assertNotIn("exclude", obj)
+
+    @patch("nanvix_zutil.matrix_cmd.load_manifest")
+    def test_output_is_valid_json(self, mock_load: MagicMock) -> None:
+        """stdout is parseable by json.loads()."""
+        mock_load.return_value = _make_manifest()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "nanvix.toml"
+            manifest.write_text(
+                '[package]\nname = "test"\nversion = "0.1.0"\n'
+                'nanvix-version = "0.12.266"\n'
+            )
+
+            buf = StringIO()
+            sys.stdout = buf
+            try:
+                with (
+                    patch(
+                        "sys.argv",
+                        ["nanvix-zutil matrix", f"--manifest={manifest}"],
+                    ),
+                    self.assertRaises(SystemExit),
+                ):
+                    main()
+            finally:
+                sys.stdout = sys.__stdout__
+
+            # Should not raise
+            json.loads(buf.getvalue())
+
+
+class TestMatrixMissingManifest(unittest.TestCase):
+    """Missing manifest exits with code 3."""
+
+    def test_missing_manifest_exits_3(self) -> None:
+        with (
+            patch(
+                "sys.argv",
+                ["nanvix-zutil matrix", "--manifest=/nonexistent/nanvix.toml"],
+            ),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 3)
+
+
+class TestMatrixWithRealToml(unittest.TestCase):
+    """``nanvix-zutil matrix`` reads a real TOML manifest."""
+
+    def test_reads_real_toml(self) -> None:
+        """Write a nanvix.toml with [builds] and verify JSON output."""
+        toml_content = textwrap.dedent("""\
+            [package]
+            name = "test-project"
+            version = "1.0.0"
+            nanvix-version = "0.12.266"
+
+            [builds.matrix]
+            platforms = ["hyperlight", "microvm"]
+            modes = ["multi-process"]
+            memory = ["256mb"]
+
+            [[builds.exclude]]
+            platform = "hyperlight"
+            mode = "multi-process"
+        """)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "nanvix.toml"
+            manifest.write_text(toml_content)
+
+            buf = StringIO()
+            sys.stdout = buf
+            try:
+                with (
+                    patch(
+                        "sys.argv",
+                        ["nanvix-zutil matrix", f"--manifest={manifest}"],
+                    ),
+                    self.assertRaises(SystemExit) as ctx,
+                ):
+                    main()
+            finally:
+                sys.stdout = sys.__stdout__
+
+            self.assertEqual(ctx.exception.code, 0)
+            obj = json.loads(buf.getvalue().strip())
+            self.assertEqual(obj["platforms"], ["hyperlight", "microvm"])
+            self.assertEqual(obj["modes"], ["multi-process"])
+            self.assertEqual(obj["memory"], ["256mb"])
+            self.assertEqual(
+                obj["exclude"],
+                [{"platform": "hyperlight", "mode": "multi-process"}],
+            )
+
+
+class TestMatrixDispatchFromMain(unittest.TestCase):
+    """``nanvix-zutil matrix`` dispatches to matrix_cmd.main()."""
+
+    @patch("nanvix_zutil.matrix_cmd.main")
+    def test_matrix_dispatches(self, mock_matrix_main: MagicMock) -> None:
+        from nanvix_zutil.__main__ import main as cli_main
+
+        original_argv = sys.argv[:]
+        try:
+            with patch("sys.argv", ["nanvix-zutil", "matrix"]):
+                cli_main()
+        except SystemExit:
+            pass
+        finally:
+            sys.argv = original_argv
+        mock_matrix_main.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a `nanvix-zutil matrix` standalone subcommand that reads the
`[builds]` section from `nanvix.toml` and emits GitHub Actions-compatible
matrix JSON to stdout.

Closes #55

## Motivation

The Nanvix build matrix is declared in `nanvix.toml` under `[builds]`,
but CI workflows in `nanvix/workflows` duplicate this information as
hardcoded JSON string inputs (`platforms`, `process-modes`,
`memory-sizes`, `matrix-exclude`).  Every consumer repo repeats the same
arrays in their caller workflow.  This creates two problems:

1. **Matrix drift** — a developer updates `nanvix.toml` but forgets to
   update the CI YAML inputs (or vice versa), causing CI to test a
   different set of combinations than `--all-builds` runs locally.
2. **Boilerplate** — every consumer repo must copy-paste the same JSON
   arrays into their workflow `with:` block.

This PR makes `nanvix.toml [builds]` the **single source of truth** for
both local builds (`--all-builds`) and CI matrix expansion by providing a
CLI command that extracts the matrix as JSON.

## What this PR does (Part 1 of 2)

This is the `nanvix/zutils` half of a two-repo change.  It adds the CLI
tool; the workflow integration comes separately in `nanvix/workflows`.

### New files

- **`src/nanvix_zutil/matrix_cmd.py`** — standalone command module
  (`_build_parser`, `_matrix_to_json`, `main`) following the
  `resolve_cmd.py` pattern.  Always outputs JSON (no `--json` flag
  needed — the consumer is always GitHub Actions).  The `exclude` key is
  omitted when empty, matching Actions semantics.
- **`tests/test_matrix_cmd.py`** — 6 tests covering JSON output
  structure, excludes omission, valid JSON, missing manifest, real TOML
  parsing, and dispatch from `__main__`.

### Modified files

- **`src/nanvix_zutil/__main__.py`** — registered `"matrix"` in
  `_STANDALONE_COMMANDS` and added dispatch branch.
- **`src/nanvix_zutil/manifest.py`** — enhanced `parse_builds_section()`
  docstring to document exclude-key validation behavior.
- **`tests/test_main.py`** — added `assertIn("matrix", output)` to
  help-text assertion.

### Example usage

```console
$ nanvix-zutil matrix --manifest .nanvix/nanvix.toml
{"platforms": ["hyperlight", "microvm"], "modes": ["standalone", "single-process", "multi-process"], "memory": ["128mb"], "exclude": [{"platform": "hyperlight", "mode": "standalone"}]}
```

## Part 2: CI workflow integration (`nanvix/workflows`)

A follow-up PR in `nanvix/workflows` (branch `feat/matrix-from-toml`)
will update the reusable CI workflow to optionally read the matrix from
`nanvix.toml` via this command.  The design:

1. Change matrix input defaults from JSON arrays to `""` (empty string).
2. Add an `extract-matrix` job that:
   - If all inputs are provided → use them directly (backward compat).
   - Otherwise → run `nanvix-zutil matrix` and extract dimensions.
   - Map TOML field names to CI field names (`modes` → `process-modes`,
     `mode` → `process-mode`) using `jq`.
   - Allow per-dimension overrides (e.g., pass only `platforms`, let
     `modes` come from TOML).
3. Update the `build` job to consume `extract-matrix` outputs instead of
   `inputs.*` directly.

**Sequencing:** This PR must be released first so `nanvix-zutil matrix`
is available in the wheel.  Then the `nanvix/workflows` PR can reference
the new zutil version.

## Design decisions

- **Always JSON output** — unlike `resolve` and `info`, there is no
  key=value mode.  The consumer (GitHub Actions `fromJSON()`) always
  needs JSON.
- **Field-name mapping lives in the workflow, not the CLI** — the
  command outputs canonical TOML names (`modes`, `mode`).  The workflow's
  `jq` step maps `mode` → `process-mode`.  This keeps the CLI
  TOML-faithful and puts CI-specific naming in the CI layer.
- **Module named `matrix_cmd.py`** (not `matrix.py`) — `matrix.py`
  already exists and contains the build matrix expansion engine for
  `--all-builds`.  The `_cmd` suffix matches `resolve_cmd.py`.
- **`exclude` omitted when empty** — matches GitHub Actions behavior
  where an absent `exclude` key means no exclusions.
- **Forward-compatible dimension output** — uses `dict(builds.dimensions)`
  so any future dimensions added to `[builds.matrix]` are automatically
  included in the JSON output without code changes.

## Verification

- `uv run tasks.py typecheck` — 0 errors, 0 warnings, 0 notes
- `uv run tasks.py test` — 492 passed, 2 skipped
- `uv run tasks.py lint` — clean

## Commits

1. `[zutils] F: Add matrix_cmd standalone module`
2. `[zutils] F: Register matrix subcommand`
3. `[tests] F: Add matrix subcommand tests`
4. `[zutils] E: Address matrix audit findings`