### PR TITLE
Wire local path refs through setup, sysroot, and buildroot

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -13,9 +13,9 @@ version = "0.1.0"
 nanvix-version = "0.12.257"
 
 [builds.matrix]
-platforms = ["hyperlight"]
-modes = ["multi-process"]
-memory = ["128mb"]
+platforms = ["microvm"]
+modes = ["standalone"]
+memory = ["256mb"]
 ```
 
 ## `[package]`
@@ -139,7 +139,7 @@ bzip2 = "1.0.0"
 [system-dependencies]
 
 [builds.matrix]
-platforms = ["hyperlight"]
-modes = ["multi-process"]
-memory = ["128mb"]
+platforms = ["microvm"]
+modes = ["standalone"]
+memory = ["256mb"]
 ```

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -11,6 +11,11 @@ build-time / runtime dependencies.
 name = "hello-world"
 version = "0.1.0"
 nanvix-version = "0.12.257"
+
+[builds.matrix]
+platforms = ["hyperlight"]
+modes = ["multi-process"]
+memory = ["128mb"]
 ```
 
 ## `[package]`
@@ -38,6 +43,7 @@ name (e.g. `zlib`); the repo is inferred as `nanvix/<name>`.
 | `dep = { tag = "v1.0" }` | `TAG` | no | Tag `v1.0` (exact) |
 | `dep = { commitish = "abc1234" }` | `COMMITISH` | no | Search `target_commitish` |
 | `dep = { id = 12345678 }` | `ID` | no | `GET /releases/12345678` |
+| *(via `NANVIX_DEP_PATH_<NAME>`)* | `LOCAL` | no | Local filesystem path |
 
 Only **one** specifier key is allowed per table.
 
@@ -62,20 +68,63 @@ exactly as written.
 Refs that already contain `-nanvix-` are rejected to prevent accidental
 double-suffixing.
 
+## `[builds]`
+
+Required section that declares the build matrix.
+
+```toml
+[builds.matrix]
+platforms = ["hyperlight", "microvm"]
+modes = ["multi-process", "standalone"]
+memory = ["128mb"]
+
+[[builds.exclude]]
+platform = "hyperlight"
+mode = "standalone"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `[builds.matrix]` | yes | Table of dimension names → lists of values. |
+| `platforms` | yes | Target platforms (e.g. `"hyperlight"`, `"microvm"`). |
+| `modes` | yes | Deployment modes (e.g. `"multi-process"`, `"standalone"`). |
+| `memory` | yes | Memory sizes (e.g. `"128mb"`). |
+| `[[builds.exclude]]` | no | List of dimension combinations to exclude. |
+
+Each exclude entry must reference valid dimension keys from the matrix.
+
 ## Environment variable overrides
+
+### Version overrides
 
 | Variable | Overrides |
 |---|---|
 | `NANVIX_VERSION` | `nanvix-version` (sysroot ref value) |
 | `NANVIX_VERSION_<NAME>` | Dependency `<name>` ref value (uppercase) |
 
-Overrides replace the **value** but keep the `RefKind` from the
+Version overrides replace the **value** but keep the `RefKind` from the
 manifest.  `NANVIX_VERSION` bypasses semver validation (intended for
 development use).
 
-## Full example
+### Local path overrides
 
-The `nanvix/cpython` consumer manifest:
+| Variable | Effect |
+|---|---|
+| `NANVIX_SYSROOT_PATH` | Point sysroot at a local directory (`RefKind.LOCAL`) |
+| `NANVIX_DEP_PATH_<NAME>` | Point dependency `<name>` at a local directory (`RefKind.LOCAL`) |
+
+Local path overrides set `RefKind.LOCAL` — the value is taken as-is
+with no suffix appended.  This is useful for inner-loop development
+(using pre-built local artifacts instead of downloading from GitHub).
+
+### Mutual exclusivity
+
+`NANVIX_VERSION` and `NANVIX_SYSROOT_PATH` are **mutually exclusive**.
+`NANVIX_VERSION_<NAME>` and `NANVIX_DEP_PATH_<NAME>` are **mutually
+exclusive** for the same dependency.  Setting both is a fatal error
+(exit code 2).
+
+## Full example
 
 ```toml
 [package]
@@ -88,4 +137,9 @@ zlib = "1.2.3"
 bzip2 = "1.0.0"
 
 [system-dependencies]
+
+[builds.matrix]
+platforms = ["hyperlight"]
+modes = ["multi-process"]
+memory = ["128mb"]
 ```

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -70,6 +70,7 @@ class RefKind(Enum):
     COMMITISH = "commitish"
     ID = "id"
     VERSION = "version"
+    LOCAL = "local"
 
 
 @dataclass
@@ -79,9 +80,11 @@ class Ref:
     Attributes:
         kind: The specifier type — :attr:`RefKind.TAG` (exact tag match),
             :attr:`RefKind.COMMITISH` (match ``target_commitish``),
-            :attr:`RefKind.ID` (direct release fetch), or
-            :attr:`RefKind.VERSION` (suffixed with nanvix version).
-        value: The version string, tag name, commitish, or release ID.
+            :attr:`RefKind.ID` (direct release fetch),
+            :attr:`RefKind.VERSION` (suffixed with nanvix version), or
+            :attr:`RefKind.LOCAL` (filesystem path, set via env var).
+        value: The version string, tag name, commitish, release ID, or
+            filesystem path.
     """
 
     kind: RefKind
@@ -101,7 +104,8 @@ class Dependency:
         name: Short library name (e.g. ``"zlib"``).
         repo: GitHub repository in ``owner/name`` format
             (e.g. ``"nanvix/zlib"``).
-        ref: Version reference — one of tag, commitish, ID, or version.
+        ref: Version reference — one of tag, commitish, ID, version,
+            or local.
         artifact_pattern: ``str.format``-style template for the asset file
             name.  Interpolated keys: ``{name}``, ``{machine}``,
             ``{mode}``, ``{mem}``.

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -98,7 +98,10 @@ class Ref:
 
 @dataclass
 class Dependency:
-    """A library dependency fetched from a GitHub release.
+    """A library dependency resolved from a GitHub release or local path.
+
+    When ``NANVIX_DEP_PATH_<NAME>`` is set, the ref kind is
+    ``RefKind.LOCAL`` and the value is the filesystem path.
 
     Attributes:
         name: Short library name (e.g. ``"zlib"``).

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -10,6 +10,7 @@ describes a single library fetched from a GitHub release.
 
 from __future__ import annotations
 
+import shutil
 import tarfile
 from dataclasses import dataclass, replace as _dc_replace
 from enum import Enum
@@ -56,6 +57,46 @@ def _relative_to_segment(member_path: Path, segment: str) -> str:
         return str(Path(*parts[idx + 1 :]))
     except ValueError:
         return member_path.name
+
+
+def _install_from_directory(
+    src: Path,
+    buildroot: Path,
+    install_libs: list[str] | None,
+    install_headers: list[str] | None,
+) -> None:
+    """Copy ``.a`` and ``.h`` files from a local directory into the buildroot.
+
+    Mirrors the tarball extraction logic: walks ``<src>/lib/`` for ``.a``
+    files and ``<src>/include/`` for ``.h`` files, applying the same
+    selective filters.
+
+    Args:
+        src: Path to the local dependency directory (must contain
+            ``lib/`` and/or ``include/`` subdirectories).
+        buildroot: Path to the buildroot directory.
+        install_libs: List of ``.a`` file names to copy.  ``None``
+            copies all.
+        install_headers: List of header file names to copy.  ``None``
+            copies all.
+    """
+    lib_src = src / "lib"
+    if lib_src.is_dir():
+        for f in lib_src.rglob("*.a"):
+            if install_libs is None or f.name in install_libs:
+                rel = f.relative_to(lib_src)
+                dest = buildroot / "lib" / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(f, dest)
+
+    inc_src = src / "include"
+    if inc_src.is_dir():
+        for f in inc_src.rglob("*.h"):
+            if install_headers is None or f.name in install_headers:
+                rel = f.relative_to(inc_src)
+                dest = buildroot / "include" / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(f, dest)
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +308,11 @@ class Buildroot:
         extracted.  Selected ``.a`` and ``.h`` files are copied into
         ``<buildroot>/lib/`` and ``<buildroot>/include/`` respectively.
 
+        When the dependency ref is ``RefKind.LOCAL``, the GitHub download
+        is skipped entirely.  A local directory is installed via
+        :func:`_install_from_directory`; a local ``.tar.bz2`` file is
+        fed directly to the existing tarball extraction logic.
+
         Args:
             dep: The :class:`Dependency` descriptor.
             machine: Target machine identifier.
@@ -278,25 +324,50 @@ class Buildroot:
                 redundant GitHub API calls when the caller has already
                 resolved the release).
         """
