### PR TITLE
[build] Handle missing shell tools gracefully

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+#
+# Git hook for pre-commit validation.
+#
+# Runs formatting and type checks before allowing a commit,
+# ensuring CI will not fail due to lint or type errors.
+#
+
+#==================================================================================================
+
+# Fast fail on errors, unset variables, and pipe failures.
+set -euo pipefail
+
+#==================================================================================================
+# Logging Helpers
+#==================================================================================================
+
+print_error() {
+    echo "error: $1" >&2
+}
+
+print_step() {
+    echo "pre-commit: $1" >&2
+}
+
+#==================================================================================================
+# Functions
+#==================================================================================================
+
+#
+# Description
+#   Run all linters (black, shfmt, shellcheck, PSScriptAnalyzer, yamllint).
+#
+# Return Value
+#   0 on success, 1 on failure.
+#
+check_formatting() {
+    print_step "Linting (black, shfmt, shellcheck, PSScriptAnalyzer, yamllint)..."
+    if ! uv run tasks.py lint; then
+        print_error "Lint failed. Run 'uv run tasks.py format' and 'uv run tasks.py shell-format' to fix formatting."
+        return 1
+    fi
+}
+
+#
+# Description
+#   Run strict type checking with basedpyright.
+#
+# Return Value
+#   0 on success, 1 on failure.
+#
+check_types() {
+    print_step "Type checking (basedpyright)..."
+    if ! uv run tasks.py typecheck; then
+        print_error "Type check failed. Fix the reported errors before committing."
+        return 1
+    fi
+}
+
+#==================================================================================================
+# Main Script
+#==================================================================================================
+
+main() {
+    print_step "Running pre-commit checks..."
+
+    check_formatting
+    check_types
+
+    print_step "All checks passed."
+}
+
+main "$@"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -48,13 +48,13 @@ check_formatting() {
 
 #
 # Description
-#   Run strict type checking with basedpyright.
+#   Run strict type checking with pyright.
 #
 # Return Value
 #   0 on success, 1 on failure.
 #
 check_types() {
-    print_step "Type checking (basedpyright)..."
+    print_step "Type checking (pyright)..."
     if ! uv run tasks.py typecheck; then
         print_error "Type check failed. Fix the reported errors before committing."
         return 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -48,13 +48,13 @@ check_formatting() {
 
 #
 # Description
-#   Run strict type checking with basedpyright.
+#   Run strict type checking with pyright.
 #
 # Return Value
 #   0 on success, 1 on failure.
 #
 check_types() {
-    print_step "Type checking (basedpyright)..."
+    print_step "Type checking (pyright)..."
     if ! uv run tasks.py typecheck; then
         print_error "Type check failed. Fix the reported errors before pushing."
         return 1

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,7 +60,7 @@ nanvix/<project>/
 
 - **Python 3.12+ only.** Matches the Nanvix CPython port (3.12.3). Use modern syntax: `X | Y` unions, `list[str]` generics, etc.
 - **External dependencies are allowed.** Add runtime dependencies to `[project] dependencies` in `pyproject.toml`.
-- **Type-checked with `basedpyright` in strict mode.** All code must pass strict type checking. Every public function must have a complete type signature.
+- **Type-checked with `pyright` in strict mode.** All code must pass strict type checking. Every public function must have a complete type signature.
 - **Formatted with `black`.** No configuration overrides.
 - **All public functions must have docstrings.**
 - **Deterministic exit codes 0–6:** 0=success, 1=general error, 2=invalid args, 3=missing dependency, 4=network error, 5=build failure, 6=test failure.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Lint (black, shfmt, shellcheck, PSScriptAnalyzer, yamllint)
         run: uv run tasks.py lint
 
-      - name: Type check (basedpyright)
-        run: uv run basedpyright src/ tests/
+      - name: Type check (pyright)
+        run: uv run pyright src/ tests/
 
       - name: Type check downstream_tests
-        run: uv run basedpyright src/downstream_tests/ scripts/downstream/wrapper.py
+        run: uv run pyright src/downstream_tests/ scripts/downstream/wrapper.py
 
   test:
     name: Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Check formatting (black)
         run: uv run black --check src/ tests/
 
-      - name: Type check (basedpyright)
-        run: uv run basedpyright src/ tests/
+      - name: Type check (pyright)
+        run: uv run pyright src/ tests/
 
   test:
     name: Tests

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ htmlcov/
 .basedpyright/
 .pyright/
 pyrightconfig.json
+!src/nanvix_zutil/configs/pyrightconfig.json
 
 # Editor
 /.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The default branch is **`dev`** — all feature work targets `dev`.
 |------------------------------|--------------------------------------|
 | `uv run tasks.py lint`      | Check formatting (black)             |
 | `uv run tasks.py format`   | Fix formatting (black)               |
-| `uv run tasks.py typecheck` | Strict type checking (basedpyright) |
+| `uv run tasks.py typecheck` | Strict type checking (pyright)      |
 | `uv run tasks.py test`     | Run test suite (pytest)              |
 | `uv run tasks.py ci`       | Run CI locally via `gh act`          |
 | `uv run tasks.py clean`    | Remove caches and build artifacts    |
@@ -33,7 +33,7 @@ The default branch is **`dev`** — all feature work targets `dev`.
 All code must pass before merging:
 
 - **Formatting** — `black` with no configuration overrides.
-- **Type checking** — `basedpyright` in strict mode. Every public function
+- **Type checking** — `pyright` in strict mode. Every public function
   needs a complete type signature.
 - **Tests** — `pytest`. Functional tests require the `nanvix/toolchain`
   Docker image and `/dev/kvm`.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ uv run tasks.py setup         # configure git hooks
 | ---------------------------- | ----------------------------------- |
 | `uv run tasks.py lint`       | Check formatting (black)            |
 | `uv run tasks.py format`     | Fix formatting (black)              |
-| `uv run tasks.py typecheck`  | Strict type checking (basedpyright) |
+| `uv run tasks.py typecheck`  | Strict type checking (pyright)      |
 | `uv run tasks.py test`       | Run test suite (pytest)             |
 | `uv run tasks.py clean`      | Remove caches and build artifacts   |
 
@@ -175,7 +175,7 @@ contains:
 | Hook         | What it does                                                    |
 | ------------ | --------------------------------------------------------------- |
 | `commit-msg` | Validates `[module] type: Description` format (B, E, F, or W)   |
-| `pre-push`   | Runs formatting (black) and type checking (basedpyright) checks |
+| `pre-push`   | Runs formatting (black) and type checking (pyright) checks      |
 
 ## License
 

--- a/etc/.vscode/settings.json
+++ b/etc/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-  "python.analysis.typeCheckingMode": "strict"
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.analysis.typeCheckingMode": "strict"
 }

--- a/etc/.zed/settings.json
+++ b/etc/.zed/settings.json
@@ -1,9 +1,9 @@
 {
   "lsp": {
-    "basedpyright": {
+    "pyright": {
       "settings": {
         "python.pythonPath": ".venv/bin/python",
-        "basedpyright": {
+        "pyright": {
           "analysis": {
             "typeCheckingMode": "strict",
             "pythonVersion": "3.12"

--- a/examples/hello-world/.nanvix/.yamllint.yml
+++ b/examples/hello-world/.nanvix/.yamllint.yml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy:
+    check-keys: false
+  document-start: disable

--- a/examples/hello-world/.yamllint.yml
+++ b/examples/hello-world/.yamllint.yml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy:
+    check-keys: false
+  document-start: disable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "black",
-  "basedpyright",
+  "pyright",
   "pytest",
   "yamllint",
 ]
@@ -34,6 +34,7 @@ Repository = "https://github.com/nanvix/zutils"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nanvix_zutil"]
+artifacts = ["src/nanvix_zutil/configs/*", "src/nanvix_zutil/configs/.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -42,7 +43,7 @@ testpaths = ["tests"]
 line-length = 88
 target-version = ["py312"]
 
-[tool.basedpyright]
+[tool.pyright]
 include = ["src", "tests"]
 pythonVersion = "3.12"
 typeCheckingMode = "strict"

--- a/src/nanvix_zutil/configs/.yamllint.yml
+++ b/src/nanvix_zutil/configs/.yamllint.yml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy:
+    check-keys: false
+  document-start: disable

--- a/src/nanvix_zutil/configs/__init__.py
+++ b/src/nanvix_zutil/configs/__init__.py
@@ -1,0 +1,8 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Canonical tool configuration files for downstream consumers.
+
+These configs are synced to consumer repos during ``nanvix-zutil setup``
+to enforce consistent tooling settings across the Nanvix ecosystem.
+"""

--- a/src/nanvix_zutil/configs/pyrightconfig.json
+++ b/src/nanvix_zutil/configs/pyrightconfig.json
@@ -1,0 +1,10 @@
+{
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "strict",
+  "include": [
+    "../src",
+    "../tests"
+  ],
+  "venvPath": ".",
+  "venv": "venv"
+}

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -149,7 +149,7 @@ class DockerConfig:
     image: str
     """Docker image name."""
 
-    mounts: list[Mount] = field(default_factory=list)
+    mounts: list[Mount] = field(default_factory=lambda: [])
     """Ordered list of volume mounts."""
 
     uid: int = field(default_factory=_get_uid)
@@ -161,10 +161,10 @@ class DockerConfig:
     workdir: PurePosixPath = field(default_factory=lambda: WORKSPACE_CONTAINER_PATH)
     """Container working directory (used by both standard and KVM runs)."""
 
-    extra_env: dict[str, str] = field(default_factory=dict)
+    extra_env: dict[str, str] = field(default_factory=lambda: {})
     """Additional ``-e KEY=VALUE`` pairs forwarded to the container."""
 
-    output_files: list[str] = field(default_factory=list)
+    output_files: list[str] = field(default_factory=lambda: [])
     """Build output files to copy back from the container to the host."""
 
     tar_excludes: list[str] = field(

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -72,8 +72,8 @@ class Manifest:
     version: str
     sysroot_ref: Ref
     builds: BuildMatrix
-    dependencies: list[Dependency] = field(default_factory=list)
-    system_dependencies: list[Dependency] = field(default_factory=list)
+    dependencies: list[Dependency] = field(default_factory=lambda: [])
+    system_dependencies: list[Dependency] = field(default_factory=lambda: [])
 
 
 # ---------------------------------------------------------------------------

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import importlib.resources
 import os
 import shutil
 import subprocess
@@ -418,7 +419,37 @@ class ZScript:
                     raise
 
         self.config.save()
+        self._sync_configs()
         return self._used_fallback
+
+    # ------------------------------------------------------------------
+    # Config synchronisation
+    # ------------------------------------------------------------------
+
+    #: Mapping of canonical config filename -> destination relative to .nanvix/.
+    _CONFIG_FILES: dict[str, str] = {
+        "pyrightconfig.json": "pyrightconfig.json",
+        ".yamllint.yml": ".yamllint.yml",
+    }
+
+    def _sync_configs(self) -> None:
+        """Sync canonical tool configuration files into ``.nanvix/``.
+
+        Copies config files shipped inside ``nanvix_zutil.configs`` to the
+        ``.nanvix/`` directory, ensuring all downstream repos use
+        consistent linter/type-checker settings.  Files whose content
+        already matches are skipped.  Configs are confined to ``.nanvix/``
+        so consumer repo roots are never modified.
+        """
+        configs = importlib.resources.files("nanvix_zutil.configs")
+        for src_name, dst_rel in self._CONFIG_FILES.items():
+            src = configs / src_name
+            dst = self.nanvix_dir / dst_rel
+            content = src.read_bytes()
+            if dst.exists() and dst.read_bytes() == content:
+                continue
+            dst.write_bytes(content)
+            log.note(f"Synced .nanvix/{dst_rel}")
 
     def distclean(self) -> None:
         """Remove all transient ``.nanvix/`` artifacts.

--- a/tasks.py
+++ b/tasks.py
@@ -259,7 +259,6 @@ def shell_lint() -> int:
         shfmt_path = shutil.which("shfmt")
         if shfmt_path is None:
             print("shfmt not found — skipping shell formatting checks")
-            rc = 1
         else:
             print_step = f"> shfmt --diff -i 4 -ci {' '.join(bash_files)}"
             print(print_step)
@@ -274,7 +273,6 @@ def shell_lint() -> int:
         shellcheck_path = shutil.which("shellcheck")
         if shellcheck_path is None:
             print("shellcheck not found — skipping shell correctness checks")
-            rc = 1
         else:
             print_step = f"> shellcheck {' '.join(bash_files)}"
             print(print_step)
@@ -325,7 +323,11 @@ def shell_format() -> int:
     if not bash_files:
         print("No bash scripts found.")
         return 0
-    return _run("shfmt", "-w", "-i", "4", "-ci", *bash_files)
+    shfmt_path = shutil.which("shfmt")
+    if shfmt_path is None:
+        print("error: shfmt not found")
+        return 1
+    return _run(shfmt_path, "-w", "-i", "4", "-ci", *bash_files)
 
 
 def yaml_lint() -> int:

--- a/tasks.py
+++ b/tasks.py
@@ -10,7 +10,7 @@ Commands:
   setup         Configure git hooks and sync dev dependencies
   lint          Run all linters (black, shfmt, shellcheck, PSScriptAnalyzer, yamllint)
   format        Fix code formatting with black
-  typecheck     Run strict type checking with basedpyright
+  typecheck     Run strict type checking with pyright
   test          Run the test suite with pytest
   test-downstream  Run the downstream_tests unit tests
   ci            Run CI locally using gh act (requires Docker + nanvix toolchain image)
@@ -79,8 +79,8 @@ def format_code() -> int:
 
 
 def typecheck() -> int:
-    """Run strict type checking with basedpyright."""
-    return _run(sys.executable, "-m", "basedpyright", *SOURCES)
+    """Run strict type checking with pyright."""
+    return _run(sys.executable, "-m", "pyright", *SOURCES)
 
 
 def test() -> int:
@@ -482,7 +482,7 @@ COMMANDS: dict[str, tuple[Callable[[], int], str]] = {
         "Run all linters (black, shfmt, shellcheck, PSScriptAnalyzer, yamllint)",
     ),
     "format": (format_code, "Fix code formatting with black"),
-    "typecheck": (typecheck, "Run strict type checking with basedpyright"),
+    "typecheck": (typecheck, "Run strict type checking with pyright"),
     "test": (test, "Run the test suite with pytest"),
     "test-downstream": (test_downstream, "Run the downstream_tests unit tests"),
     "ci": (

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -244,6 +244,62 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
             log_mod.set_json_mode(False)
 
 
+class TestZScriptSyncConfigs(unittest.TestCase):
+    """setup() syncs canonical configs into .nanvix/."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _run_setup(self) -> ZScript:
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
+            script = ZScript(Path(self._tmpdir.name))
+            script.setup()
+        return script
+
+    def test_setup_creates_config_files(self) -> None:
+        """setup() creates config files under .nanvix/."""
+        self._run_setup()
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        self.assertTrue((nanvix_dir / "pyrightconfig.json").exists())
+        self.assertTrue((nanvix_dir / ".yamllint.yml").exists())
+
+    def test_setup_skips_identical_configs(self) -> None:
+        """setup() is a no-op for configs when content already matches."""
+        self._run_setup()
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        pyright_cfg = nanvix_dir / "pyrightconfig.json"
+        mtime_before = pyright_cfg.stat().st_mtime
+        import time
+
+        time.sleep(0.01)
+        self._run_setup()
+        mtime_after = pyright_cfg.stat().st_mtime
+        self.assertEqual(mtime_before, mtime_after)
+
+    def test_setup_updates_config_when_different(self) -> None:
+        """setup() overwrites config when content differs."""
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        pyright_cfg = nanvix_dir / "pyrightconfig.json"
+        pyright_cfg.write_text("{}")
+        self._run_setup()
+        self.assertNotEqual(pyright_cfg.read_text(), "{}")
+
+    def test_setup_confines_configs_to_nanvix_dir(self) -> None:
+        """setup() never writes config files outside .nanvix/."""
+        self._run_setup()
+        repo_root = Path(self._tmpdir.name)
+        self.assertFalse((repo_root / "pyrightconfig.json").exists())
+        self.assertFalse((repo_root / ".yamllint.yml").exists())
+
+
 class TestZScriptLifecycleHooks(unittest.TestCase):
     """Default consumer lifecycle hooks are no-ops."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,18 +1,6 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
-
-[[package]]
-name = "basedpyright"
-version = "1.38.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodejs-wheel-binaries" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/58/7abba2c743571a42b2548f07aee556ebc1e4d0bc2b277aeba1ee6c83b0af/basedpyright-1.38.3.tar.gz", hash = "sha256:9725419786afbfad8a9539527f162da02d462afad440b0412fdb3f3cdf179b90", size = 25277430, upload-time = "2026-03-17T13:10:41.526Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e3/3ebb5c23bd3abb5fc2053b8a06a889aa5c1cf8cff738c78cb6c1957e90cd/basedpyright-1.38.3-py3-none-any.whl", hash = "sha256:1f15c2e489c67d6c5e896c24b6a63251195c04223a55e4568b8f8e8ed49ca830", size = 12313363, upload-time = "2026-03-17T13:10:47.344Z" },
-]
 
 [[package]]
 name = "black"
@@ -95,8 +83,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "basedpyright" },
     { name = "black" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "yamllint" },
 ]
@@ -106,26 +94,19 @@ requires-dist = [{ name = "tomli-w", specifier = ">=1.2.0" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "basedpyright" },
     { name = "black" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "yamllint" },
 ]
 
 [[package]]
-name = "nodejs-wheel-binaries"
-version = "24.14.0"
+name = "nodeenv"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/05/c75c0940b1ebf82975d14f37176679b6f3229eae8b47b6a70d1e1dae0723/nodejs_wheel_binaries-24.14.0.tar.gz", hash = "sha256:c87b515e44b0e4a523017d8c59f26ccbd05b54fe593338582825d4b51fc91e1c", size = 8057, upload-time = "2026-02-27T02:57:30.931Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/8c/b057c2db3551a6fe04e93dd14e33d810ac8907891534ffcc7a051b253858/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:59bb78b8eb08c3e32186da1ef913f1c806b5473d8bd0bb4492702092747b674a", size = 54798488, upload-time = "2026-02-27T02:56:56.831Z" },
-    { url = "https://files.pythonhosted.org/packages/30/88/7e1b29c067b6625c97c81eb8b0ef37cf5ad5b62bb81e23f4bde804910ec9/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:348fa061b57625de7250d608e2d9b7c4bc170544da7e328325343860eadd59e5", size = 54972803, upload-time = "2026-02-27T02:57:01.696Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/e0/a83f0ff12faca2a56366462e572e38ac6f5cb361877bb29e289138eb7f24/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:222dbf516ccc877afcad4e4789a81b4ee93daaa9f0ad97c464417d9597f49449", size = 59340859, upload-time = "2026-02-27T02:57:06.125Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/9f/06fad4ae8a723ae7096b5311eba67ad8b4df5f359c0a68e366750b7fef78/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b35d6fcccfe4fb0a409392d237fbc67796bac0d357b996bc12d057a1531a238b", size = 59838751, upload-time = "2026-02-27T02:57:10.449Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/72/4916dadc7307c3e9bcfa43b4b6f88237932d502c66f89eb2d90fb07810db/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:519507fb74f3f2b296ab1e9f00dcc211f36bbfb93c60229e72dcdee9dafd301a", size = 61340534, upload-time = "2026-02-27T02:57:15.309Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/a8ba881ee5d04b04e0d93abc8ce501ff7292813583e97f9789eb3fc0472a/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:68c93c52ff06d704bcb5ed160b4ba04ab1b291d238aaf996b03a5396e0e9a7ed", size = 61922394, upload-time = "2026-02-27T02:57:20.24Z" },
-    { url = "https://files.pythonhosted.org/packages/60/8c/b8c5f61201c72a0c7dc694b459941f89a6defda85deff258a9940a4e2efc/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:60b83c4e98b0c7d836ac9ccb67dcb36e343691cbe62cd325799ff9ed936286f3", size = 41218783, upload-time = "2026-02-27T02:57:24.175Z" },
-    { url = "https://files.pythonhosted.org/packages/91/23/1f904bc9cbd8eece393e20840c08ba3ac03440090c3a4e95168fa6d2709f/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:78a9bd1d6b11baf1433f9fb84962ff8aa71c87d48b6434f98224bc49a2253a6e", size = 38926103, upload-time = "2026-02-27T02:57:27.458Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
@@ -171,6 +152,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -271,6 +265,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fix `tasks.py` to handle missing optional shell tools gracefully, and add a pre-commit hook for early lint/type checking.

## Changes

### `tasks.py`

- **`shell_lint()`**: Stop treating missing `shfmt`/`shellcheck` as lint failures. When either tool is absent, print a warning and skip the check instead of setting `rc=1`. This aligns with the existing `pwsh`/PSScriptAnalyzer behavior and unblocks the pre-commit hook on machines that lack these optional tools.

- **`shell_format()`**: Guard against `FileNotFoundError` by resolving `shfmt` via `shutil.which()` before invoking it, matching the lookup pattern already used in `shell_lint()`. Print an explicit error message when the tool is missing.

### `.githooks/pre-commit` (new)

- Add a pre-commit hook that runs lint (`uv run tasks.py lint`) and type checks (`uv run tasks.py typecheck`) before allowing a commit, catching formatting and type errors early before they reach CI.

## Problem

Running `git commit` failed before even prompting for a message because the pre-commit hook ran `uv run tasks.py lint`, which set `rc=1` when `shfmt` was not on PATH — even though the missing tool was supposed to be optional.