### PR TITLE
[release] Restore template placeholders after packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
         run: |
           tar czf "templates.tar.gz" -C templates .
           (cd templates && zip -r ../templates.zip .)
+          # Restore placeholders so the working tree is clean for rebase
+          git checkout -- templates/
 
       - name: Commit and push version bump
         if: github.event_name == 'push'


### PR DESCRIPTION
## Problem

Release workflow run [#24174530128](https://github.com/nanvix/zutils/actions/runs/24174530128) failed at **Commit and push version bump** with:

```
error: cannot rebase: You have unstaged changes.
```

The `sed -i` in "Patch template versions" replaces `{{ZUTIL_VERSION}}` in tracked template files. After packaging into archives, these modifications remain as unstaged changes, blocking `git rebase origin/dev`.

## Fix

Add `git checkout -- templates/` after packaging to restore the template placeholders, leaving the working tree clean for the rebase.