### PR TITLE
feat: add --with-nanvix PATH support to z.sh and z.ps1 templates

### DIFF
--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -1,0 +1,94 @@
+# Using `--with-nanvix` for Local Development
+
+The `--with-nanvix PATH` flag allows you to override the Nanvix sysroot
+binaries with artifacts from a local build.  This is useful when developing
+Nanvix itself and testing changes against downstream consumers (zlib, bzip2,
+etc.) without publishing a release.
+
+## How It Works
+
+1. `./z setup` downloads the sysroot from GitHub as usual.
+2. Files from `PATH/bin/` and `PATH/lib/` are copied on top of the
+   downloaded sysroot, replacing matching artifacts.
+3. Sysroot verification runs against the overlaid result.
+4. If `PATH/deps/<name>/` directories exist for any declared dependency,
+   those are installed from local files instead of downloading from GitHub.
+
+## Prerequisites
+
+- A local Nanvix build with `bin/` and `lib/` output directories:
+
+  ```text
+  ~/src/nanvix/nanvix/
+  ├── bin/
+  │   ├── nanvixd.elf
+  │   ├── mkramfs.elf
+  │   ├── kernel.elf
+  │   ├── uservm.elf
+  │   └── linuxd.elf
+  └── lib/
+      └── libposix.a
+  ```
+
+- The feature-branch version of `nanvix-zutil` installed in the consumer's
+  venv.
+
+## Quick Start
+
+```bash
+cd /path/to/consumer   # e.g. usr/lib/zlib
+
+# Bootstrap venv and install feature-branch zutils
+./z setup
+.nanvix/venv/bin/pip install -e /path/to/zutils
+
+# Clean sysroot and re-run with local override
+rm -rf .nanvix/sysroot .nanvix/env.json
+WITH_NANVIX=~/src/nanvix/nanvix .nanvix/venv/bin/nanvix-zutil setup
+
+# Verify
+cmp .nanvix/sysroot/bin/nanvixd.elf ~/src/nanvix/nanvix/bin/nanvixd.elf
+
+# Build using the overlaid sysroot
+WITH_NANVIX=~/src/nanvix/nanvix .nanvix/venv/bin/nanvix-zutil build
+```
+
+## Using the Shell Wrapper
+
+Once the consumer's `z.sh` includes `--with-nanvix` support (from the
+updated template), you can pass the flag directly:
+
+```bash
+./z setup --with-nanvix ~/src/nanvix/nanvix
+./z build --with-nanvix ~/src/nanvix/nanvix
+```
+
+The wrapper resolves the path to an absolute directory and exports it as
+`WITH_NANVIX` before invoking `nanvix-zutil`.
+
+## Local Dependency Override
+
+If you also build transitive dependencies locally, place their artifacts
+under `PATH/deps/<name>/`:
+
+```text
+~/src/nanvix/nanvix/
+└── deps/
+    └── zlib/
+        ├── lib/
+        │   └── libz.a
+        └── include/
+            └── zlib.h
+```
+
+When `WITH_NANVIX` is set and `deps/<name>/` exists, the dependency
+is installed from the local directory and the GitHub download is skipped.
+
+## Notes
+
+- The overlay copies **all** files from `bin/` and `lib/` — not only the
+  ones required by the sysroot verification.  Extra files are harmless.
+- `WITH_NANVIX` has no effect on `build`, `test`, or other
+  subcommands — it only modifies behavior during `setup`.
+- To return to the normal (release-based) workflow, simply omit
+  `--with-nanvix` and delete `.nanvix/sysroot` before re-running setup.

--- a/examples/hello-transitive/z.ps1
+++ b/examples/hello-transitive/z.ps1
@@ -28,8 +28,10 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
+# NOTE: Use single quotes inside the Python code so that PowerShell does not
+# strip the quotes when passing the string to python.exe -c.
 $ShimCode = @'
