### PR TITLE
Fix lockfile to use typed list factories to satisfy strict type checking

### DIFF
--- a/src/nanvix_zutil/lockfile.py
+++ b/src/nanvix_zutil/lockfile.py
@@ -82,10 +82,10 @@ class ResolvedPackage:
     resolved_tag: str
     resolved_commitish: str
     release_id: int
-    dependencies: list[str] = field(default_factory=list)
-    assets: list[ResolvedAsset] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=lambda: list[str]())
+    assets: list[ResolvedAsset] = field(default_factory=lambda: list[ResolvedAsset]())
     transitive: bool = False
-    required_by: list[str] = field(default_factory=list)
+    required_by: list[str] = field(default_factory=lambda: list[str]())
 
 
 @dataclass
@@ -115,7 +115,7 @@ class Lockfile:
 
     metadata: LockfileMetadata
     builds: BuildMatrix
-    packages: list[ResolvedPackage] = field(default_factory=list)
+    packages: list[ResolvedPackage] = field(default_factory=lambda: list[ResolvedPackage]())
 
 
 # ---------------------------------------------------------------------------

--- a/src/nanvix_zutil/lockfile.py
+++ b/src/nanvix_zutil/lockfile.py
@@ -115,7 +115,9 @@ class Lockfile:
 
     metadata: LockfileMetadata
     builds: BuildMatrix
-    packages: list[ResolvedPackage] = field(default_factory=lambda: list[ResolvedPackage]())
+    packages: list[ResolvedPackage] = field(
+        default_factory=lambda: list[ResolvedPackage]()
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace bare `list` in `field(default_factory=list)` with typed lambdas (e.g., `lambda: list[str]()`) across dataclass definitions.

Pyright strict mode treats the unparameterized `list` callable as returning `list[Unknown]`, which causes "partially unknown type" errors on `dependencies`, `assets`, `required_by`, and `packages` fields. Using explicit typed constructors preserves runtime semantics while providing full type information to static analyzers.