### PR TITLE
Fix distclean to remove all .nanvix/ artifacts

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -371,21 +371,36 @@ class ZScript:
     def distclean(self) -> None:
         """Remove all transient ``.nanvix/`` artifacts.
 
-        Deletes the ``sysroot``, ``buildroot``, and ``cache`` directories
-        inside ``.nanvix/``.  The manifest (``nanvix.toml``), saved config
-        (``env.json``), and Python virtual environment (``venv/``) are
-        preserved.
+        Deletes the ``sysroot``, ``buildroot``, ``cache``, ``venv``, and
+        ``__pycache__`` directories and the ``env.json`` config file inside
+        ``.nanvix/``.  Only the manifest (``nanvix.toml``) and lockfile
+        (``nanvix.lock``) are preserved.
+
+        Removal is best-effort: artifacts that cannot be deleted (e.g. a
+        locked venv on Windows) are skipped with a warning so the
+        remaining artifacts are still cleaned.
         """
-        for artifact in ("sysroot", "buildroot", "cache"):
+        for artifact in (
+            "sysroot",
+            "buildroot",
+            "cache",
+            "env.json",
+            "venv",
+            "__pycache__",
+        ):
             path = self.nanvix_dir / artifact
-            if not path.exists():
+            if not path.exists() and not path.is_symlink():
                 continue
-            if path.is_symlink() or path.is_file():
-                path.unlink()
+            try:
+                if path.is_symlink() or path.is_file():
+                    path.unlink()
+                elif path.is_dir():
+                    shutil.rmtree(path)
+                else:
+                    continue
                 log.info(f"Removed {path}")
-            elif path.is_dir():
-                shutil.rmtree(path)
-                log.info(f"Removed {path}")
+            except OSError as exc:
+                log.warning(f"Could not remove {path}: {exc}")
 
     def lock(self, *, shallow: bool = False) -> None:
         """Resolve the dependency graph and write ``nanvix.lock``.

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -310,11 +310,25 @@ class TestZScriptDistclean(unittest.TestCase):
         self._make_script().distclean()
         self.assertTrue(manifest.exists())
 
-    def test_distclean_preserves_config(self) -> None:
+    def test_distclean_removes_config(self) -> None:
         config_file = self._nanvix() / "env.json"
         config_file.write_text("{}")
         self._make_script().distclean()
-        self.assertTrue(config_file.exists())
+        self.assertFalse(config_file.exists())
+
+    def test_distclean_removes_venv(self) -> None:
+        venv_dir = self._nanvix() / "venv"
+        venv_dir.mkdir()
+        (venv_dir / "pyvenv.cfg").write_text("home = /usr/bin")
+        self._make_script().distclean()
+        self.assertFalse(venv_dir.exists())
+
+    def test_distclean_removes_pycache(self) -> None:
+        pycache_dir = self._nanvix() / "__pycache__"
+        pycache_dir.mkdir()
+        (pycache_dir / "z.cpython-312.pyc").write_bytes(b"\x00")
+        self._make_script().distclean()
+        self.assertFalse(pycache_dir.exists())
 
     def test_distclean_noop_when_nothing_exists(self) -> None:
         """distclean() does not raise when artifact dirs are absent."""
@@ -338,6 +352,39 @@ class TestZScriptDistclean(unittest.TestCase):
             self.skipTest("Symlinks not supported on this platform")
         self._make_script().distclean()
         self.assertFalse(link.exists())
+
+    def test_distclean_removes_broken_symlink(self) -> None:
+        """distclean() removes a symlink even when its target is gone."""
+        target = self._nanvix() / "real_sysroot"
+        target.mkdir()
+        link = self._nanvix() / "sysroot"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlinks not supported on this platform")
+        target.rmdir()
+        self._make_script().distclean()
+        self.assertFalse(link.is_symlink())
+
+    def test_distclean_continues_on_permission_error(self) -> None:
+        """distclean() warns and skips artifacts it cannot remove."""
+        venv_dir = self._nanvix() / "venv"
+        venv_dir.mkdir()
+        cache_dir = self._nanvix() / "cache"
+        cache_dir.mkdir()
+
+        original_rmtree = __import__("shutil").rmtree
+
+        def _rmtree_fail_on_venv(path: object, *args: object, **kwargs: object) -> None:
+            if Path(str(path)).name == "venv":
+                raise PermissionError("locked by running process")
+            original_rmtree(path, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch("shutil.rmtree", side_effect=_rmtree_fail_on_venv):
+            self._make_script().distclean()
+
+        self.assertTrue(venv_dir.exists())
+        self.assertFalse(cache_dir.exists())
 
 
 class TestZScriptAvailableSubcommands(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Extend `distclean()` to also remove `env.json`, `venv/`, and `__pycache__/` from `.nanvix/`
- Update docstring to reflect only `nanvix.toml` and `nanvix.lock` are preserved
- Fix existing test (`assertTrue` → `assertFalse`) and add tests for venv and pycache cleanup

Fixes #63