### PR TITLE
[zutils] F: Parse [test.<mode>] section and add target-archs dimension

### DIFF
--- a/examples/hello-world/.nanvix/nanvix.toml
+++ b/examples/hello-world/.nanvix/nanvix.toml
@@ -8,3 +8,6 @@ nanvix-version = "0.12.410"
 platforms = ["hyperlight", "microvm"]
 modes = ["standalone", "single-process", "multi-process"]
 memory = ["128mb"]
+
+[test.standalone]
+targets = ["test-smoke", "test-integration"]

--- a/examples/hello-zlib/.nanvix/nanvix.toml
+++ b/examples/hello-zlib/.nanvix/nanvix.toml
@@ -13,3 +13,6 @@ memory = ["128mb"]
 zlib = "1.3.1"
 
 [system-dependencies]
+
+[test.standalone]
+targets = ["test-smoke", "test-integration"]

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -57,6 +57,42 @@ class BuildMatrix:
     exclude: list[dict[str, str]]
 
 
+@dataclass(frozen=True)
+class TestModeConfig:
+    """Parsed ``[test.<mode>]`` sub-table from ``nanvix.toml``.
+
+    Attributes:
+        targets: Non-empty list of make target names to run for this mode.
+    """
+
+    targets: list[str]
+
+
+@dataclass(frozen=True)
+class TestConfig:
+    """Parsed ``[test]`` section from ``nanvix.toml``.
+
+    Keys are deployment mode names, values are per-mode config.
+
+    Attributes:
+        modes: Mapping of mode name to :class:`TestModeConfig`.
+    """
+
+    modes: dict[str, TestModeConfig]
+
+    def targets_for_mode(self, mode: str) -> list[str] | None:
+        """Return the target list for *mode*, or ``None`` if no override.
+
+        Args:
+            mode: Deployment mode name to look up.
+
+        Returns:
+            A copy of the targets list, or ``None`` if the mode has no entry.
+        """
+        cfg = self.modes.get(mode)
+        return list(cfg.targets) if cfg is not None else None
+
+
 @dataclass
 class Manifest:
     """Parsed contents of a ``nanvix.toml`` manifest file.
@@ -68,6 +104,7 @@ class Manifest:
         builds: Build matrix from the required ``[builds]`` section.
         dependencies: Build-time dependencies as :class:`Dependency` objects.
         system_dependencies: Runtime dependencies as :class:`Dependency` objects.
+        test_config: Optional per-mode test overrides from ``[test]`` section.
     """
 
     name: str
@@ -76,6 +113,7 @@ class Manifest:
     builds: BuildMatrix
     dependencies: list[Dependency] = field(default_factory=list)
     system_dependencies: list[Dependency] = field(default_factory=list)
+    test_config: TestConfig | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -512,6 +550,38 @@ def load_manifest(path: Path) -> Manifest:
         cast("dict[str, object]", sys_deps_raw), path, "system-dependencies"
     )
 
+    # --- [test] (optional) ---
+    test_raw: object = data.get("test")
+    test_config: TestConfig | None = None
+    if test_raw is not None:
+        if not isinstance(test_raw, dict):
+            log.fatal(
+                f"{path}: [test] must be a table",
+                code=EXIT_INVALID_ARGS,
+            )
+        modes: dict[str, TestModeConfig] = {}
+        for mode_name, mode_raw in cast("dict[str, object]", test_raw).items():
+            if not isinstance(mode_raw, dict):
+                log.fatal(
+                    f"{path}: [test.{mode_name}] must be a table",
+                    code=EXIT_INVALID_ARGS,
+                )
+            targets_val: object = cast("dict[str, object]", mode_raw).get("targets")
+            if (
+                not isinstance(targets_val, list)
+                or not targets_val
+                or not all(isinstance(t, str) for t in cast("list[object]", targets_val))
+            ):
+                log.fatal(
+                    f"{path}: [test.{mode_name}].targets must be a"
+                    " non-empty list of strings",
+                    code=EXIT_INVALID_ARGS,
+                )
+            modes[mode_name] = TestModeConfig(
+                targets=list(cast("list[str]", targets_val))
+            )
+        test_config = TestConfig(modes=modes)
+
     # --- [builds] (required) ---
     builds_raw: object = data.get("builds")
     if builds_raw is None:
@@ -549,4 +619,5 @@ def load_manifest(path: Path) -> Manifest:
         builds=builds,
         dependencies=dependencies,
         system_dependencies=system_dependencies,
