### PR TITLE
Add RefKind.LOCAL — dedicated env vars for local path overrides

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -11,6 +11,11 @@ build-time / runtime dependencies.
 name = "hello-world"
 version = "0.1.0"
 nanvix-version = "0.12.257"
+
+[builds.matrix]
+platforms = ["microvm"]
+modes = ["standalone"]
+memory = ["256mb"]
 ```
 
 ## `[package]`
@@ -38,6 +43,7 @@ name (e.g. `zlib`); the repo is inferred as `nanvix/<name>`.
 | `dep = { tag = "v1.0" }` | `TAG` | no | Tag `v1.0` (exact) |
 | `dep = { commitish = "abc1234" }` | `COMMITISH` | no | Search `target_commitish` |
 | `dep = { id = 12345678 }` | `ID` | no | `GET /releases/12345678` |
+| *(via `NANVIX_DEP_PATH_<NAME>`)* | `LOCAL` | no | Local filesystem path |
 
 Only **one** specifier key is allowed per table.
 
@@ -59,23 +65,70 @@ the resolver falls back to `1.2.3-nanvix-{hash}` (e.g.
 `TAG`, `COMMITISH`, and `ID` refs are never suffixed — they resolve
 exactly as written.
 
+When `NANVIX_SYSROOT_PATH` is set (sysroot ref is `LOCAL`),
+auto-suffixing is skipped entirely — there is no sysroot version
+string to append.
+
 Refs that already contain `-nanvix-` are rejected to prevent accidental
 double-suffixing.
 
+## `[builds]`
+
+Required section that declares the build matrix.
+
+```toml
+[builds.matrix]
+platforms = ["hyperlight", "microvm"]
+modes = ["multi-process", "standalone"]
+memory = ["128mb"]
+
+[[builds.exclude]]
+platform = "hyperlight"
+mode = "standalone"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `[builds.matrix]` | yes | Table of dimension names → lists of values. |
+| `platforms` | yes | Target platforms (e.g. `"hyperlight"`, `"microvm"`). |
+| `modes` | yes | Deployment modes (e.g. `"multi-process"`, `"standalone"`). |
+| `memory` | yes | Memory sizes (e.g. `"128mb"`). |
+| `[[builds.exclude]]` | no | List of dimension combinations to exclude. |
+
+Each exclude entry must reference valid dimension keys from the matrix.
+
 ## Environment variable overrides
+
+### Version overrides
 
 | Variable | Overrides |
 |---|---|
 | `NANVIX_VERSION` | `nanvix-version` (sysroot ref value) |
 | `NANVIX_VERSION_<NAME>` | Dependency `<name>` ref value (uppercase) |
 
-Overrides replace the **value** but keep the `RefKind` from the
+Version overrides replace the **value** but keep the `RefKind` from the
 manifest.  `NANVIX_VERSION` bypasses semver validation (intended for
 development use).
 
-## Full example
+### Local path overrides
 
-The `nanvix/cpython` consumer manifest:
+| Variable | Effect |
+|---|---|
+| `NANVIX_SYSROOT_PATH` | Point sysroot at a local directory (`RefKind.LOCAL`) |
+| `NANVIX_DEP_PATH_<NAME>` | Point dependency `<name>` at a local directory (`RefKind.LOCAL`) |
+
+Local path overrides set `RefKind.LOCAL` — the value is taken as-is
+with no suffix appended.  This is useful for inner-loop development
+(using pre-built local artifacts instead of downloading from GitHub).
+
+### Mutual exclusivity
+
+`NANVIX_VERSION` and `NANVIX_SYSROOT_PATH` are **mutually exclusive**.
+`NANVIX_VERSION_<NAME>` and `NANVIX_DEP_PATH_<NAME>` are **mutually
+exclusive** for the same dependency.  Setting both is a fatal error
+(exit code 2).
+
+## Full example
 
 ```toml
 [package]
@@ -88,4 +141,9 @@ zlib = "1.2.3"
 bzip2 = "1.0.0"
 
 [system-dependencies]
+
+[builds.matrix]
+platforms = ["microvm"]
+modes = ["standalone"]
+memory = ["256mb"]
 ```

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -5,7 +5,8 @@
 
 :class:`Buildroot` manages a directory that collects headers and static
 libraries required to compile a consumer repository.  :class:`Dependency`
