### PR TITLE
Simplify Windows CRLF handling in Docker tar-copy strategy

### DIFF
--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -164,9 +164,6 @@ class DockerConfig:
     extra_env: dict[str, str] = field(default_factory=dict)
     """Additional ``-e KEY=VALUE`` pairs forwarded to the container."""
 
-    crlf_files: list[str] = field(default_factory=list)
-    """Files requiring CRLF→LF normalization inside the container."""
-
     output_files: list[str] = field(default_factory=list)
     """Build output files to copy back from the container to the host."""
 
@@ -327,9 +324,8 @@ class DockerConfig:
            the host workspace at ``/mnt/workspace``.
         2. Copies sources via ``tar`` from the mounted workspace into a
            container-local build dir.
-        3. Normalizes CRLF line endings in configured files.
-        4. Runs the inner command from the container-local build dir.
-        5. Copies configured output files back to the mounted workspace.
+        3. Runs the inner command from the container-local build dir.
+        4. Copies configured output files back to the mounted workspace.
 
         Args:
             *cmd: Inner command and arguments to wrap.
@@ -343,18 +339,6 @@ class DockerConfig:
 
         # Build tar exclude args.
         excludes = " ".join(f"--exclude={shlex.quote(e)}" for e in self.tar_excludes)
-
-        # CRLF normalization script.
-        crlf_script = ""
-        if self.crlf_files:
-            crlf_cmds: list[str] = []
-            for f in self.crlf_files:
-                qf = shlex.quote(f)
-                crlf_cmds.append(
-                    f'[ -f {qf} ] && sed "s/\\r$//" {qf} > /tmp/_crlf.tmp '
-                    f"&& cat /tmp/_crlf.tmp > {qf}"
-                )
-            crlf_script = " && ".join(crlf_cmds) + " && "
 
         # Output copy-back script.
         output_script = ""
@@ -377,7 +361,6 @@ class DockerConfig:
             f"tar -cf - -C {ws_mount} {excludes} . "
             f"| tar -xf - -C {build_dir} && "
             f"cd {build_dir} && "
-            f"{crlf_script}"
             f"{inner_cmd}; rc=$?{output_script}; exit $rc"
         )
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -551,10 +551,6 @@ class TestIsWindows(unittest.TestCase):
 class TestDockerConfigWindowsFields(unittest.TestCase):
     """DockerConfig Windows-specific field defaults."""
 
-    def test_crlf_files_default_empty(self) -> None:
-        cfg = DockerConfig(image="test-image")
-        self.assertEqual(cfg.crlf_files, [])
-
     def test_output_files_default_empty(self) -> None:
         cfg = DockerConfig(image="test-image")
         self.assertEqual(cfg.output_files, [])
@@ -582,7 +578,6 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
 
     def _make_config(
         self,
-        crlf_files: list[str] | None = None,
         output_files: list[str] | None = None,
     ) -> DockerConfig:
         return DockerConfig(
@@ -596,7 +591,6 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
             ],
             uid=1000,
             gid=1000,
-            crlf_files=crlf_files or [],
             output_files=output_files or [],
         )
 
@@ -616,15 +610,6 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         shell_script = cmd[-1]  # Last arg after sh -c
         self.assertIn("tar -cf", shell_script)
         self.assertIn("tar -xf", shell_script)
-
-    def test_crlf_normalization_included(self) -> None:
-        """CRLF files are normalized in the shell script."""
-        cfg = self._make_config(crlf_files=["Makefile", "configure"])
-        cmd = cfg.build_windows_run_cmd("make", "all")
-        shell_script = cmd[-1]
-        self.assertIn("Makefile", shell_script)
-        self.assertIn("configure", shell_script)
-        self.assertIn("sed", shell_script)
 
     def test_output_files_copied_back(self) -> None:
         """Output files are copied from container to host."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -505,7 +505,7 @@ class TestZScriptRun(unittest.TestCase):
             log_mod.set_json_mode(False)
 
     @patch("nanvix_zutil.script.is_windows", return_value=True)
-    def test_run_uses_windows_cmd_when_configured(self, _mock: object) -> None:
+    def test_run_uses_windows_cmd_on_windows(self, _mock: object) -> None:
         """run() delegates to build_windows_run_cmd on Windows."""
         script = ZScript(Path(self._tmpdir.name))
         script.docker = DockerConfig(
@@ -518,8 +518,6 @@ class TestZScriptRun(unittest.TestCase):
             ],
             uid=1000,
             gid=1000,
-            crlf_files=["Makefile"],
-            output_files=["output.elf"],
         )
         captured_cmds: list[list[str]] = []
 
@@ -539,7 +537,7 @@ class TestZScriptRun(unittest.TestCase):
     @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_run_dispatch_windows_default_docker(self, _mock: object) -> None:
         """run() uses build_windows_run_cmd on Windows even with default
-        (empty) crlf_files and output_files — the dispatch no longer requires
+        (empty) output_files — the dispatch no longer requires
         these fields to be populated."""
         script = ZScript(Path(self._tmpdir.name))
         script.docker = DockerConfig(
@@ -552,7 +550,7 @@ class TestZScriptRun(unittest.TestCase):
             ],
             uid=1000,
             gid=1000,
-            # crlf_files and output_files intentionally left as defaults ([])
+            # output_files intentionally left as defaults ([])
         )
         captured_cmds: list[list[str]] = []
 
@@ -566,7 +564,7 @@ class TestZScriptRun(unittest.TestCase):
         self.assertTrue(captured_cmds)
         cmd = captured_cmds[0]
         # Should still use sh -c (Windows tar-copy mode) even without
-        # crlf_files/output_files.
+        # output_files.
         self.assertIn("sh", cmd)
         self.assertIn("-c", cmd)
 


### PR DESCRIPTION
## Summary

Replaces the fragile per-file `crlf_files` list with a blanket `find + sed` normalization that runs automatically on all text files after tar extraction into the container. Also simplifies the Windows dispatch condition to always use the tar-copy strategy on Windows, and deprecates the now-inert `crlf_files` field with a removal target of v0.9.0.

Closes #88

## Commits

```
c582ee8 [doc] E: Add removal timeline to crlf_files
2a69280 [tests] E: Address review nits
4572ccb [tests] E: Update CRLF test coverage
891e2be [doc] E: Update stale CRLF docstring
b959848 [zutils] E: Deprecate crlf_files field
f0f88e3 [zutils] E: Blanket CRLF normalization
```

## Diff summary

```
src/nanvix_zutil/docker.py | 39 ++++++++++++++++++++++++++-------------
 tests/test_docker.py       | 21 +++++++++++++++------
 tests/test_script.py       |  4 +---
 3 files changed, 42 insertions(+), 22 deletions(-)
```