### PR TITLE
[release] Prevent recursive release triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml uv.lock
-          git commit -m "[release] Bump version to v${VERSION}"
+          git commit -m "[release] Bump version to v${VERSION} [skip ci]"
           git fetch origin dev
           git rebase origin/dev
           git push origin HEAD:dev


### PR DESCRIPTION
## Problem

The version bump commit pushed by the Release workflow to `dev` triggers **another** Release workflow run, creating an infinite loop. Versions spiraled from 0.7.4 → 0.7.11 before the concurrency group cancelled them.

## Fix

Add `[skip ci]` to the version bump commit message. GitHub Actions natively skips all workflow triggers for pushes whose commit messages contain this marker.