### PR TITLE
Add Windows Docker host-mode support

### DIFF
--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -42,6 +42,7 @@ Public re-exports:
 - :func:`~nanvix_zutil.matrix.expand_matrix` — expand a build matrix to all combos
 - :func:`~nanvix_zutil.matrix.filter_matrix` — filter combos by mode
 - :func:`~nanvix_zutil.matrix.run_all_builds` — run a hook across all combos in parallel
+- :func:`~nanvix_zutil.docker.is_windows` — Windows platform detection helper
 """
 
 from nanvix_zutil.buildroot import (
@@ -71,6 +72,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
+    is_windows,
     docker_available,
     image_exists,
 )
@@ -145,6 +147,7 @@ __all__ = [
     "WORKSPACE_CONTAINER_PATH",
     "Sysroot",
     "ZScript",
+    "is_windows",
     "docker_available",
     "extract_nanvix_version",
     "extract_nanvix_version_base",

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -19,6 +19,7 @@ Typical usage (via :class:`~nanvix_zutil.ZScript` — not used directly)::
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -60,6 +61,15 @@ def _get_uid() -> int:
 def _get_gid() -> int:
     """Return the current group ID, or ``0`` on platforms without ``os.getgid``."""
     return os.getgid() if hasattr(os, "getgid") else 0
+
+
+def is_windows() -> bool:
+    """Return ``True`` when running on Windows.
+
+    Extracted to a named function so tests can mock it without
+    patching ``sys.platform`` globally.
+    """
+    return sys.platform == "win32"
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +135,26 @@ class DockerConfig:
 
     extra_env: dict[str, str] = field(default_factory=dict)
     """Additional ``-e KEY=VALUE`` pairs forwarded to the container."""
+
+    crlf_files: list[str] = field(default_factory=list)
+    """Files requiring CRLF→LF normalization inside the container."""
+
+    output_files: list[str] = field(default_factory=list)
+    """Build output files to copy back from the container to the host."""
+
+    tar_excludes: list[str] = field(
+        default_factory=lambda: [
+            ".git",
+            ".nanvix/venv",
+            ".nanvix/cache",
+            ".nanvix/sysroot",
+            ".nanvix/buildroot",
+        ]
+    )
+    """Directories/files to exclude from tar-based source copy."""
+
+    container_build_dir: str = "/tmp/build"
+    """Working directory inside the container for Windows tar-copy mode."""
 
     # ------------------------------------------------------------------
     # Path translation
@@ -251,6 +281,89 @@ class DockerConfig:
 
         docker_cmd.append(self.image)
         docker_cmd.extend(cmd)
+        return docker_cmd
+
+    def build_windows_run_cmd(self, *cmd: str) -> list[str]:
+        """Build a ``docker run`` command using tar-based source copying.
+
+        Instead of building directly from the mounted workspace (which suffers
+        severe I/O penalties on Windows Docker Desktop via VirtioFS/9p), this
+        method:
+
+        1. Uses the configured container mounts as provided, typically including
+           the host workspace at ``/mnt/workspace``.
+        2. Copies sources via ``tar`` from the mounted workspace into a
+           container-local build dir.
+        3. Normalizes CRLF line endings in configured files.
+        4. Runs the inner command from the container-local build dir.
+        5. Copies configured output files back to the mounted workspace.
+
+        Args:
+            *cmd: Inner command and arguments to wrap.
+
+        Returns:
+            Full ``docker run …`` argument list ready for
+            :func:`subprocess.run`.
+        """
+        ws_mount = shlex.quote(str(WORKSPACE_CONTAINER_PATH))
+        build_dir = shlex.quote(self.container_build_dir)
+
+        # Build tar exclude args.
+        excludes = " ".join(f"--exclude={shlex.quote(e)}" for e in self.tar_excludes)
+
+        # CRLF normalization script.
+        crlf_script = ""
+        if self.crlf_files:
+            crlf_cmds: list[str] = []
+            for f in self.crlf_files:
+                qf = shlex.quote(f)
+                crlf_cmds.append(
+                    f'[ -f {qf} ] && sed "s/\\r$//" {qf} > /tmp/_crlf.tmp '
+                    f"&& cat /tmp/_crlf.tmp > {qf}"
+                )
+            crlf_script = " && ".join(crlf_cmds) + " && "
+
+        # Output copy-back script.
+        output_script = ""
+        if self.output_files:
+            copy_cmds: list[str] = []
+            for f in self.output_files:
+                src = shlex.quote(f"{self.container_build_dir}/{f}")
+                dst = shlex.quote(f"{WORKSPACE_CONTAINER_PATH}/{f}")
+                dst_dir = shlex.quote(
+                    str(PurePosixPath(f"{WORKSPACE_CONTAINER_PATH}/{f}").parent)
+                )
+                copy_cmds.append(
+                    f"[ -f {src} ] && mkdir -p {dst_dir} && cp -f {src} {dst}"
+                )
+            output_script = "; " + "; ".join(copy_cmds)
+
+        inner_cmd = " ".join(shlex.quote(c) for c in cmd)
+        shell_script = (
+            f"mkdir -p {build_dir} && "
+            f"tar -cf - -C {ws_mount} {excludes} . "
+            f"| tar -xf - -C {build_dir} && "
+            f"cd {build_dir} && "
+            f"{crlf_script}"
+            f"{inner_cmd}; rc=$?{output_script}; exit $rc"
+        )
+
+        docker_cmd: list[str] = ["docker", "run", "--rm"]
+
+        for mount in self.mounts:
+            vol = f"{mount.host_path.resolve()}:{mount.container_path}"
+            if mount.readonly:
+                vol += ":ro"
+            docker_cmd += ["-v", vol]
+
+        docker_cmd += ["-w", self.container_build_dir]
+        docker_cmd += ["-e", "HOME=/tmp"]
+
+        for key, val in self.extra_env.items():
+            docker_cmd += ["-e", f"{key}={val}"]
+
+        docker_cmd.append(self.image)
+        docker_cmd += ["sh", "-c", shell_script]
         return docker_cmd
 
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -49,6 +49,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
+    is_windows,
     docker_available,
     image_exists,
 )
@@ -322,8 +323,8 @@ class ZScript:
             for dep in deps:
                 try:
                     # Resolve release with version fallback for nanvix-suffixed
-                    # deps, then pass the pre-resolved release to install_dep()
-                    # to avoid redundant GitHub API calls.
+                    # deps, then pass the pre-resolved release and enable
+                    # cross-mode asset fallback in install_dep().
                     release: dict[str, object] | None = None
                     base_version = extract_nanvix_version_base(str(dep.ref.value))
                     if base_version is not None:
@@ -460,8 +461,18 @@ class ZScript:
     def clean(self) -> None:
         """Remove build artifacts.
 
