### PR TITLE
Wire version fallback into setup()

### DIFF
--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -251,6 +251,8 @@ class Buildroot:
         deployment_mode: str = DEFAULT_DEPLOYMENT_MODE,
         memory_size: str = DEFAULT_MEMORY_SIZE,
         gh_token: str | None = None,
+        *,
+        _release: dict[str, object] | None = None,
     ) -> None:
         """Download a dependency release and install its libraries and headers.
 
@@ -264,6 +266,10 @@ class Buildroot:
             deployment_mode: Deployment mode string.
             memory_size: Memory size string.
             gh_token: Optional GitHub token.
+            _release: Pre-resolved release metadata dictionary.  When
+                provided, the release resolution step is skipped (avoids
+                redundant GitHub API calls when the caller has already
+                resolved the release).
         """
         asset_name = dep.artifact_pattern.format(
             name=dep.name,
@@ -280,6 +286,7 @@ class Buildroot:
             asset_name=asset_name,
             dest=cache_dir,
             gh_token=gh_token,
+            _release=_release,
         )
 
         log.info(f"Extracting {asset_name}...")

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -33,7 +33,13 @@ import sys
 from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import log
-from nanvix_zutil.buildroot import Buildroot, Dependency, suffix_dep
+from nanvix_zutil.buildroot import (
+    Buildroot,
+    Dependency,
+    extract_nanvix_version,
+    extract_nanvix_version_base,
+    suffix_dep,
+)
 from nanvix_zutil.cli import build_parser
 from nanvix_zutil.config import CFG_GH_TOKEN, CFG_SYSROOT, Config
 from nanvix_zutil.docker import (
@@ -52,6 +58,7 @@ from nanvix_zutil.exitcodes import (
     EXIT_MISSING_DEP,
     EXIT_TEST_FAILURE,
 )
+from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.matrix import (
@@ -314,12 +321,42 @@ class ZScript:
             self.buildroot = Buildroot.create(self.nanvix_dir / "buildroot")
             for dep in deps:
                 try:
+                    # Resolve release with version fallback for nanvix-suffixed
+                    # deps, then pass the pre-resolved release to install_dep()
+                    # to avoid redundant GitHub API calls.
+                    release: dict[str, object] | None = None
+                    base_version = extract_nanvix_version_base(str(dep.ref.value))
+                    if base_version is not None:
+                        release, fb_ver = resolve_release_with_fallback(
+                            repo=dep.repo,
+                            version_specifier=str(dep.ref.value),
+                            base_version=base_version,
+                            gh_token=self.config.get(CFG_GH_TOKEN),
+                        )
+                        # Log when version fallback was used.
+                        # fb_ver is None when the exact tag was found;
+                        # non-None means a fallback release was used.
+                        if fb_ver is not None:
+                            requested_ver = extract_nanvix_version(str(dep.ref.value))
+                            log.info(
+                                f"Version fallback for {dep.name}: "
+                                f"requested nanvix-{requested_ver}, "
+                                f"resolved nanvix-{fb_ver}"
+                            )
+                    else:
+                        release = resolve_release(
+                            repo=dep.repo,
+                            version_specifier=dep.ref.value,
+                            gh_token=self.config.get(CFG_GH_TOKEN),
+                        )
+
                     self.buildroot.install_dep(
                         dep=dep,
                         machine=self.config.machine,
                         deployment_mode=self.config.deployment_mode,
                         memory_size=self.config.memory_size,
                         gh_token=self.config.get(CFG_GH_TOKEN),
+                        _release=release,
                     )
                 except SystemExit:
                     log.note(

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -276,12 +276,18 @@ class TestBuildrootInstallDep(unittest.TestCase):
             asset_name: str,
             dest: Path,
             gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
         ) -> Path:
             captured.append(asset_name)
             return archive_path
 
         with patch(
-            "nanvix_zutil.github.download_release_asset", side_effect=fake_download
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
         ):
             br.install_dep(
                 dep,
@@ -406,6 +412,69 @@ class TestParseSemverTuple(unittest.TestCase):
 
     def test_ordering(self) -> None:
         self.assertLess(parse_semver_tuple("0.12.291"), parse_semver_tuple("0.12.337"))
+
+
+class TestInstallDepPreResolvedRelease(unittest.TestCase):
+    """Buildroot.install_dep with _release pre-resolved."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def _setup_buildroot(self) -> Buildroot:
+        dest = Path(self._tmpdir.name) / "br"
+        return Buildroot.create(dest=dest)
+
+    def _make_archive(self) -> bytes:
+        return _make_tar_bz2(
+            {
+                "sysroot/lib/libz.a": b"lib-content",
+                "sysroot/include/zlib.h": b"header-content",
+            }
+        )
+
+    def test_pre_resolved_release_passed_through(self) -> None:
+        """When _release is provided, it's forwarded to download_release_asset."""
+        br = self._setup_buildroot()
+        archive = self._make_archive()
+        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path.write_bytes(archive)
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+        )
+
+        fake_release: dict[str, object] = {"id": 42, "tag_name": "v1.0.0"}
+        captured_releases: list[dict[str, object] | None] = []
+
+        def fake_download(
+            repo: str,
+            version_specifier: str | int,
+            asset_name: str,
+            dest: Path,
+            gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
+        ) -> Path:
+            captured_releases.append(_release)
+            return archive_path
+
+        with patch(
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
+        ):
+            br.install_dep(dep, _release=fake_release)
+
+        self.assertEqual(captured_releases[0], fake_release)
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -130,12 +130,17 @@ class TestZScriptAutoSetup(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
 
         fake_buildroot = MagicMock()
+        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.1.0"}
 
         with (
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             patch(
                 "nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot
             ) as mock_create,
+            patch(
+                "nanvix_zutil.script.resolve_release_with_fallback",
+                return_value=(fake_release, "0.1.0"),
+            ),
         ):
             script = ZScript(Path(self._tmpdir.name))
             script.setup()
@@ -195,10 +200,15 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
         fake_sysroot.tag = "v0.12.277"
 
         fake_buildroot = MagicMock()
+        fake_release: dict[str, object] = {"tag_name": "1.3.1-nanvix-0.12.277"}
 
         with (
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
+            patch(
+                "nanvix_zutil.script.resolve_release_with_fallback",
+                return_value=(fake_release, "0.12.277"),
+            ),
         ):
             script = ZScript(Path(self._tmpdir.name))
             script.setup()


### PR DESCRIPTION
## Summary

- Wires `resolve_release_with_fallback()` into `ZScript.setup()` so that nanvix-suffixed dependencies automatically fall back to the best compatible release when the exact tag doesn't exist
- Passes pre-resolved release metadata to `install_dep()` via new `_release` parameter to avoid redundant GitHub API calls
- Fixes false-positive fallback log message when the exact tag was found (`fb_ver=None` was printed as `"resolved nanvix-None"`)

Backported from `.nanvix/z.py` in nanvix/cpython.

Closes #69

## Files Changed

- `src/nanvix_zutil/buildroot.py` — added `_release` kwarg to `install_dep()`
- `src/nanvix_zutil/script.py` — version fallback wiring in `setup()`, fallback log
- `tests/test_buildroot.py` — fixed `fake_download` signature, added `TestInstallDepPreResolvedRelease`
- `tests/test_script.py` — added `resolve_release_with_fallback` mocks to setup tests

## Validation

- 465 tests pass, 0 type errors (basedpyright strict), 0 lint errors (black)