-        asset_name = dep.artifact_pattern.format(
-            name=dep.name,
-            machine=machine,
-            mode=deployment_mode,
-            mem=memory_size,
-        )
+        # --- LOCAL ref: install from filesystem ---
+        if dep.ref.kind == RefKind.LOCAL:
+            local_path = Path(str(dep.ref.value))
+            if local_path.is_dir():
+                log.info(f"Installing {dep.name} from local directory {local_path}…")
+                _install_from_directory(
+                    src=local_path,
+                    buildroot=self.path,
+                    install_libs=dep.install_libs,
+                    install_headers=dep.install_headers,
+                )
+                log.success(f"Installed {dep.name} into buildroot")
+                return
+            if local_path.is_file() and local_path.name.endswith(".tar.bz2"):
+                log.info(f"Installing {dep.name} from local tarball {local_path}…")
+                asset_path: Path = local_path
+            else:
+                log.fatal(
+                    f"Local dependency path '{local_path}' for '{dep.name}'"
+                    " is not a directory or .tar.bz2 file.",
+                    code=EXIT_MISSING_DEP,
+                    hint="Set the path to a directory with lib/ and include/"
+                    " subdirectories, or to a .tar.bz2 archive.",
+                )
+        else:
+            asset_name = dep.artifact_pattern.format(
+                name=dep.name,
+                machine=machine,
+                mode=deployment_mode,
+                mem=memory_size,
+            )
 
-        cache_dir = self.path.parent / "cache"
+            cache_dir = self.path.parent / "cache"
 
-        asset_path = github.download_release_asset(
-            repo=dep.repo,
-            version_specifier=dep.ref.value,
-            asset_name=asset_name,
-            dest=cache_dir,
-            gh_token=gh_token,
-            _release=_release,
-        )
+            asset_path = github.download_release_asset(
+                repo=dep.repo,
+                version_specifier=dep.ref.value,
+                asset_name=asset_name,
+                dest=cache_dir,
+                gh_token=gh_token,
+                _release=_release,
+            )
 
-        log.info(f"Extracting {asset_name}...")
+        log.info(f"Extracting {dep.name}...")
         with tarfile.open(asset_path, "r:bz2") as tf:
             for member in tf.getmembers():
                 member_path = Path(member.name)

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -9,12 +9,20 @@ or the literal ``"latest"``.  Dependency version fields accept a plain
 string (``version`` specifier), or a table with one of ``version``,
 ``tag``, ``commitish``, or ``id``.
 
-Environment variables ``NANVIX_VERSION`` (for the sysroot) and
-``NANVIX_VERSION_<NAME>`` (for individual dependencies) override the
-versions declared in the manifest.  When the override value looks like
-a filesystem path (starts with ``/``, ``./``, ``../``, or a Windows
-drive letter like ``C:\\``), the ref kind is set to ``local`` instead
-of preserving the original kind from the manifest.
+Environment variables override the versions declared in the manifest:
+
+- ``NANVIX_VERSION`` — override the sysroot version (value is a version
+  string, tag, or commitish).
+- ``NANVIX_VERSION_<NAME>`` — override a dependency version (same value
+  types).
+- ``NANVIX_SYSROOT_PATH`` — point the sysroot at a local filesystem
+  path instead of downloading from GitHub.  Sets ``RefKind.LOCAL``.
+- ``NANVIX_DEP_PATH_<NAME>`` — point a dependency at a local filesystem
+  path.  Sets ``RefKind.LOCAL``.
+
+``NANVIX_VERSION`` and ``NANVIX_SYSROOT_PATH`` are mutually exclusive.
+``NANVIX_VERSION_<NAME>`` and ``NANVIX_DEP_PATH_<NAME>`` are mutually
+exclusive for the same dependency.  Setting both is a fatal error.
 
 Only ``version`` specifier refs (plain string or ``{ version = "..." }``)
 are auto-suffixed with ``-nanvix-{sysroot_version}``.  ``tag``,
@@ -82,28 +90,9 @@ class Manifest:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
-
 # We are intentionally keeping the semver matching simple for now.
 _SPECIFIER_KEYS = frozenset({"version", "tag", "commitish", "id"})
 _URL_UNSAFE = set("/\\#?%")
-
-
-def _is_local_path(value: str) -> bool:
-    """Return ``True`` if *value* looks like a filesystem path.
-
-    Detects Unix absolute paths (``/``), home-directory paths (``~/``),
-    relative paths (``./``, ``../``), Windows drive-letter paths
-    (``C:\\``, ``D:/``), and Windows UNC paths (``\\\\server\\share``).
-    """
-    if value.startswith(("/", "./", "../", "~/")):
-        return True
-    # Windows drive letter: C:\, D:/, etc.
-    if len(value) >= 3 and value[1] == ":" and value[2] in ("/", "\\"):
-        return True
-    # Windows UNC path: \\server\share
-    if value.startswith("\\\\"):
-        return True
-    return False
 
 
 def _validate_version_string(raw: str, context: str, path: Path) -> str:
@@ -388,13 +377,24 @@ def _parse_dependencies(
     for name, raw_value in section.items():
         ref = _parse_version_field(raw_value, f"{section_name}.{name}", path)
 
-        env_key = f"NANVIX_VERSION_{name.upper()}"
-        env_val = os.environ.get(env_key)
-        if env_val is not None:
-            if _is_local_path(env_val):
-                ref = Ref(kind=RefKind.LOCAL, value=env_val)
-            else:
-                ref = Ref(kind=ref.kind, value=env_val)
+        env_ver_key = f"NANVIX_VERSION_{name.upper()}"
+        env_path_key = f"NANVIX_DEP_PATH_{name.upper()}"
+        env_ver = os.environ.get(env_ver_key)
+        env_path = os.environ.get(env_path_key)
+
+        if env_ver is not None and env_path is not None:
+            log.fatal(
+                f"{path}: both {env_ver_key} and {env_path_key} are set"
+                f" for dependency '{name}'",
+                code=EXIT_INVALID_ARGS,
+                hint=f"Set only one of {env_ver_key} (version override)"
+                f" or {env_path_key} (local path override).",
+            )
+
+        if env_path is not None:
+            ref = Ref(kind=RefKind.LOCAL, value=env_path)
+        elif env_ver is not None:
+            ref = Ref(kind=ref.kind, value=env_ver)
 
         if (
             ref.kind == RefKind.VERSION
@@ -429,6 +429,8 @@ def load_manifest(path: Path) -> Manifest:
 
     Environment variables ``NANVIX_VERSION`` (sysroot) and
     ``NANVIX_VERSION_<NAME>`` (per dependency) override manifest values.
+    ``NANVIX_SYSROOT_PATH`` and ``NANVIX_DEP_PATH_<NAME>`` provide
+    local filesystem path overrides (producing ``RefKind.LOCAL`` refs).
 
     Args:
         path: Path to the ``nanvix.toml`` file.
@@ -493,15 +495,24 @@ def load_manifest(path: Path) -> Manifest:
         )
 
     sysroot_ref = _parse_nanvix_version(raw_nanvix_version, path)
-    env_sysroot = os.environ.get("NANVIX_VERSION")
-    if env_sysroot is not None:
+    env_sysroot_ver = os.environ.get("NANVIX_VERSION")
+    env_sysroot_path = os.environ.get("NANVIX_SYSROOT_PATH")
+
+    if env_sysroot_ver is not None and env_sysroot_path is not None:
+        log.fatal(
+            f"{path}: both NANVIX_VERSION and NANVIX_SYSROOT_PATH are set",
+            code=EXIT_INVALID_ARGS,
+            hint="Set only one of NANVIX_VERSION (version override)"
+            " or NANVIX_SYSROOT_PATH (local path override).",
+        )
+
+    if env_sysroot_path is not None:
+        sysroot_ref = Ref(kind=RefKind.LOCAL, value=env_sysroot_path)
+    elif env_sysroot_ver is not None:
         # NOTE: NANVIX_VERSION intentionally bypasses semver validation.
         # This is a development escape hatch — CI may pass with a non-semver
         # sysroot version if this env var is set.
-        if _is_local_path(env_sysroot):
-            sysroot_ref = Ref(kind=RefKind.LOCAL, value=env_sysroot)
-        else:
-            sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot)
+        sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot_ver)
 
     # --- [dependencies] (optional) ---
     deps_raw: object = data.get("dependencies", {})

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -541,7 +541,11 @@ def load_manifest(path: Path) -> Manifest:
     # (which resolves the sysroot first and knows the actual version).
     # Strip the leading "v" from the sysroot version to match the release
     # tag format used by nanvix-zutil (e.g. "1.3.1-nanvix-0.12.291").
-    if sysroot_ref.value != "latest" and isinstance(sysroot_ref.value, str):
+    if (
+        sysroot_ref.kind != RefKind.LOCAL
+        and sysroot_ref.value != "latest"
+        and isinstance(sysroot_ref.value, str)
+    ):
         version_suffix = sysroot_ref.value.removeprefix("v")
         for dep in [*dependencies, *system_dependencies]:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -85,7 +85,7 @@ _SPECIFIER_KEYS = frozenset({"version", "tag", "commitish", "id"})
 _URL_UNSAFE = set("/\\#?%")
 
 
-def _is_local_path(value: str) -> bool:  # pyright: ignore[reportUnusedFunction]
+def _is_local_path(value: str) -> bool:
     """Return ``True`` if *value* looks like a filesystem path.
 
     Detects Unix absolute paths (``/``), home-directory paths (``~/``),
@@ -388,7 +388,10 @@ def _parse_dependencies(
         env_key = f"NANVIX_VERSION_{name.upper()}"
         env_val = os.environ.get(env_key)
         if env_val is not None:
-            ref = Ref(kind=ref.kind, value=env_val)
+            if _is_local_path(env_val):
+                ref = Ref(kind=RefKind.LOCAL, value=env_val)
+            else:
+                ref = Ref(kind=ref.kind, value=env_val)
 
         if (
             ref.kind == RefKind.VERSION
@@ -492,7 +495,10 @@ def load_manifest(path: Path) -> Manifest:
         # NOTE: NANVIX_VERSION intentionally bypasses semver validation.
         # This is a development escape hatch — CI may pass with a non-semver
         # sysroot version if this env var is set.
-        sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot)
+        if _is_local_path(env_sysroot):
+            sysroot_ref = Ref(kind=RefKind.LOCAL, value=env_sysroot)
+        else:
+            sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot)
 
     # --- [dependencies] (optional) ---
     deps_raw: object = data.get("dependencies", {})

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -88,15 +88,17 @@ _URL_UNSAFE = set("/\\#?%")
 def _is_local_path(value: str) -> bool:  # pyright: ignore[reportUnusedFunction]
     """Return ``True`` if *value* looks like a filesystem path.
 
-    Detects Unix absolute paths (``/``), relative paths (``./``,
-    ``../``), and Windows drive-letter paths (``C:\\``, ``D:/``).
-    Version strings like ``1.3.1``, ``latest``, or hex commit hashes
-    will never match.
+    Detects Unix absolute paths (``/``), home-directory paths (``~/``),
+    relative paths (``./``, ``../``), Windows drive-letter paths
+    (``C:\\``, ``D:/``), and Windows UNC paths (``\\\\server\\share``).
     """
-    if value.startswith(("/", "./", "../")):
+    if value.startswith(("/", "./", "../", "~/")):
         return True
     # Windows drive letter: C:\, D:/, etc.
     if len(value) >= 3 and value[1] == ":" and value[2] in ("/", "\\"):
+        return True
+    # Windows UNC path: \\server\share
+    if value.startswith("\\\\"):
         return True
     return False
 

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -85,6 +85,22 @@ _SPECIFIER_KEYS = frozenset({"version", "tag", "commitish", "id"})
 _URL_UNSAFE = set("/\\#?%")
 
 
+def _is_local_path(value: str) -> bool:  # pyright: ignore[reportUnusedFunction]
+    """Return ``True`` if *value* looks like a filesystem path.
+
+    Detects Unix absolute paths (``/``), relative paths (``./``,
+    ``../``), and Windows drive-letter paths (``C:\\``, ``D:/``).
+    Version strings like ``1.3.1``, ``latest``, or hex commit hashes
+    will never match.
+    """
+    if value.startswith(("/", "./", "../")):
+        return True
+    # Windows drive letter: C:\, D:/, etc.
+    if len(value) >= 3 and value[1] == ":" and value[2] in ("/", "\\"):
+        return True
+    return False
+
+
 def _validate_version_string(raw: str, context: str, path: Path) -> str:
     """Validate a plain version string.
 

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -11,7 +11,10 @@ string (``version`` specifier), or a table with one of ``version``,
 
 Environment variables ``NANVIX_VERSION`` (for the sysroot) and
 ``NANVIX_VERSION_<NAME>`` (for individual dependencies) override the
-versions declared in the manifest.
+versions declared in the manifest.  When the override value looks like
+a filesystem path (starts with ``/``, ``./``, ``../``, or a Windows
+drive letter like ``C:\\``), the ref kind is set to ``local`` instead
+of preserving the original kind from the manifest.
 
 Only ``version`` specifier refs (plain string or ``{ version = "..." }``)
 are auto-suffixed with ``-nanvix-{sysroot_version}``.  ``tag``,

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -36,6 +36,7 @@ from nanvix_zutil import log
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
+    RefKind,
     extract_nanvix_version,
     extract_nanvix_version_base,
     suffix_dep,