+        test_config=test_config,
     )

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -270,7 +270,10 @@ def parse_builds_section(
         )
     matrix = cast("dict[str, object]", matrix_raw)
 
-    _valid_dimensions = frozenset({"platforms", "modes", "memory"})
+    _optional_dimensions = frozenset({"target-archs"})
+    _valid_dimensions = (
+        frozenset({"platforms", "modes", "memory"}) | _optional_dimensions
+    )
     unknown_dims = set(matrix.keys()) - _valid_dimensions
     if unknown_dims:
         log.fatal(
@@ -311,6 +314,10 @@ def parse_builds_section(
                 code=EXIT_INVALID_ARGS,
             )
         dimensions[dim_name] = str_list
+
+    # target-archs is optional; default to ["x86"] when absent.
+    if "target-archs" not in dimensions:
+        dimensions["target-archs"] = ["x86"]
 
     exclude: list[dict[str, str]] = []
     exclude_raw: object = raw.get("exclude")

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -570,7 +570,17 @@ def load_manifest(path: Path) -> Manifest:
                     f"{path}: [test.{mode_name}] must be a table",
                     code=EXIT_INVALID_ARGS,
                 )
-            targets_val: object = cast("dict[str, object]", mode_raw).get("targets")
+            mode_table: dict[str, object] = cast("dict[str, object]", mode_raw)
+            unknown_keys: list[str] = sorted(
+                key for key in mode_table.keys() if key != "targets"
+            )
+            if unknown_keys:
+                log.fatal(
+                    f"{path}: [test.{mode_name}] contains unknown key(s): "
+                    + ", ".join(unknown_keys),
+                    code=EXIT_INVALID_ARGS,
+                )
+            targets_val: object = mode_table.get("targets")
             if (
                 not isinstance(targets_val, list)
                 or not targets_val

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -45,7 +45,9 @@ class BuildMatrix:
 
     Attributes:
         dimensions: Mapping of dimension names to allowed values.
-            Keys are ``"platforms"``, ``"modes"``, ``"memory"``.
+            Required keys: ``"platforms"``, ``"modes"``, ``"memory"``.
+            Optional key (always present after parsing, default
+            ``["x86"]``): ``"target-archs"``.
         exclude: List of partial-match dicts. Each dict maps
             combo field names (singular: ``"platform"``, ``"mode"``,
             ``"memory"``) to values; matching combos are removed.
@@ -246,10 +248,11 @@ def parse_builds_section(
 ) -> BuildMatrix:
     """Parse a ``[builds]`` table into a :class:`BuildMatrix`.
 
-    Validates that ``[builds.matrix]`` contains exactly the required
-    dimensions (``platforms``, ``modes``, ``memory``), each as a
-    non-empty list of strings.  Exclude entries use singular field
-    names (``platform``, ``mode``, ``memory``) and are validated
+    Validates that ``[builds.matrix]`` contains the required
+    dimensions (``platforms``, ``modes``, ``memory``) and the optional
+    dimension ``target-archs`` (defaults to ``["x86"]`` when absent),
+    each as a non-empty list of strings.  Exclude entries use singular
+    field names (``platform``, ``mode``, ``memory``) and are validated
     against the known set — unknown keys are rejected.
 
     Args:

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -63,6 +63,8 @@ class TestModeConfig:
 
     Attributes:
         targets: Non-empty list of make target names to run for this mode.
+            Note: ``frozen=True`` prevents field rebinding but does not make
+            the list itself immutable; callers must not mutate it in place.
     """
 
     targets: list[str]
@@ -76,6 +78,8 @@ class TestConfig:
 
     Attributes:
         modes: Mapping of mode name to :class:`TestModeConfig`.
+            Note: ``frozen=True`` prevents field rebinding but does not make
+            the dict itself immutable; callers must not mutate it in place.
     """
 
     modes: dict[str, TestModeConfig]
@@ -570,7 +574,9 @@ def load_manifest(path: Path) -> Manifest:
             if (
                 not isinstance(targets_val, list)
                 or not targets_val
-                or not all(isinstance(t, str) for t in cast("list[object]", targets_val))
+                or not all(
+                    isinstance(t, str) for t in cast("list[object]", targets_val)
+                )
             ):
                 log.fatal(
                     f"{path}: [test.{mode_name}].targets must be a"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1354,10 +1354,10 @@ class TestManifestTestConfig(unittest.TestCase):
             'targets = ["test-smoke", "test-integration"]\n'
         )
         m = load_manifest(path)
-        self.assertIsNotNone(m.test_config)
-        self.assertIn("standalone", m.test_config.modes)  # type: ignore[union-attr]
+        assert m.test_config is not None
+        self.assertIn("standalone", m.test_config.modes)
         self.assertEqual(
-            m.test_config.modes["standalone"].targets,  # type: ignore[union-attr]
+            m.test_config.modes["standalone"].targets,
             ["test-smoke", "test-integration"],
         )
 
@@ -1392,6 +1392,18 @@ class TestManifestTestConfig(unittest.TestCase):
             ["test-smoke"],
         )
 
+    def test_targets_for_mode_returns_copy(self) -> None:
+        """targets_for_mode returns a fresh list, not the internal one."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "\n[test.standalone]\n" 'targets = ["test-smoke"]\n'
+        )
+        m = load_manifest(path)
+        assert m.test_config is not None
+        result = m.test_config.targets_for_mode("standalone")
+        assert result is not None
+        self.assertIsNot(result, m.test_config.modes["standalone"].targets)
+
     def test_targets_for_mode_miss(self) -> None:
         """targets_for_mode returns None when mode has no override."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
@@ -1419,9 +1431,17 @@ class TestManifestTestConfig(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
     def test_non_table_mode_fatal(self) -> None:
-        """[test] = scalar string instead of table is fatal."""
+        """[test] = scalar string instead of table is fatal (outer guard)."""
         path = Path(self._tmpdir.name) / "nanvix.toml"
         path.write_text(self._BASE + '\ntest = "bad"\n')
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_non_table_mode_value_fatal(self) -> None:
+        """[test.standalone] as a scalar string is fatal (inner guard)."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(self._BASE + "\n[test]\n" 'standalone = "bad"\n')
         with self.assertRaises(SystemExit) as ctx:
             load_manifest(path)
         self.assertEqual(ctx.exception.code, 2)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1446,6 +1446,18 @@ class TestManifestTestConfig(unittest.TestCase):
             load_manifest(path)
         self.assertEqual(ctx.exception.code, 2)
 