-import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+import os,sys;os.getuid=getattr(os,'getuid',lambda:0);os.getgid=getattr(os,'getgid',lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
 '@
 
 $zutilGlobalVersion = try {
@@ -116,10 +118,41 @@ else {
     }
 }
 
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+$filteredArray = $filteredArgs.ToArray()
+
 if ($bin -eq $venvZutil) {
-    & $venvPython -c $ShimCode @ZArgs
+    & $venvPython -c $ShimCode @filteredArray
 }
 else {
-    & $bin @ZArgs
+    & $bin @filteredArray
 }
 exit $LASTEXITCODE

--- a/examples/hello-transitive/z.sh
+++ b/examples/hello-transitive/z.sh
@@ -72,4 +72,39 @@ else
     fi
 fi
 
-exec "$BIN" "$@"
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+# The nanvix-zutil CLI inspects positional args to find the subcommand;
+# --with-nanvix's PATH argument would be mistaken for a subcommand.
+# Pass the value via env var so z.py can pick it up.
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+exec "$BIN" "${ARGS[@]}"

--- a/examples/hello-world/z.ps1
+++ b/examples/hello-world/z.ps1
@@ -28,8 +28,10 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
+# NOTE: Use single quotes inside the Python code so that PowerShell does not
+# strip the quotes when passing the string to python.exe -c.
 $ShimCode = @'
-import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+import os,sys;os.getuid=getattr(os,'getuid',lambda:0);os.getgid=getattr(os,'getgid',lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
 '@
 
 $zutilGlobalVersion = try {
@@ -116,10 +118,41 @@ else {
     }
 }
 
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+$filteredArray = $filteredArgs.ToArray()
+
 if ($bin -eq $venvZutil) {
-    & $venvPython -c $ShimCode @ZArgs
+    & $venvPython -c $ShimCode @filteredArray
 }
 else {
-    & $bin @ZArgs
+    & $bin @filteredArray
 }
 exit $LASTEXITCODE

--- a/examples/hello-world/z.sh
+++ b/examples/hello-world/z.sh
@@ -72,4 +72,39 @@ else
     fi
 fi
 
-exec "$BIN" "$@"
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+# The nanvix-zutil CLI inspects positional args to find the subcommand;
+# --with-nanvix's PATH argument would be mistaken for a subcommand.
+# Pass the value via env var so z.py can pick it up.
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+exec "$BIN" "${ARGS[@]}"

--- a/examples/hello-zlib/z.ps1
+++ b/examples/hello-zlib/z.ps1
@@ -28,8 +28,10 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
+# NOTE: Use single quotes inside the Python code so that PowerShell does not
+# strip the quotes when passing the string to python.exe -c.
 $ShimCode = @'
-import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+import os,sys;os.getuid=getattr(os,'getuid',lambda:0);os.getgid=getattr(os,'getgid',lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
 '@
 
 $zutilGlobalVersion = try {
@@ -116,10 +118,41 @@ else {
     }
 }
 
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+$filteredArray = $filteredArgs.ToArray()
+
 if ($bin -eq $venvZutil) {
-    & $venvPython -c $ShimCode @ZArgs
+    & $venvPython -c $ShimCode @filteredArray
 }
 else {
-    & $bin @ZArgs
+    & $bin @filteredArray
 }
 exit $LASTEXITCODE

--- a/examples/hello-zlib/z.sh
+++ b/examples/hello-zlib/z.sh
@@ -72,4 +72,39 @@ else
     fi
 fi
 
-exec "$BIN" "$@"
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+# The nanvix-zutil CLI inspects positional args to find the subcommand;
+# --with-nanvix's PATH argument would be mistaken for a subcommand.
+# Pass the value via env var so z.py can pick it up.
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+exec "$BIN" "${ARGS[@]}"

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -314,6 +314,62 @@ class Buildroot:
 
         log.success(f"Installed {dep.name} into buildroot")
 
+    def install_local_nanvix(
+        self,
+        dep: Dependency,
+        local_path: Path,
+    ) -> bool:
+        """Install a dependency from a local Nanvix build directory.
+
+        Looks for ``<local_path>/deps/<dep.name>/`` containing ``lib/``
+        and/or ``include/`` subdirectories.  If found, copies the
+        matching artifacts into the buildroot.
+
+        Args:
+            dep: The :class:`Dependency` descriptor.
+            local_path: Absolute path to the local Nanvix build output.
+
+        Returns:
+            ``True`` if local artifacts were found and installed,
+            ``False`` otherwise (caller should fall back to GitHub).
+        """
+        import shutil
+
+        dep_dir = local_path / "deps" / dep.name
+        if not dep_dir.is_dir():
+            return False
+
+        installed = False
+        lib_dir = dep_dir / "lib"
+        if lib_dir.is_dir():
+            dst_lib = self.path / "lib"
+            dst_lib.mkdir(parents=True, exist_ok=True)
+            for src_file in lib_dir.iterdir():
+                if src_file.is_file() and src_file.suffix == ".a":
+                    if dep.install_libs is None or src_file.name in dep.install_libs:
+                        shutil.copy2(src_file, dst_lib / src_file.name)
+                        installed = True
+
+        include_dir = dep_dir / "include"
+        if include_dir.is_dir():
+            dst_inc = self.path / "include"
+            dst_inc.mkdir(parents=True, exist_ok=True)
+            for src_file in include_dir.rglob("*"):
+                if src_file.is_file() and src_file.suffix == ".h":
+                    if (
+                        dep.install_headers is None
+                        or src_file.name in dep.install_headers
+                    ):
+                        rel = src_file.relative_to(include_dir)
+                        dst_file = dst_inc / rel
+                        dst_file.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(src_file, dst_file)
+                        installed = True
+
+        if installed:
+            log.info(f"Installed {dep.name} from local path: {dep_dir}")
+        return installed
+
     # ------------------------------------------------------------------
     # Verification
     # ------------------------------------------------------------------

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -335,6 +335,13 @@ class ZScript:
                 gh_token=self.config.get(CFG_GH_TOKEN),
             )
 
+        # When --with-nanvix PATH is passed, overlay local build artifacts
+        # (nanvixd.elf, mkramfs.elf, uservm.elf, libposix.a, etc.) on top
+        # of the downloaded sysroot before verification.
+        nanvix_local = os.environ.get("WITH_NANVIX")
+        if nanvix_local:
+            self.sysroot.overlay_local_nanvix(Path(nanvix_local))
+
         self.sysroot.verify(self.sysroot_required_files())
 
         # Deferred auto-suffix: when sysroot is "latest", load_manifest()
@@ -355,6 +362,15 @@ class ZScript:
         if deps:
             self.buildroot = Buildroot.create(self.nanvix_dir / "buildroot")
             for dep in deps:
+                # When --with-nanvix is active, try local artifacts first (only for nanvix-owned
+                # dependencies).
+                if (
+                    nanvix_local
+                    and dep.repo.startswith("nanvix/")
+                    and self.buildroot.install_local_nanvix(dep, Path(nanvix_local))
+                ):
+                    continue
+
                 try:
                     # Resolve release with version fallback for nanvix-suffixed
                     # deps, then pass the pre-resolved release and enable

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -238,6 +238,59 @@ class Sysroot:
             log.success("Windows host binaries installed")
 
     # ------------------------------------------------------------------
+    # Local overlay
+    # ------------------------------------------------------------------
+
+    def overlay_local_nanvix(self, local_path: Path) -> None:
+        """Overlay locally-built Nanvix artifacts on top of the sysroot.
+
+        Walks the local directory and copies any files that match the
+        sysroot layout (``bin/`` and ``lib/`` subdirectories) into the
+        sysroot, overriding downloaded artifacts.  This enables
+        development workflows where nanvixd, mkramfs, uservm, etc. are
+        built from a local checkout.
+
+        Args:
+            local_path: Absolute path to the local Nanvix build output
+                directory.  Expected to mirror the sysroot layout
+                (``bin/nanvixd.elf``, ``lib/libposix.a``, etc.).
+
+        Raises:
+            SystemExit: If *local_path* does not exist or is not a
+                directory.
+        """
+        if not local_path.is_dir():
+            log.fatal(
+                f"--with-nanvix path is not a directory: {local_path}",
+                code=EXIT_MISSING_DEP,
+            )
+
+        import shutil
+
+        overlaid: list[str] = []
+        for subdir in ("bin", "lib"):
+            src_dir = local_path / subdir
+            if not src_dir.is_dir():
+                continue
+            dst_dir = self.path / subdir
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            for src_file in src_dir.iterdir():
+                if src_file.is_file():
+                    dst_file = dst_dir / src_file.name
+                    shutil.copy2(src_file, dst_file)
+                    overlaid.append(f"{subdir}/{src_file.name}")
+
+        if overlaid:
+            log.info(f"Overlaid {len(overlaid)} local artifact(s) from {local_path}")
+            for name in sorted(overlaid):
+                log.info(f"  → {name}")
+        else:
+            log.warning(
+                f"No bin/ or lib/ artifacts found in {local_path} — "
+                "sysroot unchanged"
+            )
+
+    # ------------------------------------------------------------------
     # Verification
     # ------------------------------------------------------------------
 

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -28,8 +28,10 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
+# NOTE: Use single quotes inside the Python code so that PowerShell does not
+# strip the quotes when passing the string to python.exe -c.
 $ShimCode = @'
-import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+import os,sys;os.getuid=getattr(os,'getuid',lambda:0);os.getgid=getattr(os,'getgid',lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
 '@
 
 $zutilGlobalVersion = try {
@@ -116,10 +118,41 @@ else {
     }
 }
 
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+$filteredArray = $filteredArgs.ToArray()
+
 if ($bin -eq $venvZutil) {
-    & $venvPython -c $ShimCode @ZArgs
+    & $venvPython -c $ShimCode @filteredArray
 }
 else {
-    & $bin @ZArgs
+    & $bin @filteredArray
 }
 exit $LASTEXITCODE

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -72,4 +72,39 @@ else
     fi
 fi
 
-exec "$BIN" "$@"
+# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
+# The nanvix-zutil CLI inspects positional args to find the subcommand;
+# --with-nanvix's PATH argument would be mistaken for a subcommand.
+# Pass the value via env var so z.py can pick it up.
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+exec "$BIN" "${ARGS[@]}"

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1135,5 +1135,77 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         self.assertEqual(obj["code"], EXIT_DEGRADED_SETUP)
 
 
+class TestZScriptSetupWithNanvix(unittest.TestCase):
+    """setup() with WITH_NANVIX overlays local artifacts."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+        for key in (
+            "NANVIX_MACHINE",
+            "NANVIX_DEPLOYMENT_MODE",
+            "NANVIX_MEMORY_SIZE",
+            "WITH_NANVIX",
+        ):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("WITH_NANVIX", None)
+        self._tmpdir.cleanup()
+
+    def test_setup_calls_overlay_when_env_set(self) -> None:
+        """setup() calls sysroot.overlay_local_nanvix when WITH_NANVIX is set."""
+        local_dir = Path(self._tmpdir.name) / "local-nanvix"
+        local_dir.mkdir()
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        os.environ["WITH_NANVIX"] = str(local_dir)
+
+        with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
+            script = ZScript(Path(self._tmpdir.name))
+            script.setup()
+
+        fake_sysroot.overlay_local_nanvix.assert_called_once_with(local_dir)
+        fake_sysroot.verify.assert_called_once()
+
+    def test_setup_no_overlay_without_env(self) -> None:
+        """setup() does not call overlay_local_nanvix when WITH_NANVIX is unset."""
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
+            script = ZScript(Path(self._tmpdir.name))
+            script.setup()
+
+        fake_sysroot.overlay_local_nanvix.assert_not_called()
+
+    def test_setup_local_deps_skips_github(self) -> None:
+        """setup() skips GitHub download for deps found locally."""
+        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+
+        local_dir = Path(self._tmpdir.name) / "local-nanvix"
+        (local_dir / "deps" / "zlib" / "lib").mkdir(parents=True)
+        (local_dir / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"local-zlib")
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        fake_sysroot.tag = "v0.1.0"
+
+        os.environ["WITH_NANVIX"] = str(local_dir)
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.resolve_release_with_fallback") as mock_resolve,
+        ):
+            script = ZScript(Path(self._tmpdir.name))
+            script.setup()
+
+        # The dependency was satisfied locally so GitHub resolve should not
+        # have been called.
+        mock_resolve.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -205,5 +205,84 @@ class TestSysrootVerify(unittest.TestCase):
         sysroot.verify(required_files=[])
 
 
+class TestSysrootOverlayLocal(unittest.TestCase):
+    """Sysroot.overlay_local() copies local artifacts into the sysroot."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_overlay_copies_bin_files(self) -> None:
+        sysroot_dir = Path(self._tmpdir.name) / "sysroot"
+        (sysroot_dir / "bin").mkdir(parents=True)
+        (sysroot_dir / "bin" / "nanvixd.elf").write_bytes(b"old")
+
+        local_dir = Path(self._tmpdir.name) / "local"
+        (local_dir / "bin").mkdir(parents=True)
+        (local_dir / "bin" / "nanvixd.elf").write_bytes(b"new-local")
+
+        sysroot = Sysroot(sysroot_dir)
+        sysroot.overlay_local_nanvix(local_dir)
+
+        self.assertEqual(
+            (sysroot_dir / "bin" / "nanvixd.elf").read_bytes(), b"new-local"
+        )
+
+    def test_overlay_copies_lib_files(self) -> None:
+        sysroot_dir = Path(self._tmpdir.name) / "sysroot"
+        (sysroot_dir / "lib").mkdir(parents=True)
+        (sysroot_dir / "lib" / "libposix.a").write_bytes(b"old-lib")
+
+        local_dir = Path(self._tmpdir.name) / "local"
+        (local_dir / "lib").mkdir(parents=True)
+        (local_dir / "lib" / "libposix.a").write_bytes(b"new-lib")
+
+        sysroot = Sysroot(sysroot_dir)
+        sysroot.overlay_local_nanvix(local_dir)
+
+        self.assertEqual((sysroot_dir / "lib" / "libposix.a").read_bytes(), b"new-lib")
+
+    def test_overlay_adds_new_files(self) -> None:
+        sysroot_dir = Path(self._tmpdir.name) / "sysroot"
+        (sysroot_dir / "bin").mkdir(parents=True)
+
+        local_dir = Path(self._tmpdir.name) / "local"
+        (local_dir / "bin").mkdir(parents=True)
+        (local_dir / "bin" / "uservm.elf").write_bytes(b"uservm-data")
+
+        sysroot = Sysroot(sysroot_dir)
+        sysroot.overlay_local_nanvix(local_dir)
+
+        self.assertTrue((sysroot_dir / "bin" / "uservm.elf").exists())
+        self.assertEqual(
+            (sysroot_dir / "bin" / "uservm.elf").read_bytes(), b"uservm-data"
+        )
+
+    def test_overlay_no_artifacts_warns(self) -> None:
+        sysroot_dir = Path(self._tmpdir.name) / "sysroot"
+        sysroot_dir.mkdir()
+
+        local_dir = Path(self._tmpdir.name) / "local"
+        local_dir.mkdir()  # No bin/ or lib/ subdirs
+
+        sysroot = Sysroot(sysroot_dir)
+        # Should not raise, just warn.
+        sysroot.overlay_local_nanvix(local_dir)
+
+    def test_overlay_nonexistent_path_exits(self) -> None:
+        sysroot_dir = Path(self._tmpdir.name) / "sysroot"
+        sysroot_dir.mkdir()
+        log_mod.set_json_mode(True)
+
+        sysroot = Sysroot(sysroot_dir)
+        with self.assertRaises(SystemExit) as ctx:
+            sysroot.overlay_local_nanvix(Path("/nonexistent/path"))
+        self.assertEqual(ctx.exception.code, 3)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add a `--with-nanvix PATH` option to `z.sh` and `z.ps1` that allows consumers to build against a local Nanvix checkout instead of downloading artifacts from GitHub. This enables a tight edit-build-test loop when developing Nanvix itself alongside a downstream project.

## Usage

```bash
./z --with-nanvix ~/src/nanvix/nanvix setup
./z --with-nanvix ~/src/nanvix/nanvix build
```

## Implementation

- **z.sh/z.ps1 templates**: parse `--with-nanvix`, resolve the path, and export it as the `WITH_NANVIX` environment variable before invoking `nanvix-zutil`.
- **script.py**: reads `WITH_NANVIX` and calls `sysroot.overlay_local_nanvix()` to copy local `bin/` and `lib/` artifacts over the downloaded sysroot.
- **buildroot.py**: `install_local_nanvix()` checks for `<local>/deps/<name>/` before falling back to GitHub downloads. Only nanvix-owned dependencies (`repo` starts with `nanvix/`) are eligible for local resolution.
- **Examples**: updated to match templates.

## Expected local directory layout

```
<WITH_NANVIX>/
  bin/
    nanvixd.elf
    mkramfs.elf
    uservm.elf
  lib/
    libposix.a
  deps/
    <dep-name>/
      lib/
        lib*.a
      include/
        *.h
```

## Tests

- Unit tests for `overlay_local_nanvix()` in `test_sysroot.py`
- Unit tests for local dep resolution in `test_script.py`