-        Override to clean generated files.
+        On Windows, common build artifacts are removed directly without
+        invoking the build system (which would require Docker).  Override
+        to customise the files cleaned.
         """
+        if is_windows():
+            # Common artifacts that consumers may produce.
+            # Subclasses can override to add project-specific files.
+            for name in (".nanvix-configured",):
+                p = self.repo_root / name
+                if p.is_file():
+                    p.unlink()
+                    log.info(f"Removed {name}")
 
     # ------------------------------------------------------------------
     # Subprocess helper
@@ -513,7 +524,15 @@ class ZScript:
                 merged = {**cfg.extra_env, **combo_and_explicit}
                 cfg = dataclasses.replace(cfg, extra_env=merged)
             if kvm:
+                if is_windows():
+                    log.fatal(
+                        "KVM mode is not available on Windows",
+                        code=EXIT_BUILD_FAILURE,
+                        hint="KVM requires a Linux host with /dev/kvm access.",
+                    )
                 cmd = cfg.build_kvm_run_cmd(*args)
+            elif is_windows() and (cfg.crlf_files or cfg.output_files):
+                cmd = cfg.build_windows_run_cmd(*args)
             else:
                 cmd = cfg.build_run_cmd(*args)
             working_dir = self.repo_root

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -20,6 +20,7 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
+    is_windows,
     docker_available,
     image_exists,
 )
@@ -503,6 +504,146 @@ class TestPlatformUidGid(unittest.TestCase):
             self.assertEqual(cfg.uid, os.getuid())
         if hasattr(os, "getgid"):
             self.assertEqual(cfg.gid, os.getgid())
+
+
+class TestIsWindows(unittest.TestCase):
+    """Tests for is_windows() helper."""
+
+    def test_returns_bool(self) -> None:
+        self.assertIsInstance(is_windows(), bool)
+
+    def test_false_on_linux(self) -> None:
+        with patch("nanvix_zutil.docker.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            self.assertFalse(is_windows())
+
+    def test_true_on_win32(self) -> None:
+        with patch("nanvix_zutil.docker.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            self.assertTrue(is_windows())
+
+
+class TestDockerConfigWindowsFields(unittest.TestCase):
+    """DockerConfig Windows-specific field defaults."""
+
+    def test_crlf_files_default_empty(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.crlf_files, [])
+
+    def test_output_files_default_empty(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.output_files, [])
+
+    def test_tar_excludes_has_defaults(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertIn(".git", cfg.tar_excludes)
+        self.assertIn(".nanvix/venv", cfg.tar_excludes)
+
+    def test_container_build_dir_default(self) -> None:
+        cfg = DockerConfig(image="test-image")
+        self.assertEqual(cfg.container_build_dir, "/tmp/build")
+
+
+class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
+    """Tests for DockerConfig.build_windows_run_cmd()."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._workspace = Path(self._tmpdir.name) / "workspace"
+        self._workspace.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_config(
+        self,
+        crlf_files: list[str] | None = None,
+        output_files: list[str] | None = None,
+    ) -> DockerConfig:
+        return DockerConfig(
+            image="nanvix/toolchain:latest-minimal",
+            mounts=[
+                Mount(
+                    host_path=self._workspace,
+                    container_path=WORKSPACE_CONTAINER_PATH,
+                    readonly=False,
+                ),
+            ],
+            uid=1000,
+            gid=1000,
+            crlf_files=crlf_files or [],
+            output_files=output_files or [],
+        )
+
+    def test_tar_copy_command_structure(self) -> None:
+        """Windows run command uses tar instead of bind mounts."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        self.assertEqual(cmd[:3], ["docker", "run", "--rm"])
+        # Should use sh -c wrapping.
+        self.assertIn("sh", cmd)
+        self.assertIn("-c", cmd)
+
+    def test_contains_tar_in_shell_script(self) -> None:
+        """The shell script should include tar commands."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        shell_script = cmd[-1]  # Last arg after sh -c
+        self.assertIn("tar -cf", shell_script)
+        self.assertIn("tar -xf", shell_script)
+
+    def test_crlf_normalization_included(self) -> None:
+        """CRLF files are normalized in the shell script."""
+        cfg = self._make_config(crlf_files=["Makefile", "configure"])
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        shell_script = cmd[-1]
+        self.assertIn("Makefile", shell_script)
+        self.assertIn("configure", shell_script)
+        self.assertIn("sed", shell_script)
+
+    def test_output_files_copied_back(self) -> None:
+        """Output files are copied from container to host."""
+        cfg = self._make_config(output_files=["build/output.elf", "result.bin"])
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        shell_script = cmd[-1]
+        self.assertIn("build/output.elf", shell_script)
+        self.assertIn("result.bin", shell_script)
+        self.assertIn("cp -f", shell_script)
+        self.assertIn("mkdir -p", shell_script)
+
+    def test_inner_command_in_script(self) -> None:
+        """The inner command appears in the shell script."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("make", "-j4", "all")
+        shell_script = cmd[-1]
+        self.assertIn("make -j4 all", shell_script)
+
+    def test_workdir_is_build_dir(self) -> None:
+        """Working directory is set to container_build_dir."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("echo")
+        w_idx = cmd.index("-w")
+        self.assertEqual(cmd[w_idx + 1], "/tmp/build")
+
+    def test_tar_excludes_in_command(self) -> None:
+        """Tar excludes appear in the shell script."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("echo")
+        shell_script = cmd[-1]
+        self.assertIn("--exclude=.git", shell_script)
+
+    def test_no_user_flag(self) -> None:
+        """Windows run cmd does not include --user flag."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("echo")
+        self.assertNotIn("--user", cmd)
+
+    def test_extra_env_forwarded(self) -> None:
+        """Extra env vars are forwarded to the container."""
+        cfg = self._make_config()
+        cfg.extra_env["MY_VAR"] = "hello"
+        cmd = cfg.build_windows_run_cmd("echo")
+        self.assertIn("MY_VAR=hello", cmd)
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -431,6 +431,58 @@ class TestZScriptRun(unittest.TestCase):
         finally:
             log_mod.set_json_mode(False)
 
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    def test_run_kvm_fatal_on_windows(self, _mock: object) -> None:
+        """run() with kvm=True exits fatally on Windows."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.docker = DockerConfig(
+            image="test-image",
+            mounts=[],
+            uid=0,
+            gid=0,
+        )
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                script.run("echo", kvm=True)
+            self.assertEqual(ctx.exception.code, 5)
+        finally:
+            log_mod.set_json_mode(False)
+
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    def test_run_uses_windows_cmd_when_configured(self, _mock: object) -> None:
+        """run() delegates to build_windows_run_cmd on Windows with crlf/output files."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.docker = DockerConfig(
+            image="nanvix/toolchain:latest-minimal",
+            mounts=[
+                Mount(
+                    host_path=script.repo_root,
+                    container_path=WORKSPACE_CONTAINER_PATH,
+                )
+            ],
+            uid=1000,
+            gid=1000,
+            crlf_files=["Makefile"],
+            output_files=["output.elf"],
+        )
+        captured_cmds: list[list[str]] = []
+
+        import subprocess as sp
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured_cmds.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.run("make", "all")
+
+        self.assertTrue(captured_cmds)
+        cmd = captured_cmds[0]
+        # Should use sh -c (Windows tar-copy mode).
+        self.assertIn("sh", cmd)
+        self.assertIn("-c", cmd)
+
 
 class TestZScriptSysrootRequiredFiles(unittest.TestCase):
     """sysroot_required_files() varies by deployment mode."""