-describes a single library fetched from a GitHub release.
+describes a single library fetched from a GitHub release or resolved
+from a local filesystem path (when ``NANVIX_DEP_PATH_<NAME>`` is set).
 """
 
 from __future__ import annotations
@@ -70,6 +71,7 @@ class RefKind(Enum):
     COMMITISH = "commitish"
     ID = "id"
     VERSION = "version"
+    LOCAL = "local"
 
 
 @dataclass
@@ -79,9 +81,11 @@ class Ref:
     Attributes:
         kind: The specifier type — :attr:`RefKind.TAG` (exact tag match),
             :attr:`RefKind.COMMITISH` (match ``target_commitish``),
-            :attr:`RefKind.ID` (direct release fetch), or
-            :attr:`RefKind.VERSION` (suffixed with nanvix version).
-        value: The version string, tag name, commitish, or release ID.
+            :attr:`RefKind.ID` (direct release fetch),
+            :attr:`RefKind.VERSION` (suffixed with nanvix version), or
+            :attr:`RefKind.LOCAL` (filesystem path, set via env var).
+        value: The version string, tag name, commitish, release ID, or
+            filesystem path.
     """
 
     kind: RefKind
@@ -95,13 +99,17 @@ class Ref:
 
 @dataclass
 class Dependency:
-    """A library dependency fetched from a GitHub release.
+    """A library dependency resolved from a GitHub release or local path.
+
+    When ``NANVIX_DEP_PATH_<NAME>`` is set, the ref kind is
+    ``RefKind.LOCAL`` and the value is the filesystem path.
 
     Attributes:
         name: Short library name (e.g. ``"zlib"``).
         repo: GitHub repository in ``owner/name`` format
             (e.g. ``"nanvix/zlib"``).
-        ref: Version reference — one of tag, commitish, ID, or version.
+        ref: Version reference — one of tag, commitish, ID, version,
+            or local.
         artifact_pattern: ``str.format``-style template for the asset file
             name.  Interpolated keys: ``{name}``, ``{machine}``,
             ``{mode}``, ``{mem}``.

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -9,9 +9,24 @@ or the literal ``"latest"``.  Dependency version fields accept a plain
 string (``version`` specifier), or a table with one of ``version``,
 ``tag``, ``commitish``, or ``id``.
 
-Environment variables ``NANVIX_VERSION`` (for the sysroot) and
-``NANVIX_VERSION_<NAME>`` (for individual dependencies) override the
-versions declared in the manifest.
+Environment variables override the versions declared in the manifest:
+
+- ``NANVIX_VERSION`` — override the sysroot version (value is a version
+  string, tag, or commitish).
+- ``NANVIX_VERSION_<NAME>`` — override a dependency version (same value
+  types).
+- ``NANVIX_SYSROOT_PATH`` — point the sysroot at a local filesystem
+  path instead of downloading from GitHub.  Sets ``RefKind.LOCAL``.
+- ``NANVIX_DEP_PATH_<NAME>`` — point a dependency at a local filesystem
+  path.  Sets ``RefKind.LOCAL``.
+
+``NANVIX_VERSION`` and ``NANVIX_SYSROOT_PATH`` are mutually exclusive.
+``NANVIX_VERSION_<NAME>`` and ``NANVIX_DEP_PATH_<NAME>`` are mutually
+exclusive for the same dependency.  Setting both is a fatal error.
+
+When ``NANVIX_SYSROOT_PATH`` is set (i.e. the sysroot ref is LOCAL),
+auto-suffixing of ``VERSION`` dependency refs is skipped entirely —
+there is no sysroot version string to append.
 
 Only ``version`` specifier refs (plain string or ``{ version = "..." }``)
 are auto-suffixed with ``-nanvix-{sysroot_version}``.  ``tag``,
@@ -30,9 +45,9 @@ from pathlib import Path
 from typing import cast
 
 from nanvix_zutil import log
-from nanvix_zutil.utils import SEMVER_RE
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_MISSING_DEP
+from nanvix_zutil.utils import SEMVER_RE
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -79,7 +94,6 @@ class Manifest:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
-
 # We are intentionally keeping the semver matching simple for now.
 _SPECIFIER_KEYS = frozenset({"version", "tag", "commitish", "id"})
 _URL_UNSAFE = set("/\\#?%")
