### PR TITLE
ci: add Windows support to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
     name: Tests (Windows)
     runs-on: windows-latest
     timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
     name: Tests (Windows)
     runs-on: windows-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: none
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,27 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v
 
+  test-windows:
+    name: Tests (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install project and dev dependencies
+        run: uv sync
+
+      - name: Verify import succeeds
+        run: uv run python -c "import nanvix_zutil; print('import OK')"
+
+      - name: Run unit tests
+        run: uv run pytest tests/ -v
+
   release:
     name: Build & Publish
     needs: [lint-and-typecheck, test]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
   release:
     name: Build & Publish
-    needs: [lint-and-typecheck, test]
+    needs: [lint-and-typecheck, test, test-windows]
     runs-on: ubuntu-latest
     environment: release
     concurrency:


### PR DESCRIPTION
Add missing Windows coverage to both CI and release workflows:

- **ci.yml**: Add `GH_TOKEN` env to the existing `test-windows` job, matching the Linux `test` job
- **release.yml**: Add a new `test-windows` job (checkout, uv setup, sync, import verify, pytest)
- **release.yml**: Gate the `release` job on `test-windows` passing (`needs: [lint-and-typecheck, test, test-windows]`)