@@ -667,6 +719,38 @@ class TestZScriptDockerIntegration(unittest.TestCase):
         # -e MY_VAR=hello must appear in the docker run command
         self.assertIn("-e", cmd)
         self.assertIn("MY_VAR=hello", cmd)
+
+
+class TestZScriptCleanWindows(unittest.TestCase):
+    """ZScript.clean() Windows behavior."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    def test_clean_removes_configured_artifact(self, _mock: object) -> None:
+        """clean() removes .nanvix-configured on Windows."""
+        script = ZScript(Path(self._tmpdir.name))
+        artifact = script.repo_root / ".nanvix-configured"
+        artifact.write_text("marker")
+        script.clean()
+        self.assertFalse(artifact.exists())
+
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    def test_clean_noop_when_no_artifacts(self, _mock: object) -> None:
+        """clean() does not raise when no artifacts exist on Windows."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.clean()  # Should not raise.
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_clean_noop_on_linux(self, _mock: object) -> None:
+        """clean() is a no-op on Linux (base class)."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.clean()  # Should not raise.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `is_windows()` helper and `build_windows_run_cmd()` method to `DockerConfig` for tar-based source copying on Windows Docker Desktop (avoids VirtioFS/9p I/O penalties)
- Adds four new `DockerConfig` fields: `crlf_files`, `output_files`, `tar_excludes`, `container_build_dir`
- Updates `ZScript.run()` to detect Windows and route to `build_windows_run_cmd` when configured, and to block KVM mode on Windows with a clear error
- Updates `ZScript.clean()` to remove common build artifacts directly on Windows (without invoking the build system)
- Re-exports `is_windows` from `__init__.py`

Backported from `.nanvix/z.py` in nanvix/cpython. Stacked on #75 (version-fallback PR).

Refs #69

## Files Changed

- `src/nanvix_zutil/docker.py` — `is_windows()`, `import shlex`, 4 new `DockerConfig` fields, `build_windows_run_cmd()`
- `src/nanvix_zutil/script.py` — `is_windows` import, Windows `clean()` body, Windows `run()` guards
- `src/nanvix_zutil/__init__.py` — `is_windows` re-export
- `tests/test_docker.py` — `TestIsWindows`, `TestDockerConfigWindowsFields`, `TestDockerConfigBuildWindowsRunCmd`
- `tests/test_script.py` — `TestZScriptCleanWindows`, `test_run_kvm_fatal_on_windows`, `test_run_uses_windows_cmd_when_configured`

## Validation

- 486 tests pass (21 new), 0 type errors (basedpyright strict), 0 lint errors (black)