### PR TITLE
ci: pass GH_TOKEN to test job to avoid API rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     env:
       NANVIX_TOOLCHAIN: /opt/nanvix
       USER: runner
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

The `test` job in `ci.yml` makes unauthenticated GitHub API requests when running `test_full_lifecycle`, which downloads release assets from `nanvix/nanvix`. Without a token the anonymous rate limit (60 req/hour) is easily exceeded, causing intermittent HTTP 403 failures (exit code 4).

## Fix

Pass the automatic `GITHUB_TOKEN` via `GH_TOKEN` so the GitHub client uses authenticated requests (5,000 req/hour). This matches the pattern already used in `release.yml` and the downstream CI template (`templates/nanvix-ci.yml`).