@@ -291,6 +292,10 @@ class ZScript:
                 super().setup()
                 # extra verification or configuration here
         """
+        sysroot_local: Path | None = None
+        if self.manifest.sysroot_ref.kind == RefKind.LOCAL:
+            sysroot_local = Path(str(self.manifest.sysroot_ref.value))
+
         self.sysroot = Sysroot.download(
             machine=self.config.machine,
             deployment_mode=self.config.deployment_mode,
@@ -299,9 +304,28 @@ class ZScript:
             gh_token=self.config.get(CFG_GH_TOKEN),
             dest=self.nanvix_dir / "sysroot",
             config=self.config,
+            local_path=sysroot_local,
         )
         self.sysroot.verify(self.sysroot_required_files())
         self.config.set(CFG_SYSROOT, str(self.sysroot.path))
+
+        # LOCAL sysroot cannot provide a nanvix version for auto-suffixing
+        # VERSION deps.  Error early with a clear message.
+        if self.manifest.sysroot_ref.kind == RefKind.LOCAL:
+            version_deps = [
+                d for d in self.manifest.dependencies if d.ref.kind == RefKind.VERSION
+            ]
+            if version_deps:
+                names = ", ".join(d.name for d in version_deps)
+                log.fatal(
+                    f"Local sysroot cannot be used with VERSION dependencies"
+                    f" ({names}). VERSION deps require a resolvable nanvix"
+                    f" version for auto-suffixing.",
+                    code=EXIT_MISSING_DEP,
+                    hint="Either override each dependency with a local path"
+                    " (NANVIX_DEP_PATH_<NAME>=/path) or use a GitHub sysroot"
+                    " version instead of a local path.",
+                )
 
         # Deferred auto-suffix: when sysroot is "latest", load_manifest()
         # skips suffixing because the real version isn't known yet.  Now
@@ -326,30 +350,37 @@ class ZScript:
                     # deps, then pass the pre-resolved release and enable
                     # cross-mode asset fallback in install_dep().
                     release: dict[str, object] | None = None
-                    base_version = extract_nanvix_version_base(str(dep.ref.value))
-                    if base_version is not None:
-                        release, fb_ver = resolve_release_with_fallback(
-                            repo=dep.repo,
-                            version_specifier=str(dep.ref.value),
-                            base_version=base_version,
-                            gh_token=self.config.get(CFG_GH_TOKEN),
-                        )
-                        # Log when version fallback was used.
-                        # fb_ver is None when the exact tag was found;
-                        # non-None means a fallback release was used.
-                        if fb_ver is not None:
-                            requested_ver = extract_nanvix_version(str(dep.ref.value))
-                            log.info(
-                                f"Version fallback for {dep.name}: "
-                                f"requested nanvix-{requested_ver}, "
-                                f"resolved nanvix-{fb_ver}"
-                            )
+                    if dep.ref.kind == RefKind.LOCAL:
+                        # LOCAL deps skip GitHub resolution entirely.
+                        # install_dep() handles the local path directly.
+                        pass
                     else:
-                        release = resolve_release(
-                            repo=dep.repo,
-                            version_specifier=dep.ref.value,
-                            gh_token=self.config.get(CFG_GH_TOKEN),
-                        )
+                        base_version = extract_nanvix_version_base(str(dep.ref.value))
+                        if base_version is not None:
+                            release, fb_ver = resolve_release_with_fallback(
+                                repo=dep.repo,
+                                version_specifier=str(dep.ref.value),
+                                base_version=base_version,
+                                gh_token=self.config.get(CFG_GH_TOKEN),
+                            )
+                            # Log when version fallback was used.
+                            # fb_ver is None when the exact tag was found;
+                            # non-None means a fallback release was used.
+                            if fb_ver is not None:
+                                requested_ver = extract_nanvix_version(
+                                    str(dep.ref.value)
+                                )
+                                log.info(
+                                    f"Version fallback for {dep.name}: "
+                                    f"requested nanvix-{requested_ver}, "
+                                    f"resolved nanvix-{fb_ver}"
+                                )
+                        else:
+                            release = resolve_release(
+                                repo=dep.repo,
+                                version_specifier=dep.ref.value,
+                                gh_token=self.config.get(CFG_GH_TOKEN),
+                            )
 
                     self.buildroot.install_dep(
                         dep=dep,

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -10,6 +10,7 @@ machine, deployment mode, and memory-size configuration.
 
 from __future__ import annotations
 
+import shutil
 import tarfile
 from pathlib import Path
 
@@ -69,6 +70,7 @@ class Sysroot:
         dest: Path | None = None,
         config: Config | None = None,
         target: str = DEFAULT_TARGET,
+        local_path: Path | None = None,
     ) -> "Sysroot":
         """Download and extract the Nanvix runtime artifact from GitHub releases.
 
@@ -89,6 +91,10 @@ class Sysroot:
                 download the tag is written back to *config* and
                 saved to disk.
             target: Target architecture (default: ``"x86"``).
+            local_path: Optional local directory to copy instead of
+                downloading from GitHub.  When set, *tag* and *gh_token*
+                are ignored and the contents of *local_path* are copied
+                into *dest*.
 
         Returns:
             A :class:`Sysroot` pointing at the extracted directory.
@@ -108,6 +114,25 @@ class Sysroot:
                 hint="Remove or rename this path and re-run"
                 " `./z setup` to download the Nanvix sysroot.",
             )
+
+        # --- LOCAL path: copy from filesystem instead of downloading ---
+        if local_path is not None:
+            if not local_path.is_dir():
+                log.fatal(
+                    f"Local sysroot path '{local_path}' does not exist"
+                    " or is not a directory.",
+                    code=EXIT_MISSING_DEP,
+                    hint="Verify the path in NANVIX_SYSROOT_PATH and re-run"
+                    " `./z setup`.",
+                )
+            log.info(f"Copying local sysroot from {local_path}…")
+            sysroot_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(local_path, sysroot_dir, dirs_exist_ok=True)
+            log.success(f"Sysroot copied to {sysroot_dir}")
+            if config is not None:
+                config.set("sysroot_tag", "")
+                config.save()
+            return Sysroot(sysroot_dir.resolve(), tag="")
 
         release = github.resolve_release(_SYSROOT_REPO, tag, gh_token, semver=True)
         tag_name = release.get("tag_name", "")

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -19,6 +19,7 @@ from nanvix_zutil.buildroot import (
     extract_nanvix_version,
     extract_nanvix_version_base,
     parse_semver_tuple,
+    suffix_dep,
 )
 
 
@@ -78,6 +79,27 @@ class TestDependency(unittest.TestCase):
             artifact_pattern="{name}.tar.bz2",
         )
         self.assertEqual(dep.artifact_pattern, "{name}.tar.bz2")
+
+    def test_local_ref_kind(self) -> None:
+        """RefKind.LOCAL exists and can be used in Dependency."""
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value="/home/me/zlib-build"),
+        )
+        self.assertEqual(dep.ref.kind, RefKind.LOCAL)
+        self.assertEqual(dep.ref.value, "/home/me/zlib-build")
+
+    def test_local_dep_not_suffixed_by_suffix_dep(self) -> None:
+        """suffix_dep() leaves LOCAL deps unchanged."""
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value="/home/me/zlib-build"),
+        )
+        result = suffix_dep(dep, "0.12.257")
+        self.assertEqual(result.ref.kind, RefKind.LOCAL)
+        self.assertEqual(result.ref.value, "/home/me/zlib-build")
 
 
 class TestBuildrootCreate(unittest.TestCase):

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -499,5 +499,162 @@ class TestInstallDepPreResolvedRelease(unittest.TestCase):
         self.assertEqual(captured_releases[0], fake_release)
 
 