+    def test_unknown_key_fatal(self) -> None:
+        """Unknown key in [test.<mode>] sub-table is fatal (typo guard)."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "\n[test.standalone]\n"
+            'targets = ["test-smoke"]\n'
+            'target = ["typo"]\n'
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1316,5 +1316,116 @@ class TestTargetArchs(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
+class TestManifestTestConfig(unittest.TestCase):
+    """Tests for [test] section parsing."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    _BASE = (
+        "[package]\n"
+        'name = "myapp"\n'
+        'version = "1.0.0"\n'
+        'nanvix-version = "0.12.410"\n'
+        "[builds]\n"
+        "[builds.matrix]\n"
+        'platforms = ["hyperlight"]\n'
+        'modes = ["standalone", "multi-process"]\n'
+        'memory = ["128mb"]\n'
+    )
+
+    def test_no_test_section(self) -> None:
+        """No [test] section -> test_config is None."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(self._BASE)
+        m = load_manifest(path)
+        self.assertIsNone(m.test_config)
+
+    def test_valid_single_mode(self) -> None:
+        """Valid [test.standalone] parses correctly."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "\n[test.standalone]\n"
+            'targets = ["test-smoke", "test-integration"]\n'
+        )
+        m = load_manifest(path)
+        self.assertIsNotNone(m.test_config)
+        self.assertIn("standalone", m.test_config.modes)  # type: ignore[union-attr]
+        self.assertEqual(
+            m.test_config.modes["standalone"].targets,  # type: ignore[union-attr]
+            ["test-smoke", "test-integration"],
+        )
+
+    def test_valid_multiple_modes(self) -> None:
+        """Multiple [test.<mode>] sub-tables parse correctly."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "\n[test.standalone]\n"
+            'targets = ["test-smoke"]\n'
+            "\n[test.single-process]\n"
+            'targets = ["test-smoke", "test-integration"]\n'
+        )
+        m = load_manifest(path)
+        assert m.test_config is not None
+        self.assertEqual(len(m.test_config.modes), 2)
+        self.assertEqual(m.test_config.modes["standalone"].targets, ["test-smoke"])
+        self.assertEqual(
+            m.test_config.modes["single-process"].targets,
+            ["test-smoke", "test-integration"],
+        )
+
+    def test_targets_for_mode_hit(self) -> None:
+        """targets_for_mode returns targets when mode matches."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "\n[test.standalone]\n" 'targets = ["test-smoke"]\n'
+        )
+        m = load_manifest(path)
+        assert m.test_config is not None
+        self.assertEqual(
+            m.test_config.targets_for_mode("standalone"),
+            ["test-smoke"],
+        )
+
+    def test_targets_for_mode_miss(self) -> None:
+        """targets_for_mode returns None when mode has no override."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "\n[test.standalone]\n" 'targets = ["test-smoke"]\n'
+        )
+        m = load_manifest(path)
+        assert m.test_config is not None
+        self.assertIsNone(m.test_config.targets_for_mode("multi-process"))
+
+    def test_empty_targets_fatal(self) -> None:
+        """Empty targets list is fatal."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(self._BASE + "\n[test.standalone]\n" "targets = []\n")
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_non_string_targets_fatal(self) -> None:
+        """Non-string entries in targets list is fatal."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(self._BASE + "\n[test.standalone]\n" "targets = [42]\n")
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_non_table_mode_fatal(self) -> None:
+        """[test] = scalar string instead of table is fatal."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(self._BASE + '\ntest = "bad"\n')
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1233,5 +1233,49 @@ class TestLoadManifestBuildsSection(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
+class TestTargetArchs(unittest.TestCase):
+    """Tests for target-archs dimension in [builds.matrix]."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(True)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    _BASE = (
+        "[package]\n"
+        'name = "myapp"\n'
+        'version = "1.0.0"\n'
+        'nanvix-version = "0.12.410"\n'
+        "[builds]\n"
+        "[builds.matrix]\n"
+    )
+
+    def test_target_archs_present(self) -> None:
+        """Explicit target-archs parsed into dimensions."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + 'target-archs = ["x86", "arm64"]\n'
+            'platforms = ["hyperlight"]\n'
+            'modes = ["standalone"]\n'
+            'memory = ["128mb"]\n'
+        )
+        m = load_manifest(path)
+        self.assertEqual(m.builds.dimensions["target-archs"], ["x86", "arm64"])
+
+    def test_target_archs_absent_defaults_to_x86(self) -> None:
+        """Missing target-archs defaults to ["x86"]."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + 'platforms = ["hyperlight"]\n'
+            'modes = ["standalone"]\n'
+            'memory = ["128mb"]\n'
+        )
+        m = load_manifest(path)
+        self.assertEqual(m.builds.dimensions["target-archs"], ["x86"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1276,6 +1276,45 @@ class TestTargetArchs(unittest.TestCase):
         m = load_manifest(path)
         self.assertEqual(m.builds.dimensions["target-archs"], ["x86"])
 
+    def test_target_archs_empty_fatal(self) -> None:
+        """Empty target-archs list is fatal."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "target-archs = []\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["standalone"]\n'
+            'memory = ["128mb"]\n'
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_target_archs_non_string_element_fatal(self) -> None:
+        """Non-string element in target-archs is fatal."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + "target-archs = [42]\n"
+            'platforms = ["hyperlight"]\n'
+            'modes = ["standalone"]\n'
+            'memory = ["128mb"]\n'
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_target_archs_not_a_list_fatal(self) -> None:
+        """target-archs as a scalar string is fatal."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(
+            self._BASE + 'target-archs = "x86"\n'
+            'platforms = ["hyperlight"]\n'
+            'modes = ["standalone"]\n'
+            'memory = ["128mb"]\n'
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            load_manifest(path)
+        self.assertEqual(ctx.exception.code, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# What

Adds two pieces of `nanvix.toml` schema, parser-only:

- **`[test.<mode>]` sub-tables** — declare per-deployment-mode test target lists (e.g. `targets = ["test-smoke", "test-integration"]`). Parsed into a new `Manifest.test_config: TestConfig | None` with a `targets_for_mode(mode)` helper. Optional; absent → `None`.
- **`target-archs` build dimension** — optional fourth dimension in `[builds.matrix]` alongside `platforms`/`modes`/`memory`. Defaults to `["x86"]` to keep existing manifests valid.

Validation: non-table `[test]`, non-table mode, non-list / empty / non-string `targets`, and malformed `target-archs` are all fatal with `EXIT_INVALID_ARGS`. Both example manifests (`hello-world`, `hello-zlib`) gain a `[test.standalone]` block.

# Why

Closes #135. The next PR (#136, depends on this one) will wire `Manifest.test_config` into `nanvix-zutil test` so `./z test` honors per-mode target overrides instead of running the full suite, and feed `target-archs` into the matrix expander / CI workflow.

# Priority

🔴 - Blocks #131, #136.