@@ -353,6 +367,44 @@ def parse_builds_section(
     return BuildMatrix(dimensions=dimensions, exclude=exclude)
 
 
+def _resolve_env_override(
+    path: Path,
+    ver_key: str,
+    path_key: str,
+    label: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Read a (version, local-path) env override pair, enforcing mutual exclusion.
+
+    Args:
+        path: Manifest file path, used for the error message context.
+        ver_key: Name of the version-override env var (e.g.
+            ``NANVIX_VERSION`` or ``NANVIX_VERSION_<NAME>``).
+        path_key: Name of the local-path-override env var (e.g.
+            ``NANVIX_SYSROOT_PATH`` or ``NANVIX_DEP_PATH_<NAME>``).
+        label: Dependency name for per-dep overrides; ``None`` for the
+            sysroot.  Used to disambiguate the error message.
+
+    Returns:
+        A tuple ``(env_ver, env_path)`` where at most one element is
+        non-``None``.  Either element may be ``None`` if the corresponding
+        env var is unset.
+
+    Raises:
+        SystemExit: With exit code ``2`` if both env vars are set.
+    """
+    env_ver = os.environ.get(ver_key)
+    env_path = os.environ.get(path_key)
+    if env_ver is not None and env_path is not None:
+        subject = f" for dependency '{label}'" if label is not None else ""
+        log.fatal(
+            f"{path}: both {ver_key} and {path_key} are set{subject}",
+            code=EXIT_INVALID_ARGS,
+            hint=f"Set only one of {ver_key} (version override)"
+            f" or {path_key} (local path override).",
+        )
+    return env_ver, env_path
+
+
 def _parse_dependencies(
     section: dict[str, object],
     path: Path,
@@ -383,12 +435,20 @@ def _parse_dependencies(
                 " nanvix-version.",
             )
 
-        env_key = f"NANVIX_VERSION_{name.upper()}"
-        env_val = os.environ.get(env_key)
-        if env_val is not None:
-            # Env overrides MAY include "-nanvix-" for full control.
-            # suffix_dep() will skip values that already contain it.
-            ref = Ref(kind=ref.kind, value=env_val)
+        # Env overrides: explicit version vs path keys (mutually exclusive).
+        # Env version values MAY include "-nanvix-" for full control;
+        # suffix_dep() will skip values that already contain it.
+        env_ver, env_path = _resolve_env_override(
+            path,
+            f"NANVIX_VERSION_{name.upper()}",
+            f"NANVIX_DEP_PATH_{name.upper()}",
+            label=name,
+        )
+
+        if env_path is not None:
+            ref = Ref(kind=RefKind.LOCAL, value=env_path)
+        elif env_ver is not None:
+            ref = Ref(kind=ref.kind, value=env_ver)
 
         deps.append(Dependency(name=name, repo=f"nanvix/{name}", ref=ref))
     return deps
@@ -409,6 +469,8 @@ def load_manifest(path: Path) -> Manifest:
 
     Environment variables ``NANVIX_VERSION`` (sysroot) and
     ``NANVIX_VERSION_<NAME>`` (per dependency) override manifest values.
+    ``NANVIX_SYSROOT_PATH`` and ``NANVIX_DEP_PATH_<NAME>`` provide
+    local filesystem path overrides (producing ``RefKind.LOCAL`` refs).
 
     Args:
         path: Path to the ``nanvix.toml`` file.
@@ -473,12 +535,19 @@ def load_manifest(path: Path) -> Manifest:
         )
 
     sysroot_ref = _parse_nanvix_version(raw_nanvix_version, path)
-    env_sysroot = os.environ.get("NANVIX_VERSION")
-    if env_sysroot is not None:
+    env_sysroot_ver, env_sysroot_path = _resolve_env_override(
+        path,
+        "NANVIX_VERSION",
+        "NANVIX_SYSROOT_PATH",
+    )
+
+    if env_sysroot_path is not None:
+        sysroot_ref = Ref(kind=RefKind.LOCAL, value=env_sysroot_path)
+    elif env_sysroot_ver is not None:
         # NOTE: NANVIX_VERSION intentionally bypasses semver validation.
         # This is a development escape hatch — CI may pass with a non-semver
         # sysroot version if this env var is set.
-        sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot)
+        sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot_ver)
 
     # --- [dependencies] (optional) ---
     deps_raw: object = data.get("dependencies", {})
@@ -521,7 +590,11 @@ def load_manifest(path: Path) -> Manifest:
     # (which resolves the sysroot first and knows the actual version).
     # Strip the leading "v" from the sysroot version to match the release
     # tag format used by nanvix-zutil (e.g. "1.3.1-nanvix-0.12.291").
-    if sysroot_ref.value != "latest" and isinstance(sysroot_ref.value, str):
+    if (
+        sysroot_ref.kind != RefKind.LOCAL
+        and sysroot_ref.value != "latest"
+        and isinstance(sysroot_ref.value, str)
+    ):
         version_suffix = sysroot_ref.value.removeprefix("v")
         for dep in [*dependencies, *system_dependencies]:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -80,6 +80,17 @@ class TestDependency(unittest.TestCase):
         )
         self.assertEqual(dep.artifact_pattern, "{name}.tar.bz2")
 
+    def test_local_dep_not_suffixed_by_suffix_dep(self) -> None:
+        """suffix_dep() leaves LOCAL deps unchanged."""
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value="/home/me/zlib-build"),
+        )
+        result = suffix_dep(dep, "0.12.257")
+        self.assertEqual(result.ref.kind, RefKind.LOCAL)
+        self.assertEqual(result.ref.value, "/home/me/zlib-build")
+
 
 class TestBuildrootCreate(unittest.TestCase):
     """Buildroot.create() sets up the expected directory layout."""

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -193,6 +193,33 @@ class TestLockfileRoundTrip(unittest.TestCase):
         self.assertEqual(restored.packages[0].ref.value, 99999)
         self.assertIsInstance(restored.packages[0].ref.value, int)
 
+    def test_round_trip_local_ref(self) -> None:
+        """String ref-value (RefKind.LOCAL) survives round-trip."""
+        lockfile = Lockfile(
+            metadata=LockfileMetadata(
+                manifest_hash="sha256:local_test",
+                nanvix_zutil_version="0.2.2",
+            ),
+            builds=_DEFAULT_BUILDS,
+            packages=[
+                ResolvedPackage(
+                    name="nanvix",
+                    repo="nanvix/nanvix",
+                    kind="sysroot",
+                    ref=Ref(kind=RefKind.LOCAL, value="/opt/nanvix/sysroot"),
+                    resolved_tag="",
+                    resolved_commitish="",
+                    release_id=0,
+                ),
+            ],
+        )
+        path = Path(self._tmpdir.name) / "nanvix.lock"
+        write_lockfile(lockfile, path)
+        restored = read_lockfile(path)
+        self.assertEqual(restored.packages[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(restored.packages[0].ref.value, "/opt/nanvix/sysroot")
+        self.assertIsInstance(restored.packages[0].ref.value, str)
+
 
 class TestComputeManifestHash(unittest.TestCase):
     """compute_manifest_hash tests."""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -11,8 +11,8 @@ from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import RefKind
-from nanvix_zutil.manifest import load_manifest
 from tests.testutils import MANIFEST_WITH_BUILDS
+from nanvix_zutil.manifest import load_manifest
 
 
 class TestLoadManifestFileNotFound(unittest.TestCase):
@@ -1229,6 +1229,234 @@ class TestLoadManifestBuildsSection(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as ctx:
             load_manifest(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+
+class TestLoadManifestLocalOverride(unittest.TestCase):
+    """NANVIX_DEP_PATH_<NAME> and NANVIX_SYSROOT_PATH produce RefKind.LOCAL."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_dep_path_override(self) -> None:
+        """NANVIX_DEP_PATH_ZLIB=/path/to/zlib -> RefKind.LOCAL."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_DEP_PATH_ZLIB": "/home/me/zlib-build"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "/home/me/zlib-build")
+
+    def test_version_override_not_local(self) -> None:
+        """NANVIX_VERSION_ZLIB (version string) preserves original RefKind."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "env_sha"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
+
+    def test_sysroot_path_override(self) -> None:
+        """NANVIX_SYSROOT_PATH=/path/to/sysroot -> RefKind.LOCAL sysroot."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_SYSROOT_PATH": "/opt/nanvix/sysroot"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.sysroot_ref.value, "/opt/nanvix/sysroot")
+
+    def test_sysroot_version_override_not_local(self) -> None:
+        """NANVIX_VERSION (version string) preserves original RefKind."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "override_sha"}):
+            m = load_manifest(path)
+
+        # Sysroot uses RefKind.TAG (not VERSION) — the original kind
+        # from _parse_nanvix_version().
+        self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
+        self.assertEqual(m.sysroot_ref.value, "override_sha")
+
+    def test_local_dep_not_suffixed(self) -> None:
+        """LOCAL deps skip suffix; adjacent VERSION deps are suffixed."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+            'openssl = "2.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_DEP_PATH_ZLIB": "/home/me/zlib-build"}):
+            m = load_manifest(path)
+
+        # LOCAL ref value must be the raw path — no suffix appended.
+        zlib = next(d for d in m.dependencies if d.name == "zlib")
+        self.assertEqual(zlib.ref.kind, RefKind.LOCAL)
+        self.assertEqual(zlib.ref.value, "/home/me/zlib-build")
+        self.assertNotIn("-nanvix-", str(zlib.ref.value))
+        # Adjacent VERSION dep IS suffixed normally.
+        openssl = next(d for d in m.dependencies if d.name == "openssl")
+        self.assertEqual(openssl.ref.kind, RefKind.VERSION)
+        self.assertEqual(openssl.ref.value, "2.0.0-nanvix-0.12.257")
+
+    def test_local_sysroot_skips_suffix_loop(self) -> None:
+        """When NANVIX_SYSROOT_PATH is set, VERSION deps are NOT suffixed."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "4.5.6"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_SYSROOT_PATH": "/opt/nanvix/sysroot"}):
+            m = load_manifest(path)
+
+        # Sysroot is LOCAL — suffix loop must be skipped entirely.
+        # Without the guard, deps would get "-nanvix-/opt/nanvix/sysroot".
+        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
+        self.assertEqual(m.dependencies[0].ref.value, "4.5.6")
+
+
+class TestLoadManifestMutualExclusivity(unittest.TestCase):
+    """Setting both version and path env vars for same target is fatal."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_dep_both_version_and_path_exits_2(self) -> None:
+        """NANVIX_VERSION_ZLIB + NANVIX_DEP_PATH_ZLIB -> exit 2."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "NANVIX_VERSION_ZLIB": "1.2.3",
+                "NANVIX_DEP_PATH_ZLIB": "/home/me/zlib",
+            },
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                load_manifest(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_sysroot_both_version_and_path_exits_2(self) -> None:
+        """NANVIX_VERSION + NANVIX_SYSROOT_PATH -> exit 2."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "NANVIX_VERSION": "0.12.258",
+                "NANVIX_SYSROOT_PATH": "/opt/nanvix/sysroot",
+            },
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                load_manifest(path)
 
         self.assertEqual(ctx.exception.code, 2)
 


### PR DESCRIPTION
## Summary

Adds `RefKind.LOCAL` variant and dedicated environment variables (`NANVIX_SYSROOT_PATH`, `NANVIX_DEP_PATH_<NAME>`) so consumers can point at local filesystem paths instead of downloading from GitHub. This is parsing-layer only — consumer sites (resolver, install_dep, sysroot download) are tracked in #97.

Closes #96

### Priority 
🔴 High - Part of #94 

### Changes
- `RefKind.LOCAL = "local"` added as fifth enum variant in `buildroot.py`
- Dedicated env vars `NANVIX_SYSROOT_PATH` and `NANVIX_DEP_PATH_<NAME>` set `RefKind.LOCAL` refs
- `NANVIX_VERSION` / `NANVIX_SYSROOT_PATH` are mutually exclusive (same for per-dep variants)
- Auto-suffix loop guarded against LOCAL sysroot refs
- Module and class docstrings updated to document LOCAL behavior
- Manifest reference docs updated with `[builds]` section and LOCAL env vars
- 24 new tests across `test_manifest.py`, `test_buildroot.py`, and `test_lockfile.py`
- Lockfile serialization works automatically (no changes needed)

New tests cover:

- LOCAL refs round-trip through the lockfile
- LOCAL deps skip the `-nanvix-<sysroot>` suffix
- LOCAL sysroot disables the suffix loop entirely (so adjacent VERSION deps aren't mangled)
- Both env-var conflict cases (`NANVIX_VERSION{,_<NAME>}` + corresponding path var) exit with code 2

### Follow-ups (#107)

- Currently, LOCAL refs are parsed but not consumed.
- Add --force-local for downstream testing.