+class TestInstallDepLocal(unittest.TestCase):
+    """Buildroot.install_dep() handles LOCAL ref dependencies."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def _setup_buildroot(self) -> Buildroot:
+        dest = Path(self._tmpdir.name) / "br"
+        return Buildroot.create(dest=dest)
+
+    def test_local_directory_copies_libs(self) -> None:
+        """LOCAL directory dep copies .a files into buildroot/lib/."""
+        br = self._setup_buildroot()
+        src = Path(self._tmpdir.name) / "local-dep"
+        (src / "lib").mkdir(parents=True)
+        (src / "lib" / "libz.a").write_bytes(b"lib-content")
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value=str(src)),
+        )
+
+        with patch("nanvix_zutil.github.download_release_asset") as mock_dl:
+            br.install_dep(dep)
+            mock_dl.assert_not_called()
+
+        self.assertTrue((br.path / "lib" / "libz.a").exists())
+
+    def test_local_directory_copies_headers(self) -> None:
+        """LOCAL directory dep copies .h files into buildroot/include/."""
+        br = self._setup_buildroot()
+        src = Path(self._tmpdir.name) / "local-dep"
+        (src / "include").mkdir(parents=True)
+        (src / "include" / "zlib.h").write_bytes(b"header-content")
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value=str(src)),
+        )
+
+        br.install_dep(dep)
+
+        self.assertTrue((br.path / "include" / "zlib.h").exists())
+
+    def test_local_directory_preserves_subdirs(self) -> None:
+        """LOCAL directory dep preserves subdirectory structure."""
+        br = self._setup_buildroot()
+        src = Path(self._tmpdir.name) / "local-dep"
+        (src / "lib" / "engines").mkdir(parents=True)
+        (src / "lib" / "engines" / "libcapi.a").write_bytes(b"engine")
+        (src / "include" / "openssl").mkdir(parents=True)
+        (src / "include" / "openssl" / "ssl.h").write_bytes(b"ssl")
+
+        dep = Dependency(
+            name="openssl",
+            repo="nanvix/openssl",
+            ref=Ref(kind=RefKind.LOCAL, value=str(src)),
+        )
+
+        br.install_dep(dep)
+
+        self.assertTrue((br.path / "lib" / "engines" / "libcapi.a").exists())
+        self.assertTrue((br.path / "include" / "openssl" / "ssl.h").exists())
+
+    def test_local_directory_selective_libs(self) -> None:
+        """LOCAL directory dep respects install_libs filter."""
+        br = self._setup_buildroot()
+        src = Path(self._tmpdir.name) / "local-dep"
+        (src / "lib").mkdir(parents=True)
+        (src / "lib" / "libz.a").write_bytes(b"wanted")
+        (src / "lib" / "libextra.a").write_bytes(b"not-wanted")
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value=str(src)),
+            install_libs=["libz.a"],
+        )
+
+        br.install_dep(dep)
+
+        self.assertTrue((br.path / "lib" / "libz.a").exists())
+        self.assertFalse((br.path / "lib" / "libextra.a").exists())
+
+    def test_local_directory_selective_headers(self) -> None:
+        """LOCAL directory dep respects install_headers filter."""
+        br = self._setup_buildroot()
+        src = Path(self._tmpdir.name) / "local-dep"
+        (src / "include").mkdir(parents=True)
+        (src / "include" / "zlib.h").write_bytes(b"wanted")
+        (src / "include" / "internal.h").write_bytes(b"not-wanted")
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value=str(src)),
+            install_headers=["zlib.h"],
+        )
+
+        br.install_dep(dep)
+
+        self.assertTrue((br.path / "include" / "zlib.h").exists())
+        self.assertFalse((br.path / "include" / "internal.h").exists())
+
+    def test_local_tarball_extracts(self) -> None:
+        """LOCAL tarball dep extracts using existing tarball logic."""
+        br = self._setup_buildroot()
+        archive = _make_tar_bz2(
+            {
+                "sysroot/lib/libz.a": b"lib-content",
+                "sysroot/include/zlib.h": b"header-content",
+            }
+        )
+        tarball = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        tarball.write_bytes(archive)
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value=str(tarball)),
+        )
+
+        with patch("nanvix_zutil.github.download_release_asset") as mock_dl:
+            br.install_dep(dep)
+            mock_dl.assert_not_called()
+
+        self.assertTrue((br.path / "lib" / "libz.a").exists())
+        self.assertTrue((br.path / "include" / "zlib.h").exists())
+
+    def test_local_invalid_path_exits(self) -> None:
+        """LOCAL ref pointing to non-existent path triggers fatal error."""
+        br = self._setup_buildroot()
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(
+                kind=RefKind.LOCAL,
+                value=str(Path(self._tmpdir.name) / "does-not-exist"),
+            ),
+        )
+
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                br.install_dep(dep)
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -193,6 +193,31 @@ class TestLockfileRoundTrip(unittest.TestCase):
         self.assertEqual(restored.packages[0].ref.value, 99999)
         self.assertIsInstance(restored.packages[0].ref.value, int)
 
+    def test_round_trip_local_ref(self) -> None:
+        """String ref-value (RefKind.LOCAL) survives round-trip."""
+        lockfile = Lockfile(
+            metadata=LockfileMetadata(
+                manifest_hash="sha256:local_test",
+                nanvix_zutil_version="0.2.2",
+            ),
+            packages=[
+                ResolvedPackage(
+                    name="nanvix",
+                    repo="nanvix/nanvix",
+                    kind="sysroot",
+                    ref=Ref(kind=RefKind.LOCAL, value="/opt/nanvix/sysroot"),
+                    resolved_tag="",
+                    resolved_commitish="",
+                    release_id=0,
+                ),
+            ],
+        )
+        path = Path(self._tmpdir.name) / "nanvix.lock"
+        write_lockfile(lockfile, path)
+        restored = read_lockfile(path)
+        self.assertEqual(restored.packages[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(restored.packages[0].ref.value, "/opt/nanvix/sysroot")
+
 
 class TestComputeManifestHash(unittest.TestCase):
     """compute_manifest_hash tests."""

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -200,6 +200,7 @@ class TestLockfileRoundTrip(unittest.TestCase):
                 manifest_hash="sha256:local_test",
                 nanvix_zutil_version="0.2.2",
             ),
+            builds=_DEFAULT_BUILDS,
             packages=[
                 ResolvedPackage(
                     name="nanvix",

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -217,6 +217,7 @@ class TestLockfileRoundTrip(unittest.TestCase):
         restored = read_lockfile(path)
         self.assertEqual(restored.packages[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(restored.packages[0].ref.value, "/opt/nanvix/sysroot")
+        self.assertIsInstance(restored.packages[0].ref.value, str)
 
 
 class TestComputeManifestHash(unittest.TestCase):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -12,10 +12,7 @@ from unittest.mock import patch
 import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import RefKind
 from tests.testutils import MANIFEST_WITH_BUILDS
-from nanvix_zutil.manifest import (
-    _is_local_path,  # pyright: ignore[reportPrivateUsage]
-    load_manifest,
-)
+from nanvix_zutil.manifest import load_manifest
 
 
 class TestLoadManifestFileNotFound(unittest.TestCase):
@@ -1032,7 +1029,6 @@ class TestLoadManifestTypeValidation(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
-<<<<<<< HEAD
 class TestLoadManifestBuildsSection(unittest.TestCase):
     """Tests for the required [builds] section in nanvix.toml."""
 
@@ -1187,53 +1183,10 @@ class TestLoadManifestBuildsSection(unittest.TestCase):
             load_manifest(path)
 
         self.assertEqual(ctx.exception.code, 2)
-||||||| parent of f129376 ([tests] F: Add tests for RefKind.LOCAL)
-=======
-class TestIsLocalPath(unittest.TestCase):
-    """_is_local_path() detects filesystem paths correctly."""
-
-    def test_unix_absolute(self) -> None:
-        self.assertTrue(_is_local_path("/home/me/zlib-build"))
-
-    def test_unix_root(self) -> None:
-        self.assertTrue(_is_local_path("/"))
-
-    def test_relative_dot_slash(self) -> None:
-        self.assertTrue(_is_local_path("./local-build"))
-
-    def test_relative_dot_dot_slash(self) -> None:
-        self.assertTrue(_is_local_path("../sibling/build"))
-
-    def test_tilde_home(self) -> None:
-        self.assertTrue(_is_local_path("~/nanvix"))
-
-    def test_windows_drive_backslash(self) -> None:
-        self.assertTrue(_is_local_path("C:\\Users\\me\\nanvix"))
-
-    def test_windows_drive_forward_slash(self) -> None:
-        self.assertTrue(_is_local_path("D:/builds/nanvix"))
-
-    def test_windows_unc(self) -> None:
-        self.assertTrue(_is_local_path("\\\\server\\share"))
-
-    def test_semver_string(self) -> None:
-        self.assertFalse(_is_local_path("1.3.1"))
-
-    def test_latest(self) -> None:
-        self.assertFalse(_is_local_path("latest"))
-
-    def test_v_prefixed_version(self) -> None:
-        self.assertFalse(_is_local_path("v0.12.291"))
-
-    def test_commit_hash(self) -> None:
-        self.assertFalse(_is_local_path("b7a6a3c"))
-
-    def test_tag_string(self) -> None:
-        self.assertFalse(_is_local_path("v1.0.0-nanvix-abc"))
 
 
 class TestLoadManifestLocalOverride(unittest.TestCase):
-    """Env var overrides with filesystem paths produce RefKind.LOCAL."""
+    """NANVIX_DEP_PATH_<NAME> and NANVIX_SYSROOT_PATH produce RefKind.LOCAL."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -1243,8 +1196,8 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
         self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
