### PR TITLE
feat: download Windows host binaries during setup

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -116,6 +116,14 @@ class ZScript:
         "bin/mkramfs.elf",
     )
 
+    SYSROOT_REQUIRED_FILES_WINDOWS: tuple[str, ...] = (
+        "lib/libposix.a",
+        "lib/user.ld",
+        "bin/nanvixd.exe",
+        "bin/kernel.elf",
+        "bin/mkramfs.exe",
+    )
+
     SYSROOT_MULTI_PROCESS_FILES: tuple[str, ...] = (
         "bin/linuxd.elf",
         "bin/uservm.elf",
@@ -136,13 +144,18 @@ class ZScript:
     )
 
     def sysroot_required_files(self) -> list[str]:
-        """Return the sysroot files required for the current deployment mode.
+        """Return the sysroot files required for the current platform and mode.
 
-        Multi-process mode additionally requires ``linuxd.elf`` and
-        ``uservm.elf``.  Subclasses can extend by overriding the class
-        attributes or this method.
+        Uses Windows binary names (``nanvixd.exe``, ``mkramfs.exe``) on
+        Windows; Linux names on other platforms.  Multi-process mode
+        additionally requires ``linuxd.elf`` and ``uservm.elf``.
+        Subclasses can extend by overriding the class attributes or
+        this method.
         """
-        files = list(self.SYSROOT_REQUIRED_FILES)
+        if is_windows():
+            files = list(self.SYSROOT_REQUIRED_FILES_WINDOWS)
+        else:
+            files = list(self.SYSROOT_REQUIRED_FILES)
         if self.config.deployment_mode == "multi-process":
             files.extend(self.SYSROOT_MULTI_PROCESS_FILES)
         return files
@@ -310,8 +323,20 @@ class ZScript:
             dest=self.nanvix_dir / "sysroot",
             config=self.config,
         )
-        self.sysroot.verify(self.sysroot_required_files())
         self.config.set(CFG_SYSROOT, str(self.sysroot.path))
+
+        # On Windows, download host-native binaries (nanvixd.exe, mkramfs.exe)
+        # BEFORE verifying required files — the base sysroot from
+        # Sysroot.download() only has Linux .elf binaries.
+        if is_windows():
+            self.sysroot.download_windows_binaries(
+                machine=self.config.machine,
+                deployment_mode=self.config.deployment_mode,
+                memory_size=self.config.memory_size,
+                gh_token=self.config.get(CFG_GH_TOKEN),
+            )
+
+        self.sysroot.verify(self.sysroot_required_files())
 
         # Deferred auto-suffix: when sysroot is "latest", load_manifest()
         # skips suffixing because the real version isn't known yet.  Now

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -30,6 +30,11 @@ _DEFAULT_SYSROOT_DIR = Path(".nanvix") / "sysroot"
 
 _SYSROOT_REPO = "nanvix/nanvix"
 _SYSROOT_ASSET_PREFIX = "nanvix-{target}-{machine}-{mode}-release-{mem}"
+_WINDOWS_SYSROOT_ASSET_PREFIX = "nanvix-windows-{target}-{machine}-{mode}-release-{mem}"
+
+# Host binaries needed from the Windows release to run VMs on Windows.
+# kernel.elf is a *guest* binary (i686) — nanvixd.exe loads it directly.
+WINDOWS_HOST_BINARIES = ("nanvixd.exe", "mkramfs.exe", "kernel.elf")
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +147,95 @@ class Sysroot:
             config.set("sysroot_tag", resolved_tag)
             config.save()
         return Sysroot(sysroot_dir.resolve(), tag=resolved_tag)
+
+    # ------------------------------------------------------------------
+    # Windows host binaries
+    # ------------------------------------------------------------------
+
+    def download_windows_binaries(
+        self,
+        machine: str,
+        deployment_mode: str,
+        memory_size: str,
+        gh_token: str | None = None,
+        target: str = DEFAULT_TARGET,
+    ) -> None:
+        """Download Windows host binaries from the Nanvix release.
+
+        On Windows, the sysroot from :meth:`download` contains only
+        Linux ELF binaries.  This method downloads the matching Windows
+        release asset (``.zip``) and extracts ``nanvixd.exe``,
+        ``mkramfs.exe``, and ``kernel.elf`` into the sysroot ``bin/``
+        directory.
+
+        Skips silently if all required binaries are already present.
+        """
+        import zipfile
+
+        bin_dir = self.path / "bin"
+        if all((bin_dir / b).is_file() for b in WINDOWS_HOST_BINARIES):
+            log.info("Windows host binaries already present in sysroot")
+            return
+
+        tag = self.tag
+        if not tag:
+            log.warning("No sysroot tag available — cannot download Windows binaries")
+            return
+
+        asset_prefix = _WINDOWS_SYSROOT_ASSET_PREFIX.format(
+            target=target,
+            machine=machine,
+            mode=deployment_mode,
+            mem=memory_size,
+        )
+
+        release = github.resolve_release(_SYSROOT_REPO, tag, gh_token, semver=True)
+
+        cache_dir = self.path.parent / "cache"
+        asset_path = github.download_release_asset(
+            repo=_SYSROOT_REPO,
+            version_specifier=tag,
+            asset_name=asset_prefix,
+            dest=cache_dir,
+            gh_token=gh_token,
+            match_prefix=True,
+            semver=True,
+            _release=release,
+            allow_missing=True,
+        )
+        if asset_path is None:
+            log.fatal(
+                f"Windows asset matching '{asset_prefix}' not found in release {tag}",
+                code=EXIT_MISSING_DEP,
+                hint="Check that the Nanvix release includes Windows assets.",
+            )
+
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        wanted = set(WINDOWS_HOST_BINARIES)
+        with zipfile.ZipFile(asset_path) as zf:
+            for entry in zf.namelist():
+                basename = Path(entry).name
+                if basename in wanted:
+                    dest = bin_dir / basename
+                    with zf.open(entry) as src, open(dest, "wb") as dst:
+                        import shutil
+
+                        shutil.copyfileobj(src, dst)
+                    log.info(f"Extracted {basename} to sysroot/bin/")
+
+        missing = [b for b in WINDOWS_HOST_BINARIES if not (bin_dir / b).is_file()]
+        if missing:
+            log.fatal(
+                f"Windows binaries missing after download: {', '.join(missing)}",
+                code=EXIT_MISSING_DEP,
+                hint=(
+                    "Delete `.nanvix/sysroot` and run `./z setup` again, or "
+                    "check that the Windows release asset contains the expected "
+                    "host binaries."
+                ),
+            )
+        else:
+            log.success("Windows host binaries installed")
 
     # ------------------------------------------------------------------
     # Verification

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -641,15 +641,19 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
 
     def test_base_files_always_present(self) -> None:
         """Core files are required regardless of deployment mode."""
+        import sys
+
+        nanvixd = "bin/nanvixd.exe" if sys.platform == "win32" else "bin/nanvixd.elf"
+        mkramfs = "bin/mkramfs.exe" if sys.platform == "win32" else "bin/mkramfs.elf"
         for mode in ("multi-process", "single-process", "standalone"):
             os.environ["NANVIX_DEPLOYMENT_MODE"] = mode
             script = ZScript(Path(self._tmpdir.name))
             files = script.sysroot_required_files()
             self.assertIn("lib/libposix.a", files, f"missing in {mode}")
             self.assertIn("lib/user.ld", files, f"missing in {mode}")
-            self.assertIn("bin/nanvixd.elf", files, f"missing in {mode}")
+            self.assertIn(nanvixd, files, f"missing in {mode}")
             self.assertIn("bin/kernel.elf", files, f"missing in {mode}")
-            self.assertIn("bin/mkramfs.elf", files, f"missing in {mode}")
+            self.assertIn(mkramfs, files, f"missing in {mode}")
 
     def test_default_deployment_mode_is_standalone(self) -> None:
         """Default (no env override) should be standalone."""


### PR DESCRIPTION
## Summary

Adds automatic Windows host binary download to the `Sysroot` class, fixing the setup failure on Windows where `nanvixd.exe` is missing after downloading the Linux-only sysroot. Closes #122.

## Problem

`Sysroot.download()` fetches the Linux release tarball which contains `nanvixd.elf`, `mkramfs.elf`, etc. On Windows, `verify()` then checks for `nanvixd.exe` and fails because the Linux tarball doesn't have Windows binaries. Consumers like cpython had per-repo workarounds (`_download_windows_binaries()` in their z.py), but this wasn't generic — library repos (zlib, bzip2, sqlite, openssl, libffi) hit the same failure with no workaround.

## Solution

- Add `Sysroot.download_windows_binaries()` — downloads the matching Windows release asset (`.zip`), extracts `nanvixd.exe`, `mkramfs.exe`, and `kernel.elf` into `sysroot/bin/`. Skips if binaries already present.
- Call it from `ZScript.setup()` on Windows, between `Sysroot.download()` and `verify()` — so the Windows binaries are in place before verification runs.
- All consumers inherit this from the base class — replaces the per-repo `_download_windows_binaries()` pattern that was duplicated in cpython and posix-tests, and enables Windows support for zlib, bzip2, sqlite, openssl, and libffi without any changes to those repos' z.py.

## Testing

Verified on a Windows box: `./z setup` downloads both the Linux sysroot and the Windows host binaries, `verify()` passes, and `./z test` runs successfully (cpython hello + regrtest, 64 modules all pass).