### PR TITLE
[release] Fix multi-line stdout breaking GITHUB_OUTPUT

### DIFF
--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -14,9 +14,15 @@ import tomllib
 
 
 def main() -> int:
-    result = subprocess.run(["uv", "version", "--bump", "patch"], check=False)
+    result = subprocess.run(
+        ["uv", "version", "--bump", "patch"], check=False, capture_output=True
+    )
     if result.returncode != 0:
         print("error: failed to bump version", file=sys.stderr)
+        if result.stdout:
+            sys.stderr.buffer.write(result.stdout)
+        if result.stderr:
+            sys.stderr.buffer.write(result.stderr)
         return 1
 
     with open("pyproject.toml", "rb") as f:


### PR DESCRIPTION
## Problem

The Release workflow (run [#24173517815](https://github.com/nanvix/zutils/actions/runs/24173517815)) failed at the **Resolve version** step with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '0.7.4'
```

`uv version --bump patch` prints an info line to stdout (e.g. `nanvix-zutil 0.7.3 => 0.7.4`). The script then also prints the version. Both lines get captured into `$VERSION`, producing a multi-line value that breaks `$GITHUB_OUTPUT`.

## Fix

Add `capture_output=True` to the `subprocess.run()` call in `scripts/bump-version.py` so only the clean semver string is emitted to stdout.