-    def test_dep_override_unix_path(self) -> None:
-        """NANVIX_VERSION_ZLIB=/path/to/zlib -> RefKind.LOCAL."""
+    def test_dep_path_override(self) -> None:
+        """NANVIX_DEP_PATH_ZLIB=/path/to/zlib -> RefKind.LOCAL."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -1253,16 +1206,21 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             'nanvix-version = "0.12.257"\n'
             "[dependencies]\n"
             'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
-        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/home/me/zlib-build"}):
+        with patch.dict(os.environ, {"NANVIX_DEP_PATH_ZLIB": "/home/me/zlib-build"}):
             m = load_manifest(path)
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.value, "/home/me/zlib-build")
 
-    def test_dep_override_windows_path(self) -> None:
-        """NANVIX_VERSION_ZLIB=C:\\path -> RefKind.LOCAL."""
+    def test_dep_path_override_windows(self) -> None:
+        """NANVIX_DEP_PATH_ZLIB=C:\\path -> RefKind.LOCAL."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -1271,16 +1229,21 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             'nanvix-version = "0.12.257"\n'
             "[dependencies]\n"
             'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
-        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "C:\\Users\\me\\zlib"}):
+        with patch.dict(os.environ, {"NANVIX_DEP_PATH_ZLIB": "C:\\Users\\me\\zlib"}):
             m = load_manifest(path)
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.value, "C:\\Users\\me\\zlib")
 
-    def test_dep_override_relative_path(self) -> None:
-        """NANVIX_VERSION_ZLIB=./local-build -> RefKind.LOCAL."""
+    def test_dep_path_override_relative(self) -> None:
+        """NANVIX_DEP_PATH_ZLIB=./local-build -> RefKind.LOCAL."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -1289,16 +1252,21 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             'nanvix-version = "0.12.257"\n'
             "[dependencies]\n"
             'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
-        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "./local-build"}):
+        with patch.dict(os.environ, {"NANVIX_DEP_PATH_ZLIB": "./local-build"}):
             m = load_manifest(path)
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.value, "./local-build")
 
-    def test_dep_override_version_string_not_local(self) -> None:
-        """Non-path env var preserves original RefKind."""
+    def test_version_override_not_local(self) -> None:
+        """NANVIX_VERSION_ZLIB (version string) preserves original RefKind."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -1307,6 +1275,11 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             'nanvix-version = "0.12.257"\n'
             "[dependencies]\n"
             'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "env_sha"}):
@@ -1314,8 +1287,8 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
 
-    def test_sysroot_override_unix_path(self) -> None:
-        """NANVIX_VERSION=/path/to/sysroot -> RefKind.LOCAL sysroot."""
+    def test_sysroot_path_override(self) -> None:
+        """NANVIX_SYSROOT_PATH=/path/to/sysroot -> RefKind.LOCAL sysroot."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -1324,28 +1297,39 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             'nanvix-version = "0.12.257"\n'
             "[dependencies]\n"
             'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
-        with patch.dict(os.environ, {"NANVIX_VERSION": "/opt/nanvix/sysroot"}):
+        with patch.dict(os.environ, {"NANVIX_SYSROOT_PATH": "/opt/nanvix/sysroot"}):
             m = load_manifest(path)
 
         self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
         self.assertEqual(m.sysroot_ref.value, "/opt/nanvix/sysroot")
 
-    def test_sysroot_override_version_string_not_local(self) -> None:
-        """Non-path NANVIX_VERSION preserves original RefKind."""
+    def test_sysroot_version_override_not_local(self) -> None:
+        """NANVIX_VERSION (version string) preserves original RefKind."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
             'nanvix-version = "0.12.257"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
         with patch.dict(os.environ, {"NANVIX_VERSION": "override_sha"}):
             m = load_manifest(path)
 
-        # Sysroot uses RefKind.TAG (not VERSION) — the original kind from the manifest.
+        # Sysroot uses RefKind.TAG (not VERSION) — the original kind
+        # from _parse_nanvix_version().
         self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
         self.assertEqual(m.sysroot_ref.value, "override_sha")
 
@@ -1360,9 +1344,14 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             "[dependencies]\n"
             'zlib = "1.0.0"\n'
             'openssl = "2.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
-        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/home/me/zlib-build"}):
+        with patch.dict(os.environ, {"NANVIX_DEP_PATH_ZLIB": "/home/me/zlib-build"}):
             m = load_manifest(path)
 
         # LOCAL ref value must be the raw path — no suffix appended.
@@ -1376,7 +1365,7 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
         self.assertEqual(openssl.ref.value, "2.0.0-nanvix-0.12.257")
 
     def test_local_sysroot_skips_suffix_loop(self) -> None:
