### PR TITLE
[examples] B: Fix nanvixd version skew in functional test

### DIFF
--- a/examples/hello-world/.nanvix/z.py
+++ b/examples/hello-world/.nanvix/z.py
@@ -110,6 +110,8 @@ class HelloWorld(ZScript):
             "--foreground",
             "60",
             f"{sysroot}/bin/nanvixd.elf",
+            "-bin-dir",
+            f"{sysroot}/bin",
             "--",
             str(workspace_binary),
             kvm=True,


### PR DESCRIPTION
## Summary

Fix a runtime version-skew bug in the hello-world functional test where `nanvixd.elf` (from a pinned sysroot) downloads incompatible registry binaries from the latest GitHub release.

## Problem

`nanvixd.elf` defaults to looking for `kernel.elf`, `linuxd.elf`, and `uservm.elf` in `./bin/` (CWD-relative). When those are missing, it falls back to the `nanvix-registry`, which **always fetches the latest release**. If the latest release has protocol changes, the version mismatch causes:

```
Error: invalid control-plane message from linuxd
       (error=Custom { kind: InvalidData, error: "invalid linuxd command: 6" })
```

This broke CI after nanvix v0.12.379 was published while the hello-world example pins v0.12.365.

## Fix

Pass `-bin-dir {sysroot}/bin` to `nanvixd.elf` so it uses the co-located binaries from the sysroot tarball instead of fetching from the registry.

## Upstream

Filed [nanvix/nanvix#1990](https://github.com/nanvix/nanvix/issues/1990) to track the long-term fix: making `nanvixd` infer its binary directory from its own executable path.