### PR TITLE
Report setup fallback state instead of silent success

### DIFF
--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -79,6 +79,7 @@ from nanvix_zutil.docker import (
 )
 from nanvix_zutil.exitcodes import (
     EXIT_BUILD_FAILURE,
+    EXIT_DEGRADED_SETUP,
     EXIT_GENERAL_ERROR,
     EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
@@ -129,6 +130,7 @@ __all__ = [
     "Dependency",
     "DockerConfig",
     "EXIT_BUILD_FAILURE",
+    "EXIT_DEGRADED_SETUP",
     "EXIT_GENERAL_ERROR",
     "EXIT_INVALID_ARGS",
     "EXIT_MISSING_DEP",

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -122,7 +122,8 @@ class Dependency:
 def suffix_dep(dep: Dependency, version: str) -> Dependency:
     """Return a copy of *dep* with its VERSION ref suffixed with *version*.
 
-    If *dep* has a non-VERSION ref kind, it is returned unchanged.
+    If *dep* has a non-VERSION ref kind, or its value already contains
+    ``-nanvix-`` (e.g. from an env-var override), it is returned unchanged.
 
     Args:
         dep: The dependency to suffix.
@@ -134,6 +135,8 @@ def suffix_dep(dep: Dependency, version: str) -> Dependency:
         original if no suffixing is needed.
     """
     if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
+        if "-nanvix-" in dep.ref.value:
+            return dep
         return _dc_replace(
             dep,
             ref=Ref(

--- a/src/nanvix_zutil/exitcodes.py
+++ b/src/nanvix_zutil/exitcodes.py
@@ -28,3 +28,6 @@ EXIT_BUILD_FAILURE: int = 5
 
 EXIT_TEST_FAILURE: int = 6
 """One or more tests failed."""
+
+EXIT_DEGRADED_SETUP: int = 7
+"""Setup completed but one or more dependencies used fallback versions."""

--- a/src/nanvix_zutil/log.py
+++ b/src/nanvix_zutil/log.py
@@ -132,18 +132,18 @@ def success(msg: str) -> None:
         print(f"\033[32msuccess:\033[0m {msg}", file=sys.stderr, flush=True)
 
 
-def warning(msg: str) -> None:
+def warning(msg: str, code: int | None = None) -> None:
     """Emit a warning message.
 
     Args:
         msg: The message text.
+        code: Optional process exit code associated with the warning.
     """
     if _json_mode:
-        print(
-            json.dumps({"level": "warning", "message": msg}),
-            file=sys.stderr,
-            flush=True,
-        )
+        obj: dict[str, object] = {"level": "warning", "message": msg}
+        if code is not None:
+            obj["code"] = code
+        print(json.dumps(obj), file=sys.stderr, flush=True)
     else:
         print(f"\033[33mwarning:\033[0m {msg}", file=sys.stderr, flush=True)
 

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -367,11 +367,8 @@ def _parse_dependencies(
     for name, raw_value in section.items():
         ref = _parse_version_field(raw_value, f"{section_name}.{name}", path)
 
-        env_key = f"NANVIX_VERSION_{name.upper()}"
-        env_val = os.environ.get(env_key)
-        if env_val is not None:
-            ref = Ref(kind=ref.kind, value=env_val)
-
+        # Manifest values must not include the nanvix suffix — it is
+        # derived automatically from nanvix-version.
         if (
             ref.kind == RefKind.VERSION
             and isinstance(ref.value, str)
@@ -385,6 +382,13 @@ def _parse_dependencies(
                 " — the nanvix version is derived automatically from"
                 " nanvix-version.",
             )
+
+        env_key = f"NANVIX_VERSION_{name.upper()}"
+        env_val = os.environ.get(env_key)
+        if env_val is not None:
+            # Env overrides MAY include "-nanvix-" for full control.
+            # suffix_dep() will skip values that already contain it.
+            ref = Ref(kind=ref.kind, value=env_val)
 
         deps.append(Dependency(name=name, repo=f"nanvix/{name}", ref=ref))
     return deps
@@ -521,6 +525,8 @@ def load_manifest(path: Path) -> Manifest:
         version_suffix = sysroot_ref.value.removeprefix("v")
         for dep in [*dependencies, *system_dependencies]:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
+                if "-nanvix-" in dep.ref.value:
+                    continue
                 dep.ref = Ref(
                     kind=dep.ref.kind,
                     value=f"{dep.ref.value}-nanvix-{version_suffix}",

--- a/src/nanvix_zutil/matrix.py
+++ b/src/nanvix_zutil/matrix.py
@@ -70,6 +70,8 @@ class BuildResult:
     success: bool
     duration_seconds: float
     error: str | None = None
+    #: ``True`` when ``setup()`` resolved one or more deps via version fallback.
+    used_fallback: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +244,7 @@ def run_all_builds(
         builds_dir = repo_root / ".nanvix" / _BUILDS_DIR
         builds_dir.mkdir(parents=True, exist_ok=True)
         combo_workspace = builds_dir / combo_slug
+        used_fallback = False
 
         try:
             # Create an isolated workspace copy so parallel Docker
@@ -306,7 +309,13 @@ def run_all_builds(
             for step in hook_chain:
                 method = getattr(instance, step, None)
                 if callable(method):
-                    method()
+                    result = method()
+                    if step == "setup":
+                        used_fallback = (
+                            used_fallback
+                            or instance._used_fallback  # pyright: ignore[reportPrivateUsage]
+                            or bool(result)
+                        )
 
         except SystemExit as exc:
             elapsed = time.monotonic() - start
@@ -334,6 +343,7 @@ def run_all_builds(
             combo=combo,
             success=True,
             duration_seconds=time.monotonic() - start,
+            used_fallback=used_fallback,
         )
 
     results: dict[BuildCombo, BuildResult] = {}

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -55,6 +55,7 @@ from nanvix_zutil.docker import (
 )
 from nanvix_zutil.exitcodes import (
     EXIT_BUILD_FAILURE,
+    EXIT_DEGRADED_SETUP,
     EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
     EXIT_TEST_FAILURE,
@@ -163,6 +164,7 @@ class ZScript:
         self.buildroot: Buildroot | None = None
         self.docker: DockerConfig | None = None
         self.combo_env: dict[str, str] | None = None
+        self._used_fallback: bool = False
 
     # ------------------------------------------------------------------
     # Hook classification helpers
@@ -277,7 +279,7 @@ class ZScript:
     # Lifecycle hooks — auto-implemented
     # ------------------------------------------------------------------
 
-    def setup(self) -> None:
+    def setup(self) -> bool:
         """Prepare the build environment.
 
         The base implementation automatically downloads the Nanvix sysroot
@@ -287,10 +289,18 @@ class ZScript:
         Subclasses may override this to perform additional setup steps.
         Call ``super().setup()`` to retain the automatic download behaviour::
 
-            def setup(self) -> None:
-                super().setup()
+            def setup(self) -> bool:
+                used_fallback = super().setup()
                 # extra verification or configuration here
+                return used_fallback
+
+        Returns:
+            ``True`` if any dependency was resolved via version fallback,
+            ``False`` if all dependencies matched their exact requested
+            versions.
         """
+        self._used_fallback = False
+
         self.sysroot = Sysroot.download(
             machine=self.config.machine,
             deployment_mode=self.config.deployment_mode,
@@ -338,8 +348,9 @@ class ZScript:
                         # fb_ver is None when the exact tag was found;
                         # non-None means a fallback release was used.
                         if fb_ver is not None:
+                            self._used_fallback = True
                             requested_ver = extract_nanvix_version(str(dep.ref.value))
-                            log.info(
+                            log.warning(
                                 f"Version fallback for {dep.name}: "
                                 f"requested nanvix-{requested_ver}, "
                                 f"resolved nanvix-{fb_ver}"
@@ -367,6 +378,7 @@ class ZScript:
                     raise
 
         self.config.save()
+        return self._used_fallback
 
     def distclean(self) -> None:
         """Remove all transient ``.nanvix/`` artifacts.
@@ -753,6 +765,19 @@ class ZScript:
                     f"{failed}/{len(results)} build(s) failed",
                     code=failure_code,
                 )
+                return  # log.fatal exits, but be explicit
+
+            any_fallback = any(r.used_fallback for r in results.values())
+            if any_fallback:
+                n_fb = sum(1 for r in results.values() if r.used_fallback)
+                log.warning(
+                    f"All {len(results)} build(s) passed, but "
+                    f"{n_fb} used fallback dependencies",
+                    code=EXIT_DEGRADED_SETUP,
+                )
+                sys.exit(EXIT_DEGRADED_SETUP)
+                return  # sys.exit raises, but be explicit
+
             log.success(f"All {len(results)} build(s) passed")
             return
 
@@ -779,7 +804,20 @@ class ZScript:
 
         handler = dispatch.get(subcommand) if subcommand is not None else None
         if callable(handler) and subcommand is not None:
-            handler()
-            log.success(f"{subcommand.capitalize()} complete")
+            handler_result = handler()
+            if subcommand == "setup":
+                used_fallback = instance._used_fallback or bool(handler_result)
+                instance._used_fallback = used_fallback
+            else:
+                used_fallback = False
+
+            if subcommand == "setup" and used_fallback:
+                log.warning(
+                    f"{subcommand.capitalize()} complete with fallback dependencies",
+                    code=EXIT_DEGRADED_SETUP,
+                )
+                sys.exit(EXIT_DEGRADED_SETUP)
+            else:
+                log.success(f"{subcommand.capitalize()} complete")
         else:
             log.fatal(f"Unknown subcommand: {subcommand}", code=EXIT_INVALID_ARGS)

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -19,6 +19,7 @@ from nanvix_zutil.buildroot import (
     extract_nanvix_version,
     extract_nanvix_version_base,
     parse_semver_tuple,
+    suffix_dep,
 )
 
 
@@ -379,6 +380,38 @@ class TestBuildrootInstallDep(unittest.TestCase):
 
         self.assertTrue((br.path / "lib" / "libz.a").exists())
         self.assertTrue((br.path / "include" / "zlib.h").exists())
+
+
+class TestSuffixDep(unittest.TestCase):
+    """Tests for suffix_dep()."""
+
+    def test_suffixes_version_ref(self) -> None:
+        """VERSION ref gets the nanvix suffix appended."""
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
+        )
+        result = suffix_dep(dep, "0.12.410")
+        self.assertEqual(result.ref.value, "1.3.1-nanvix-0.12.410")
+
+    def test_skips_non_version_ref(self) -> None:
+        """TAG ref is returned unchanged."""
+        dep = Dependency(
+            name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.3.1")
+        )
+        result = suffix_dep(dep, "0.12.410")
+        self.assertEqual(result.ref.value, "v1.3.1")
+
+    def test_skips_already_suffixed(self) -> None:
+        """VERSION ref that already contains -nanvix- is not double-suffixed."""
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.VERSION, value="1.3.1-nanvix-99.99.99"),
+        )
+        result = suffix_dep(dep, "0.12.410")
+        self.assertEqual(result.ref.value, "1.3.1-nanvix-99.99.99")
 
 
 class TestExtractNanvixVersion(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,9 +31,10 @@ class _MockConsumer(ZScript):
         super().__init__(repo_root)
         self.called: list[str] = []
 
-    def setup(self) -> None:
+    def setup(self) -> bool:
         """Record setup hook invocation."""
         self.called.append("setup")
+        return False
 
     def build(self) -> None:
         """Record build hook invocation."""

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -95,6 +95,19 @@ class TestWarning(unittest.TestCase):
         obj = json.loads(buf.getvalue().strip())
         self.assertEqual(obj["level"], "warning")
 
+    def test_json_mode_with_code(self) -> None:
+        log_mod.set_json_mode(True)
+        buf = StringIO()
+        sys.stderr = buf
+        try:
+            log_mod.warning("degraded", code=7)
+        finally:
+            sys.stderr = sys.__stderr__
+            log_mod.set_json_mode(False)
+        obj = json.loads(buf.getvalue().strip())
+        self.assertEqual(obj["level"], "warning")
+        self.assertEqual(obj["code"], 7)
+
 
 class TestError(unittest.TestCase):
     """Tests for log.error."""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -697,6 +697,54 @@ class TestLoadManifestEnvOverride(unittest.TestCase):
         self.assertEqual(m.sysroot_ref.value, "env_nanvix")
         self.assertEqual(m.dependencies[0].ref.value, "env_zlib-nanvix-env_nanvix")
 
+    def test_env_override_with_nanvix_suffix_skips_auto_suffix(self) -> None:
+        """NANVIX_VERSION_<NAME> with -nanvix- suffix bypasses auto-suffixing."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.410"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+            "\n"
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "1.3.1-nanvix-99.99.99"}):
+            m = load_manifest(path)
+
+        # The env override already has the suffix — must NOT be double-suffixed.
+        self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-99.99.99")
+
+    def test_env_override_without_suffix_still_gets_suffixed(self) -> None:
+        """NANVIX_VERSION_<NAME> without -nanvix- still gets auto-suffixed."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.410"\n'
+            "[dependencies]\n"
+            'zlib = "1.3.1"\n'
+            "\n"
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "2.0.0"}):
+            m = load_manifest(path)
+
+        # Plain base version override still gets the nanvix suffix.
+        self.assertEqual(m.dependencies[0].ref.value, "2.0.0-nanvix-0.12.410")
+
 
 class TestLoadManifestAutoSuffix(unittest.TestCase):
     """Only VERSION refs are auto-suffixed with the nanvix version."""

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -200,6 +200,13 @@ class TestBuildResult(unittest.TestCase):
         self.assertEqual(result.error, "build failed")
         self.assertEqual(result.duration_seconds, 0.3)
 
+    def test_used_fallback_defaults_false(self) -> None:
+        """used_fallback defaults to False when not specified."""
+        combo = BuildCombo(platform="microvm", mode="standalone", memory="256mb")
+        result = BuildResult(combo=combo, success=True, duration_seconds=1.0)
+
+        self.assertFalse(result.used_fallback)
+
 
 class TestRunAllBuilds(unittest.TestCase):
     """Tests for :func:`run_all_builds`."""
@@ -228,8 +235,9 @@ class TestRunAllBuilds(unittest.TestCase):
             def clean(self) -> None:
                 _Stub.hook_log.append("clean")
 
-            def setup(self) -> None:
+            def setup(self) -> bool:
                 _Stub.hook_log.append("setup")
+                return False
 
         self._stub_cls = _Stub
         _Stub.hook_log = []
@@ -290,8 +298,8 @@ class TestRunAllBuilds(unittest.TestCase):
         from nanvix_zutil.script import ZScript
 
         class _Failing(ZScript):
-            def setup(self) -> None:
-                pass
+            def setup(self) -> bool:
+                return False
 
             def build(self) -> None:
                 raise SystemExit(5)
@@ -419,8 +427,8 @@ class TestRunAllBuilds(unittest.TestCase):
         from nanvix_zutil.script import ZScript
 
         class _Failing(ZScript):
-            def setup(self) -> None:
-                pass
+            def setup(self) -> bool:
+                return False
 
             def build(self) -> None:
                 raise SystemExit(5)
@@ -448,6 +456,80 @@ class TestRunAllBuilds(unittest.TestCase):
             builds_dir.exists() and any(builds_dir.iterdir()),
             "Per-combo workspaces should be cleaned up even on failure",
         )
+
+    def test_setup_fallback_propagated_to_result(self) -> None:
+        """run_all_builds sets used_fallback=True when setup sets _used_fallback."""
+        from nanvix_zutil.matrix import run_all_builds
+        from nanvix_zutil.script import ZScript
+
+        class _FallbackStub(ZScript):
+            def setup(self) -> bool:
+                self._used_fallback = True
+                return True
+
+        combos = [
+            BuildCombo(platform="microvm", mode="standalone", memory="256mb"),
+        ]
+
+        results = run_all_builds(
+            script_cls=_FallbackStub,
+            combos=combos,
+            hook="setup",
+            targets=[],
+            docker_image=None,
+            repo_root=self._repo_root,
+        )
+
+        result = results[combos[0]]
+        self.assertTrue(result.success)
+        self.assertTrue(result.used_fallback)
+
+    def test_no_fallback_result_has_false(self) -> None:
+        """run_all_builds sets used_fallback=False when setup() returns False."""
+        from nanvix_zutil.matrix import run_all_builds
+
+        combos = [
+            BuildCombo(platform="microvm", mode="standalone", memory="256mb"),
+        ]
+
+        results = run_all_builds(
+            script_cls=self._stub_cls,
+            combos=combos,
+            hook="setup",
+            targets=[],
+            docker_image=None,
+            repo_root=self._repo_root,
+        )
+
+        result = results[combos[0]]
+        self.assertTrue(result.success)
+        self.assertFalse(result.used_fallback)
+
+    def test_setup_return_value_propagated_to_result(self) -> None:
+        """run_all_builds honors setup() returning True without mutating state."""
+        from nanvix_zutil.matrix import run_all_builds
+        from nanvix_zutil.script import ZScript
+
+        class _ReturnOnlyFallback(ZScript):
+            def setup(self) -> bool:
+                return True
+
+        combos = [
+            BuildCombo(platform="microvm", mode="standalone", memory="256mb"),
+        ]
+
+        results = run_all_builds(
+            script_cls=_ReturnOnlyFallback,
+            combos=combos,
+            hook="setup",
+            targets=[],
+            docker_image=None,
+            repo_root=self._repo_root,
+        )
+
+        result = results[combos[0]]
+        self.assertTrue(result.success)
+        self.assertTrue(result.used_fallback)
 
 
 class TestUnsupportedAllBuilds(unittest.TestCase):
@@ -485,6 +567,81 @@ class TestUnsupportedAllBuilds(unittest.TestCase):
 
         sys.argv = ["z.py", "distclean", "--all-builds"]
         with self.assertRaises(SystemExit):
+            ZScript.main(repo_root=self._repo_root)
+
+
+class TestAllBuildsFallbackExit(unittest.TestCase):
+    """--all-builds exits EXIT_DEGRADED_SETUP when any combo used fallback."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        from tests.testutils import MANIFEST_WITH_BUILDS, write_manifest
+
+        self._tmpdir = tempfile.mkdtemp()
+        self._repo_root = Path(self._tmpdir)
+        write_manifest(self._repo_root, content=MANIFEST_WITH_BUILDS)
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_all_builds_exits_7_when_any_combo_used_fallback(self) -> None:
+        """--all-builds setup exits EXIT_DEGRADED_SETUP on fallback."""
+        from unittest.mock import patch
+
+        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
+        from nanvix_zutil.script import ZScript
+
+        combo = BuildCombo(platform="hyperlight", mode="multi-process", memory="128mb")
+        fake_results = {
+            combo: BuildResult(
+                combo=combo,
+                success=True,
+                duration_seconds=1.0,
+                used_fallback=True,
+            ),
+        }
+
+        with (
+            patch("sys.argv", ["z.py", "--all-builds", "setup"]),
+            patch(
+                "nanvix_zutil.script.run_all_builds",
+                return_value=fake_results,
+            ),
+            patch("nanvix_zutil.script.print_summary"),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            ZScript.main(repo_root=self._repo_root)
+
+        self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
+
+    def test_all_builds_succeeds_when_no_fallback(self) -> None:
+        """--all-builds setup exits cleanly when no combo used fallback."""
+        from unittest.mock import patch
+
+        from nanvix_zutil.script import ZScript
+
+        combo = BuildCombo(platform="hyperlight", mode="multi-process", memory="128mb")
+        fake_results = {
+            combo: BuildResult(
+                combo=combo,
+                success=True,
+                duration_seconds=1.0,
+                used_fallback=False,
+            ),
+        }
+
+        with (
+            patch("sys.argv", ["z.py", "--all-builds", "setup"]),
+            patch(
+                "nanvix_zutil.script.run_all_builds",
+                return_value=fake_results,
+            ),
+            patch("nanvix_zutil.script.print_summary"),
+        ):
+            # Should not raise SystemExit.
             ZScript.main(repo_root=self._repo_root)
 
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -3,11 +3,13 @@
 
 """Tests for nanvix_zutil.script (ZScript)."""
 
+import json
 import os
 import subprocess as sp
 import sys
 import tempfile
 import unittest
+from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -869,6 +871,203 @@ class TestZScriptCleanWindows(unittest.TestCase):
         """clean() is a no-op on Linux (base class)."""
         script = ZScript(Path(self._tmpdir.name))
         script.clean()  # Should not raise.
+
+
+class TestZScriptSetupFallbackReporting(unittest.TestCase):
+    """setup() reports fallback state correctly."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_setup_returns_false_when_no_fallback(self) -> None:
+        """setup() returns False when all deps resolve exactly."""
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        fake_buildroot = MagicMock()
+        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.1.0"}
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
+            patch(
+                "nanvix_zutil.script.resolve_release_with_fallback",
+                return_value=(fake_release, None),  # None = no fallback
+            ),
+        ):
+            script = ZScript(Path(self._tmpdir.name))
+            result = script.setup()
+
+        self.assertFalse(result)
+
+    def test_setup_returns_true_when_fallback_used(self) -> None:
+        """setup() returns True when a dep falls back to a different version."""
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        fake_buildroot = MagicMock()
+        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.0.9"}
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
+            patch(
+                "nanvix_zutil.script.resolve_release_with_fallback",
+                return_value=(fake_release, "0.0.9"),  # non-None = fallback used
+            ),
+        ):
+            script = ZScript(Path(self._tmpdir.name))
+            result = script.setup()
+
+        self.assertTrue(result)
+
+    def test_setup_no_deps_returns_false(self) -> None:
+        """setup() returns False when there are no dependencies."""
+        write_manifest(Path(self._tmpdir.name))  # default manifest, no deps
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
+            script = ZScript(Path(self._tmpdir.name))
+            result = script.setup()
+
+        self.assertFalse(result)
+
+    def test_setup_fallback_logs_warning(self) -> None:
+        """setup() logs at warning level when fallback is used."""
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        fake_buildroot = MagicMock()
+        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.0.9"}
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
+            patch(
+                "nanvix_zutil.script.resolve_release_with_fallback",
+                return_value=(fake_release, "0.0.9"),
+            ),
+            patch("nanvix_zutil.script.log") as mock_log,
+        ):
+            script = ZScript(Path(self._tmpdir.name))
+            script.setup()
+
+        # Verify warning was called (not info) for fallback message.
+        warning_calls = [
+            call
+            for call in mock_log.warning.call_args_list
+            if "fallback" in str(call).lower()
+        ]
+        self.assertTrue(warning_calls, "Expected a warning log for fallback")
+
+        # Verify info was NOT called for fallback (regression guard).
+        info_calls = [
+            call
+            for call in mock_log.info.call_args_list
+            if "fallback" in str(call).lower()
+        ]
+        self.assertFalse(info_calls, "Fallback should use warning, not info")
+
+
+class TestZScriptMainDegradedExit(unittest.TestCase):
+    """main() exits with EXIT_DEGRADED_SETUP when setup uses fallback."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_exit_degraded_setup_value(self) -> None:
+        """EXIT_DEGRADED_SETUP has the expected value of 7."""
+        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
+
+        self.assertEqual(EXIT_DEGRADED_SETUP, 7)
+
+    def test_main_exits_7_on_fallback_setup(self) -> None:
+        """main() with setup subcommand exits 7 when fallback was used."""
+        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
+
+        def _setup_with_fallback(self_inner: ZScript) -> bool:
+            self_inner._used_fallback = True  # pyright: ignore[reportPrivateUsage]
+            return True
+
+        with (
+            patch("sys.argv", ["z.py", "setup"]),
+            patch.object(ZScript, "setup", _setup_with_fallback),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            ZScript.main(repo_root=Path(self._tmpdir.name))
+
+        self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
+
+    def test_main_exits_7_on_return_only_fallback_setup(self) -> None:
+        """main() honors setup() returning True without touching private state."""
+        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
+
+        with (
+            patch("sys.argv", ["z.py", "setup"]),
+            patch.object(ZScript, "setup", return_value=True),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            ZScript.main(repo_root=Path(self._tmpdir.name))
+
+        self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
+
+    def test_main_exits_0_on_clean_setup(self) -> None:
+        """main() with setup subcommand completes normally when no fallback."""
+        with (
+            patch("sys.argv", ["z.py", "setup"]),
+            patch.object(ZScript, "setup", return_value=False),
+            patch("nanvix_zutil.script.log") as mock_log,
+        ):
+            # Should not raise SystemExit.
+            ZScript.main(repo_root=Path(self._tmpdir.name))
+
+        # Verify success log was emitted.
+        success_calls = [
+            call
+            for call in mock_log.success.call_args_list
+            if "complete" in str(call).lower()
+        ]
+        self.assertTrue(success_calls, "Expected a success log on clean setup")
+
+    def test_main_json_warning_includes_degraded_code(self) -> None:
+        """main() emits a warning JSON object with code on degraded setup."""
+        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
+
+        buf = StringIO()
+        original_stderr = sys.stderr
+        log_mod.set_json_mode(True)
+        sys.stderr = buf
+        try:
+            with (
+                patch("sys.argv", ["z.py", "--json", "setup"]),
+                patch.object(ZScript, "setup", return_value=True),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                ZScript.main(repo_root=Path(self._tmpdir.name))
+        finally:
+            sys.stderr = original_stderr
+            log_mod.set_json_mode(False)
+
+        self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
+        json_lines = [ln for ln in buf.getvalue().splitlines() if ln.startswith("{")]
+        self.assertTrue(json_lines, "Expected JSON output on stderr")
+        obj = json.loads(json_lines[-1])
+        self.assertEqual(obj["level"], "warning")
+        self.assertEqual(obj["code"], EXIT_DEGRADED_SETUP)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #92. When `./z setup` resolves a dependency via version fallback (exact nanvix-suffixed tag not found, falls back to best available), the process now exits with code **7** (`EXIT_DEGRADED_SETUP`) and emits a warning instead of silently reporting success.

## Changes

### Core fallback reporting (`b103495`)
- Add `EXIT_DEGRADED_SETUP = 7` exit code and export it
- `ZScript.setup()` returns `bool` — `True` when any dep used version fallback
- Upgrade fallback log from `log.info` to `log.warning`
- `main()` dispatches exit 7 when setup reports fallback
- 7 new tests covering return value, warning log, and exit code

### Regression guards (`490f9e9`)
- Add negative assertion: fallback does NOT emit `log.info` (only `log.warning`)
- Add positive assertion: success log emitted on clean setup

### `--all-builds` fallback propagation (`bb8d5f2`)
- `BuildResult.used_fallback` field on the dataclass
- `_run_combo` captures setup return and sets the field
- `--all-builds` dispatch exits 7 when any combo used fallback
- 5 new tests

### Env override suffix bypass (`cbad53d`)
- `NANVIX_VERSION_<NAME>` values containing `-nanvix-` skip auto-suffixing in both code paths (`suffix_dep()` and inline `load_manifest()`)
- Enables `NANVIX_VERSION_ZLIB=1.3.1-nanvix-99.99.99` to force fallback for testing
- 5 new tests

### Instance-attribute fallback state (`e77d865`)
- Add `self._used_fallback: bool` instance attribute on `ZScript`
- `main()` and `_run_combo` read the attribute instead of relying on `setup()` return value
- Survives subclass overrides that call `super().setup()` but discard the return (e.g. sqlite's `z.py`)
- Updated 2 existing tests to match

## Testing

- 519/520 tests pass (1 pre-existing toolchain failure)
- Typecheck clean (basedpyright), lint clean (black + shfmt + shellcheck)
- Downstream validated: `test-downstream.sh --force-fallback sqlite` → exit 7 ✓

## Known limitation

Consumer repos that fully override `setup()` without calling `super()` (e.g. cpython's `z.py`) won't exit 7 — their custom fallback logic doesn't set `_used_fallback`. This requires a follow-up PR in each consumer repo to either call `super().setup()` or remove their custom download code.