-        """When NANVIX_VERSION is a path, VERSION deps are NOT suffixed."""
+        """When NANVIX_SYSROOT_PATH is set, VERSION deps are NOT suffixed."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -1385,9 +1374,14 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             'nanvix-version = "0.12.257"\n'
             "[dependencies]\n"
             'zlib = "4.5.6"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
         )
 
-        with patch.dict(os.environ, {"NANVIX_VERSION": "/opt/nanvix/sysroot"}):
+        with patch.dict(os.environ, {"NANVIX_SYSROOT_PATH": "/opt/nanvix/sysroot"}):
             m = load_manifest(path)
 
         # Sysroot is LOCAL — suffix loop must be skipped entirely.
@@ -1395,7 +1389,74 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
         self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
         self.assertEqual(m.dependencies[0].ref.value, "4.5.6")
->>>>>>> f129376 ([tests] F: Add tests for RefKind.LOCAL)
+
+
+class TestLoadManifestMutualExclusivity(unittest.TestCase):
+    """Setting both version and path env vars for same target is fatal."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_dep_both_version_and_path_exits_2(self) -> None:
+        """NANVIX_VERSION_ZLIB + NANVIX_DEP_PATH_ZLIB -> exit 2."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "NANVIX_VERSION_ZLIB": "1.2.3",
+                "NANVIX_DEP_PATH_ZLIB": "/home/me/zlib",
+            },
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                load_manifest(path)
+
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_sysroot_both_version_and_path_exits_2(self) -> None:
+        """NANVIX_VERSION + NANVIX_SYSROOT_PATH -> exit 2."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[builds]\n"
+            "[builds.matrix]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["multi-process"]\n'
+            'memory = ["128mb"]\n'
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "NANVIX_VERSION": "0.12.258",
+                "NANVIX_SYSROOT_PATH": "/opt/nanvix/sysroot",
+            },
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                load_manifest(path)
+
+        self.assertEqual(ctx.exception.code, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import RefKind
-from nanvix_zutil.manifest import load_manifest
+from nanvix_zutil.manifest import _is_local_path, load_manifest  # pyright: ignore[reportPrivateUsage]
 from tests.testutils import MANIFEST_WITH_BUILDS
 
 
@@ -1029,6 +1029,7 @@ class TestLoadManifestTypeValidation(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
+<<<<<<< HEAD
 class TestLoadManifestBuildsSection(unittest.TestCase):
     """Tests for the required [builds] section in nanvix.toml."""
 
@@ -1183,6 +1184,208 @@ class TestLoadManifestBuildsSection(unittest.TestCase):
             load_manifest(path)
 
         self.assertEqual(ctx.exception.code, 2)
+||||||| parent of f129376 ([tests] F: Add tests for RefKind.LOCAL)
+=======
+class TestIsLocalPath(unittest.TestCase):
+    """_is_local_path() detects filesystem paths correctly."""
+
+    def test_unix_absolute(self) -> None:
+        self.assertTrue(_is_local_path("/home/me/zlib-build"))
+
+    def test_unix_root(self) -> None:
+        self.assertTrue(_is_local_path("/"))
+
+    def test_relative_dot_slash(self) -> None:
+        self.assertTrue(_is_local_path("./local-build"))
+
+    def test_relative_dot_dot_slash(self) -> None:
+        self.assertTrue(_is_local_path("../sibling/build"))
+
+    def test_tilde_home(self) -> None:
+        self.assertTrue(_is_local_path("~/nanvix"))
+
+    def test_windows_drive_backslash(self) -> None:
+        self.assertTrue(_is_local_path("C:\\Users\\me\\nanvix"))
+
+    def test_windows_drive_forward_slash(self) -> None:
+        self.assertTrue(_is_local_path("D:/builds/nanvix"))
+
+    def test_windows_unc(self) -> None:
+        self.assertTrue(_is_local_path("\\\\server\\share"))
+
+    def test_semver_string(self) -> None:
+        self.assertFalse(_is_local_path("1.3.1"))
+
+    def test_latest(self) -> None:
+        self.assertFalse(_is_local_path("latest"))
+
+    def test_v_prefixed_version(self) -> None:
+        self.assertFalse(_is_local_path("v0.12.291"))
+
+    def test_commit_hash(self) -> None:
+        self.assertFalse(_is_local_path("b7a6a3c"))
+
+    def test_tag_string(self) -> None:
+        self.assertFalse(_is_local_path("v1.0.0-nanvix-abc"))
+
+
+class TestLoadManifestLocalOverride(unittest.TestCase):
+    """Env var overrides with filesystem paths produce RefKind.LOCAL."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_dep_override_unix_path(self) -> None:
+        """NANVIX_VERSION_ZLIB=/path/to/zlib -> RefKind.LOCAL."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/home/me/zlib-build"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "/home/me/zlib-build")
+
+    def test_dep_override_windows_path(self) -> None:
+        """NANVIX_VERSION_ZLIB=C:\\path -> RefKind.LOCAL."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "C:\\Users\\me\\zlib"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "C:\\Users\\me\\zlib")
+
+    def test_dep_override_relative_path(self) -> None:
+        """NANVIX_VERSION_ZLIB=./local-build -> RefKind.LOCAL."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "./local-build"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "./local-build")
+
+    def test_dep_override_version_string_not_local(self) -> None:
+        """Non-path env var preserves original RefKind."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "env_sha"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
+
+    def test_sysroot_override_unix_path(self) -> None:
+        """NANVIX_VERSION=/path/to/sysroot -> RefKind.LOCAL sysroot."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "/opt/nanvix/sysroot"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.sysroot_ref.value, "/opt/nanvix/sysroot")
+
+    def test_sysroot_override_version_string_not_local(self) -> None:
+        """Non-path NANVIX_VERSION preserves original RefKind."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "override_sha"}):
+            m = load_manifest(path)
+
+        # Sysroot uses RefKind.TAG (not VERSION) — the original kind from the manifest.
+        self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
+        self.assertEqual(m.sysroot_ref.value, "override_sha")
+
+    def test_local_dep_not_suffixed(self) -> None:
+        """LOCAL deps are never auto-suffixed with nanvix version."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "1.0.0"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/home/me/zlib-build"}):
+            m = load_manifest(path)
+
+        # LOCAL ref value must be the raw path — no suffix appended.
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "/home/me/zlib-build")
+
+    def test_local_sysroot_skips_suffix_loop(self) -> None:
+        """When NANVIX_VERSION is a path, VERSION deps are NOT suffixed."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            "[package]\n"
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.12.257"\n'
+            "[dependencies]\n"
+            'zlib = "4.5.6"\n'
+        )
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "/opt/nanvix/sysroot"}):
+            m = load_manifest(path)
+
+        # Sysroot is LOCAL — suffix loop must be skipped entirely.
+        # Without the guard, deps would get "-nanvix-/opt/nanvix/sysroot".
+        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
+        self.assertEqual(m.dependencies[0].ref.value, "4.5.6")
+>>>>>>> f129376 ([tests] F: Add tests for RefKind.LOCAL)
 
 
 if __name__ == "__main__":

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -11,8 +11,11 @@ from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import RefKind
-from nanvix_zutil.manifest import _is_local_path, load_manifest  # pyright: ignore[reportPrivateUsage]
 from tests.testutils import MANIFEST_WITH_BUILDS
+from nanvix_zutil.manifest import (
+    _is_local_path,  # pyright: ignore[reportPrivateUsage]
+    load_manifest,
+)
 
 
 class TestLoadManifestFileNotFound(unittest.TestCase):
@@ -1347,7 +1350,7 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
         self.assertEqual(m.sysroot_ref.value, "override_sha")
 
     def test_local_dep_not_suffixed(self) -> None:
-        """LOCAL deps are never auto-suffixed with nanvix version."""
+        """LOCAL deps skip suffix; adjacent VERSION deps are suffixed."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(
             "[package]\n"
@@ -1356,14 +1359,21 @@ class TestLoadManifestLocalOverride(unittest.TestCase):
             'nanvix-version = "0.12.257"\n'
             "[dependencies]\n"
             'zlib = "1.0.0"\n'
+            'openssl = "2.0.0"\n'
         )
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/home/me/zlib-build"}):
             m = load_manifest(path)
 
         # LOCAL ref value must be the raw path — no suffix appended.
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
-        self.assertEqual(m.dependencies[0].ref.value, "/home/me/zlib-build")
+        zlib = next(d for d in m.dependencies if d.name == "zlib")
+        self.assertEqual(zlib.ref.kind, RefKind.LOCAL)
+        self.assertEqual(zlib.ref.value, "/home/me/zlib-build")
+        self.assertNotIn("-nanvix-", str(zlib.ref.value))
+        # Adjacent VERSION dep IS suffixed normally.
+        openssl = next(d for d in m.dependencies if d.name == "openssl")
+        self.assertEqual(openssl.ref.kind, RefKind.VERSION)
+        self.assertEqual(openssl.ref.value, "2.0.0-nanvix-0.12.257")
 
     def test_local_sysroot_skips_suffix_loop(self) -> None:
         """When NANVIX_VERSION is a path, VERSION deps are NOT suffixed."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -873,5 +873,115 @@ class TestZScriptCleanWindows(unittest.TestCase):
         script.clean()  # Should not raise.
 
 
+class TestZScriptSetupLocalRefs(unittest.TestCase):
+    """setup() handles LOCAL refs correctly."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_local_sysroot_passes_local_path(self) -> None:
+        """setup() passes local_path to Sysroot.download for LOCAL sysroot."""
+        from nanvix_zutil.buildroot import Ref, RefKind
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with patch(
+            "nanvix_zutil.script.Sysroot.download",
+            return_value=fake_sysroot,
+        ) as mock_download:
+            script = ZScript(Path(self._tmpdir.name))
+            script.manifest.sysroot_ref = Ref(
+                kind=RefKind.LOCAL, value="/tmp/my-sysroot"
+            )
+            script.setup()
+
+        _, kwargs = mock_download.call_args
+        self.assertEqual(kwargs["local_path"], Path("/tmp/my-sysroot"))
+
+    def test_non_local_sysroot_no_local_path(self) -> None:
+        """setup() passes local_path=None for non-LOCAL sysroot."""
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with patch(
+            "nanvix_zutil.script.Sysroot.download",
+            return_value=fake_sysroot,
+        ) as mock_download:
+            script = ZScript(Path(self._tmpdir.name))
+            script.setup()
+
+        _, kwargs = mock_download.call_args
+        self.assertIsNone(kwargs.get("local_path"))
+
+    def test_local_sysroot_with_version_deps_exits(self) -> None:
+        """setup() fatally errors when LOCAL sysroot + VERSION deps."""
+        from nanvix_zutil.buildroot import Ref, RefKind
+
+        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                patch(
+                    "nanvix_zutil.script.Sysroot.download",
+                    return_value=fake_sysroot,
+                ),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                script = ZScript(Path(self._tmpdir.name))
+                script.manifest.sysroot_ref = Ref(
+                    kind=RefKind.LOCAL, value="/tmp/my-sysroot"
+                )
+                script.setup()
+
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
+    def test_local_dep_skips_github_resolution(self) -> None:
+        """setup() skips resolve_release for LOCAL deps."""
+        from nanvix_zutil.buildroot import Dependency, Ref, RefKind
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        fake_buildroot = MagicMock()
+
+        with (
+            patch(
+                "nanvix_zutil.script.Sysroot.download",
+                return_value=fake_sysroot,
+            ),
+            patch(
+                "nanvix_zutil.script.Buildroot.create",
+                return_value=fake_buildroot,
+            ),
+            patch("nanvix_zutil.script.resolve_release") as mock_resolve,
+            patch("nanvix_zutil.script.resolve_release_with_fallback") as mock_fallback,
+        ):
+            script = ZScript(Path(self._tmpdir.name))
+            script.manifest.dependencies = [
+                Dependency(
+                    name="zlib",
+                    repo="nanvix/zlib",
+                    ref=Ref(kind=RefKind.LOCAL, value="/tmp/zlib-build"),
+                )
+            ]
+            script.setup()
+
+        mock_resolve.assert_not_called()
+        mock_fallback.assert_not_called()
+        fake_buildroot.install_dep.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -163,6 +163,121 @@ class TestSysrootDownloadFetches(unittest.TestCase):
         self.assertTrue(sysroot.path.is_absolute())
 
 
+class TestSysrootDownloadLocal(unittest.TestCase):
+    """Sysroot.download() copies from a local directory when local_path is set."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_copies_local_directory(self) -> None:
+        """Local sysroot directory is copied into dest."""
+        src = Path(self._tmpdir.name) / "local-sysroot"
+        src.mkdir()
+        (src / "lib").mkdir()
+        (src / "lib" / "libposix.a").write_bytes(b"posix-lib")
+        (src / "bin").mkdir()
+        (src / "bin" / "nanvixd.elf").write_bytes(b"elf")
+
+        dest = Path(self._tmpdir.name) / "sysroot"
+
+        with patch("nanvix_zutil.github.download_release_asset") as mock_dl:
+            sysroot = Sysroot.download(
+                machine="microvm",
+                deployment_mode="standalone",
+                memory_size="256mb",
+                tag="ignored",
+                dest=dest,
+                local_path=src,
+            )
+            mock_dl.assert_not_called()
+
+        self.assertTrue(sysroot.path.is_dir())
+        self.assertTrue((sysroot.path / "lib" / "libposix.a").exists())
+        self.assertTrue((sysroot.path / "bin" / "nanvixd.elf").exists())
+        self.assertEqual(sysroot.tag, "")
+
+    def test_local_path_is_absolute(self) -> None:
+        """Returned sysroot path is absolute for local copies."""
+        src = Path(self._tmpdir.name) / "local-sysroot"
+        src.mkdir()
+        dest = Path(self._tmpdir.name) / "sysroot"
+
+        sysroot = Sysroot.download(
+            machine="microvm",
+            deployment_mode="standalone",
+            memory_size="256mb",
+            tag="ignored",
+            dest=dest,
+            local_path=src,
+        )
+
+        self.assertTrue(sysroot.path.is_absolute())
+
+    def test_local_path_not_directory_exits(self) -> None:
+        """Non-existent local_path triggers fatal error."""
+        dest = Path(self._tmpdir.name) / "sysroot"
+        bad_path = Path(self._tmpdir.name) / "does-not-exist"
+
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                Sysroot.download(
+                    machine="microvm",
+                    deployment_mode="standalone",
+                    memory_size="256mb",
+                    tag="ignored",
+                    dest=dest,
+                    local_path=bad_path,
+                )
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
+    def test_local_skips_when_dest_exists(self) -> None:
+        """Cache hit still applies: if dest exists, local_path is not used."""
+        src = Path(self._tmpdir.name) / "local-sysroot"
+        src.mkdir()
+        dest = Path(self._tmpdir.name) / "sysroot"
+        dest.mkdir()
+
+        sysroot = Sysroot.download(
+            machine="microvm",
+            deployment_mode="standalone",
+            memory_size="256mb",
+            tag="ignored",
+            dest=dest,
+            local_path=src,
+        )
+
+        self.assertEqual(sysroot.path, dest.resolve())
+
+    def test_local_persists_empty_tag(self) -> None:
+        """Config receives sysroot_tag='' for local copies."""
+        from nanvix_zutil.config import Config
+
+        src = Path(self._tmpdir.name) / "local-sysroot"
+        src.mkdir()
+        dest = Path(self._tmpdir.name) / "sysroot"
+        config = Config(Path(self._tmpdir.name) / ".nanvix")
+
+        Sysroot.download(
+            machine="microvm",
+            deployment_mode="standalone",
+            memory_size="256mb",
+            tag="ignored",
+            dest=dest,
+            config=config,
+            local_path=src,
+        )
+
+        self.assertEqual(config.get("sysroot_tag", "missing"), "")
+
+
 class TestSysrootVerify(unittest.TestCase):
     """Sysroot.verify() checks that required files exist."""
 


### PR DESCRIPTION
## Summary

Wire `RefKind.LOCAL` handling through the three layers that currently break when a LOCAL ref reaches them, completing the work started in #96.

- **sysroot.py**: Add `local_path` parameter to `Sysroot.download()`; copies local directory into dest via `shutil.copytree`, skipping all GitHub API calls
- **buildroot.py**: Add `_install_from_directory()` helper; add LOCAL branch in `install_dep()` for directory copy and local tarball extraction
- **script.py**: Import `RefKind`; pass `local_path` when sysroot is LOCAL; hard-error on LOCAL sysroot + VERSION deps (can't auto-suffix); skip GitHub resolution for LOCAL deps

## Design Decisions

1. **Copy, not symlink** — matches the download path's behavior; avoids breakage if source is modified/deleted after setup
2. **`local_path` parameter** on `Sysroot.download()` — avoids overloading `tag` (typed `str | int`)
3. **`dep.ref.kind` check** in `Buildroot.install_dep()` — two sub-cases: directory (walk+copy) or tarball (skip download, reuse extraction)
4. **Hard error** for LOCAL sysroot + VERSION deps — VERSION deps need a nanvix version for auto-suffixing, which a local path can't provide

## Testing

- 16 new tests across `test_sysroot.py`, `test_buildroot.py`, and `test_script.py`
- All 539 tests pass, 0 typecheck errors

## Validation

```
✅ uv run tasks.py format
✅ uv run tasks.py lint
✅ uv run basedpyright src/ tests/ — 0 errors, 0 warnings, 0 notes
✅ uv run pytest tests/ -v — 539 passed, 2 skipped
```

Closes #97
Depends on #96