### PR TITLE
[zutils] E: Add lint and format lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Build orchestration utilities for the [Nanvix](https://github.com/nanvix/nanvix)
 
 `nanvix_zutil` is a Python 3.12+ library that provides a unified `ZScript`
 base class with lifecycle hooks (`setup`, `distclean`, `build`, `test`, `benchmark`,
-`release`, `clean`, `lock`), structured logging, config persistence, GitHub release
-artifact downloading, lockfile-based dependency resolution, and deterministic
-exit codes.
+`release`, `clean`, `lock`, `lint`, `format`), structured logging, config persistence,
+GitHub release artifact downloading, lockfile-based dependency resolution, and
+deterministic exit codes.
 
 ## Quick Start
 
@@ -32,6 +32,8 @@ Then invoke via the bootstrap wrapper or the `nanvix-zutil` CLI:
 ./z setup            # download sysroot + install dependencies
 ./z build            # cross-compile (Docker auto-enabled)
 ./z test             # run tests
+./z lint             # black --check + pyright on .nanvix/*.py
+./z format           # auto-format .nanvix/*.py with black
 ./z distclean        # remove all generated artifacts
 ```
 
@@ -42,6 +44,8 @@ nanvix-zutil lock    # resolve dependency graph → nanvix.lock
 nanvix-zutil setup   # download sysroot + install deps
 nanvix-zutil build   # cross-compile
 nanvix-zutil test    # run tests
+nanvix-zutil lint    # lint .nanvix/*.py
+nanvix-zutil format  # format .nanvix/*.py
 ```
 
 ## Installation
@@ -66,7 +70,7 @@ version into `.nanvix/venv/`.
 ## Documentation
 
 | Document | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | [Design Overview](doc/design.md) | Architecture, module graph, data flow |
 | [Setup](doc/setup.md) | Developer environment setup |
 | [Build](doc/build.md) | How to build the project |
@@ -76,7 +80,7 @@ version into `.nanvix/venv/`.
 Additional references:
 
 | Document | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | [Manifest Reference](docs/manifest.md) | `nanvix.toml` format and options |
 | [Local Development (`--with-nanvix`)](docs/with-nanvix.md) | Using local Nanvix builds |
 | [Contributing](CONTRIBUTING.md) | Contribution guidelines and release process |

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -25,13 +25,21 @@ uv run tasks.py setup         # configure git hooks
 `uv sync` creates a `.venv/` virtualenv and installs all dependencies
 (runtime + dev group) declared in `pyproject.toml`.
 
+## Dependency Groups
+
+| Group | Scope | Contents |
+| ----- | ----- | -------- |
+| `[project] dependencies` | Runtime | `tomli-w` |
+| `[project.optional-dependencies] lint` | Consumer repos | `black`, `pyright` — installed in consumer venvs via `nanvix-zutil[lint]` |
+| `[dependency-groups] dev` | Dev only | `black`, `pyright`, `pytest`, `yamllint` |
+
 ## Git Hooks
 
 `uv run tasks.py setup` points Git at the `.githooks/` directory, which
 contains:
 
 | Hook | What it does |
-|------|-------------|
+| ------ | ------------- |
 | `commit-msg` | Validates `[module] (B\|E\|F\|W): Description` format. Valid modules: `zutils`, `ci`, `doc`, `git`, `tests`, `build`, `examples` |
 | `pre-commit` | Runs `tasks.py lint` (black, shfmt, shellcheck, PSScriptAnalyzer, yamllint) + `tasks.py typecheck` (pyright) |
 | `pre-push` | Runs `tasks.py lint` + `tasks.py typecheck` (same checks as pre-commit) |
@@ -42,7 +50,7 @@ These are used by the library at runtime (in consumer repos), not during
 development of `nanvix-zutil` itself:
 
 | Variable | Default | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `NANVIX_TARGET` | `x86` | Target architecture |
 | `NANVIX_MACHINE` | `microvm` | Target machine |
 | `NANVIX_DEPLOYMENT_MODE` | `standalone` | Deployment mode |
@@ -53,17 +61,18 @@ development of `nanvix-zutil` itself:
 
 ## Project Layout
 
-```
+```text
 zutils/
-├── src/nanvix_zutil/   # Library source code
-├── tests/              # Test suite (pytest)
-├── templates/          # Bootstrap wrapper templates (z, z.sh, z.ps1)
-├── examples/           # Example consumer repos
-├── docs/               # Additional reference docs
-├── doc/                # Developer documentation
-├── tasks.py            # Dev task runner
-├── pyproject.toml      # Project metadata + dependencies
-└── .githooks/          # Git hooks (commit-msg, pre-push)
+├── src/nanvix_zutil/          # Library source code
+│   └── configs/               # Canonical tool configs synced to consumers
+├── tests/                     # Test suite (pytest)
+├── templates/                 # Bootstrap wrapper templates (z, z.sh, z.ps1)
+├── examples/                  # Example consumer repos
+├── docs/                      # Additional reference docs
+├── doc/                       # Developer documentation
+├── tasks.py                   # Dev task runner
+├── pyproject.toml             # Project metadata + dependencies
+└── .githooks/                 # Git hooks (commit-msg, pre-push)
 ```
 
 ## IDE Configuration

--- a/examples/bin-hello/z.ps1
+++ b/examples/bin-hello/z.ps1
@@ -70,7 +70,7 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
-    & $venvPython -m pip install --quiet $wheelUrl
+    & $venvPython -m pip install --quiet "$($wheelUrl)[lint]"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }

--- a/examples/bin-hello/z.sh
+++ b/examples/bin-hello/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
+    "$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/examples/lib-hello/z.ps1
+++ b/examples/lib-hello/z.ps1
@@ -70,7 +70,7 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
-    & $venvPython -m pip install --quiet $wheelUrl
+    & $venvPython -m pip install --quiet "$($wheelUrl)[lint]"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }

--- a/examples/lib-hello/z.sh
+++ b/examples/lib-hello/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
+    "$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "tomli-w>=1.2.0",
 ]
 
+[project.optional-dependencies]
+lint = ["black", "pyright"]
+
 [dependency-groups]
 dev = [
   "black",

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -35,6 +35,8 @@ SUBCOMMANDS: tuple[str, ...] = (
     "release",
     "clean",
     "lock",
+    "lint",
+    "format",
     "help",
 )
 
@@ -57,6 +59,8 @@ _SUBCOMMAND_HELP: dict[str, str] = {
     "release": "Package a release",
     "clean": "Remove build artifacts",
     "lock": "Resolve dependencies and write nanvix.lock",
+    "lint": "Run linters (black --check + pyright) on .nanvix/*.py",
+    "format": "Format .nanvix/*.py with black",
     "help": "Show help message",
 }
 
@@ -137,6 +141,13 @@ def build_parser(
                 action="store_true",
                 default=False,
                 help="Resolve only direct dependencies (skip transitive discovery)",
+            )
+        if name == "format":
+            sub.add_argument(
+                "--check",
+                action="store_true",
+                default=False,
+                help="Check formatting without modifying files (exit non-zero on diff)",
             )
         if name in DOCKER_SUBCOMMANDS:
             sub.add_argument(

--- a/src/nanvix_zutil/configs/black.toml
+++ b/src/nanvix_zutil/configs/black.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+target-version = ["py312"]

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -125,7 +125,14 @@ class ZScript:
 
     #: Hooks that are auto-implemented in the base class and always
     #: available in the CLI, regardless of subclass overrides.
-    AUTO_HOOKS: tuple[str, ...] = ("setup", "distclean", "lock", "help")
+    AUTO_HOOKS: tuple[str, ...] = (
+        "setup",
+        "distclean",
+        "lock",
+        "lint",
+        "format",
+        "help",
+    )
 
     #: Consumer-defined hooks that appear in the CLI only when the
     #: subclass overrides the corresponding method.
@@ -422,6 +429,7 @@ class ZScript:
     _CONFIG_FILES: dict[str, str] = {
         "pyrightconfig.json": "pyrightconfig.json",
         ".yamllint.yml": ".yamllint.yml",
+        "black.toml": "black.toml",
     }
 
     def _sync_configs(self) -> None:
@@ -518,6 +526,66 @@ class ZScript:
                 "Lockfile is stale — nanvix.toml has changed since it was generated.",
                 code=EXIT_INVALID_ARGS,
                 hint="Run `nanvix-zutil lock` to regenerate the lockfile.",
+            )
+
+    # ------------------------------------------------------------------
+    # Lint & format hooks — auto-implemented
+    # ------------------------------------------------------------------
+
+    def lint(self) -> None:
+        """Run linters on ``.nanvix/*.py``.
+
+        Runs ``black --check`` followed by ``pyright`` on all Python
+        files in the ``.nanvix/`` directory.  Exits with
+        ``EXIT_BUILD_FAILURE`` if either tool reports problems.
+        """
+        py_files = sorted(self.nanvix_dir.glob("*.py"))
+        if not py_files:
+            log.warning("No .py files found in .nanvix/ — nothing to lint")
+            return
+        str_files = [str(f) for f in py_files]
+        black_cfg = str(self.nanvix_dir / "black.toml")
+        pyright_cfg = str(self.nanvix_dir / "pyrightconfig.json")
+        self._run_tool("black", "--config", black_cfg, "--check", *str_files)
+        self._run_tool("pyright", "--project", pyright_cfg, *str_files)
+
+    def format(self, *, check: bool = False) -> None:
+        """Format ``.nanvix/*.py`` with black.
+
+        Args:
+            check: When ``True``, run ``black --check`` instead of
+                auto-formatting (exit non-zero on diff).
+        """
+        py_files = sorted(self.nanvix_dir.glob("*.py"))
+        if not py_files:
+            log.warning("No .py files found in .nanvix/ — nothing to format")
+            return
+        str_files = [str(f) for f in py_files]
+        black_cfg = str(self.nanvix_dir / "black.toml")
+        cmd = ["black", "--config", black_cfg]
+        if check:
+            cmd.append("--check")
+        cmd.extend(str_files)
+        self._run_tool(*cmd)
+
+    def _run_tool(self, *args: str) -> None:
+        """Run a host-side tool via ``sys.executable -m``, exiting on failure."""
+        import importlib.util as _imputil
+
+        tool = args[0]
+        if _imputil.find_spec(tool) is None:
+            log.fatal(
+                f"'{tool}' not found — install it with: "
+                f"pip install nanvix-zutil[lint]",
+                code=EXIT_MISSING_DEP,
+            )
+        cmd = [sys.executable, "-m", *args]
+        log.info(f"$ {' '.join(args)}")
+        result = subprocess.run(cmd, cwd=self.repo_root)
+        if result.returncode != 0:
+            log.fatal(
+                f"{tool} failed with exit code {result.returncode}",
+                code=EXIT_BUILD_FAILURE,
             )
 
     # ------------------------------------------------------------------
@@ -807,6 +875,12 @@ class ZScript:
                 instance.lock(shallow=args.shallow)
             return
 
+        # Special handling for format subcommand (--check flag).
+        if subcommand == "format":
+            instance.format(check=args.check)
+            log.success("Format complete")
+            return
+
         dispatch: dict[str, object] = {
             "setup": instance.setup,
             "distclean": instance.distclean,
@@ -815,6 +889,7 @@ class ZScript:
             "benchmark": instance.benchmark,
             "release": instance.release,
             "clean": instance.clean,
+            "lint": instance.lint,
         }
 
         handler = dispatch.get(subcommand) if subcommand is not None else None

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -70,7 +70,7 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
-    & $venvPython -m pip install --quiet $wheelUrl
+    & $venvPython -m pip install --quiet "$($wheelUrl)[lint]"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
+    "$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,5 +117,47 @@ class TestDockerFlags(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
+class TestLintFormatSubcommands(unittest.TestCase):
+    """Tests for lint and format subcommands."""
+
+    def test_lint_registered(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["lint"])
+        self.assertEqual(args.subcommand, "lint")
+
+    def test_format_registered(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["format"])
+        self.assertEqual(args.subcommand, "format")
+
+    def test_format_check_flag(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["format", "--check"])
+        self.assertTrue(args.check)
+
+    def test_format_check_default_false(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["format"])
+        self.assertFalse(args.check)
+
+    def test_lint_in_subcommands(self) -> None:
+        self.assertIn("lint", SUBCOMMANDS)
+
+    def test_format_in_subcommands(self) -> None:
+        self.assertIn("format", SUBCOMMANDS)
+
+    def test_lint_available_restricted(self) -> None:
+        """lint is accepted when in the available set."""
+        parser = build_parser(available=("lint", "help"))
+        args = parser.parse_args(["lint"])
+        self.assertEqual(args.subcommand, "lint")
+
+    def test_format_available_restricted(self) -> None:
+        """format is accepted when in the available set."""
+        parser = build_parser(available=("format", "help"))
+        args = parser.parse_args(["format"])
+        self.assertEqual(args.subcommand, "format")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -270,6 +270,7 @@ class TestZScriptSyncConfigs(unittest.TestCase):
         nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
         self.assertTrue((nanvix_dir / "pyrightconfig.json").exists())
         self.assertTrue((nanvix_dir / ".yamllint.yml").exists())
+        self.assertTrue((nanvix_dir / "black.toml").exists())
 
     def test_setup_skips_identical_configs(self) -> None:
         """setup() is a no-op for configs when content already matches."""
@@ -1246,6 +1247,234 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         # The dependency was satisfied locally so GitHub resolve should not
         # have been called.
         mock_resolve.assert_not_called()
+
+
+class TestZScriptLint(unittest.TestCase):
+    """Tests for ZScript.lint() default implementation."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_script(self) -> ZScript:
+        return ZScript(Path(self._tmpdir.name))
+
+    def test_lint_runs_black_and_pyright(self) -> None:
+        """lint() runs black --check and pyright on .nanvix/*.py files."""
+        script = self._make_script()
+        # Create a .py file in .nanvix/
+        py_file = script.nanvix_dir / "z.py"
+        py_file.write_text("x = 1\n")
+
+        calls: list[list[str]] = []
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            calls.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0)
+
+        with (
+            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+        ):
+            script.lint()
+
+        self.assertEqual(len(calls), 2)
+        self.assertIn("-m", calls[0])
+        self.assertIn("black", calls[0])
+        self.assertIn("--config", calls[0])
+        self.assertIn("--check", calls[0])
+        self.assertIn("-m", calls[1])
+        self.assertIn("pyright", calls[1])
+        self.assertIn("--project", calls[1])
+
+    def test_lint_no_py_files_warns(self) -> None:
+        """lint() warns and returns when no .py files exist."""
+        script = self._make_script()
+        # Remove all .py files from .nanvix/
+        for f in script.nanvix_dir.glob("*.py"):
+            f.unlink()
+
+        with patch("nanvix_zutil.script.log") as mock_log:
+            script.lint()
+
+        mock_log.warning.assert_called_once()
+        self.assertIn("nothing to lint", mock_log.warning.call_args[0][0].lower())
+
+    def test_lint_exits_on_black_failure(self) -> None:
+        """lint() exits with EXIT_BUILD_FAILURE when black fails."""
+        script = self._make_script()
+        py_file = script.nanvix_dir / "z.py"
+        py_file.write_text("x = 1\n")
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            return sp.CompletedProcess(args=cmd, returncode=1)
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+                patch("importlib.util.find_spec", return_value=True),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                script.lint()
+            self.assertEqual(ctx.exception.code, 5)
+        finally:
+            log_mod.set_json_mode(False)
+
+    def test_lint_exits_when_tool_missing(self) -> None:
+        """lint() exits with EXIT_MISSING_DEP when black is not installed."""
+        script = self._make_script()
+        py_file = script.nanvix_dir / "z.py"
+        py_file.write_text("x = 1\n")
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                patch("importlib.util.find_spec", return_value=None),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                script.lint()
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
+
+class TestZScriptFormat(unittest.TestCase):
+    """Tests for ZScript.format() default implementation."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_script(self) -> ZScript:
+        return ZScript(Path(self._tmpdir.name))
+
+    def test_format_runs_black(self) -> None:
+        """format() runs black on .nanvix/*.py files."""
+        script = self._make_script()
+        py_file = script.nanvix_dir / "z.py"
+        py_file.write_text("x = 1\n")
+
+        calls: list[list[str]] = []
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            calls.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0)
+
+        with (
+            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+        ):
+            script.format()
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("-m", calls[0])
+        self.assertIn("black", calls[0])
+        self.assertIn("--config", calls[0])
+        self.assertNotIn("--check", calls[0])
+
+    def test_format_check_mode(self) -> None:
+        """format(check=True) runs black --check."""
+        script = self._make_script()
+        py_file = script.nanvix_dir / "z.py"
+        py_file.write_text("x = 1\n")
+
+        calls: list[list[str]] = []
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            calls.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0)
+
+        with (
+            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+        ):
+            script.format(check=True)
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("-m", calls[0])
+        self.assertIn("black", calls[0])
+        self.assertIn("--config", calls[0])
+        self.assertIn("--check", calls[0])
+
+    def test_format_no_py_files_warns(self) -> None:
+        """format() warns and returns when no .py files exist."""
+        script = self._make_script()
+        for f in script.nanvix_dir.glob("*.py"):
+            f.unlink()
+
+        with patch("nanvix_zutil.script.log") as mock_log:
+            script.format()
+
+        mock_log.warning.assert_called_once()
+        self.assertIn("nothing to format", mock_log.warning.call_args[0][0].lower())
+
+    def test_format_exits_on_failure(self) -> None:
+        """format() exits with EXIT_BUILD_FAILURE when black fails."""
+        script = self._make_script()
+        py_file = script.nanvix_dir / "z.py"
+        py_file.write_text("x = 1\n")
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            return sp.CompletedProcess(args=cmd, returncode=1)
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+                patch("importlib.util.find_spec", return_value=True),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                script.format()
+            self.assertEqual(ctx.exception.code, 5)
+        finally:
+            log_mod.set_json_mode(False)
+
+
+class TestZScriptLintInAutoHooks(unittest.TestCase):
+    """lint and format appear in AUTO_HOOKS and available_subcommands."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_lint_in_auto_hooks(self) -> None:
+        self.assertIn("lint", ZScript.AUTO_HOOKS)
+
+    def test_format_in_auto_hooks(self) -> None:
+        self.assertIn("format", ZScript.AUTO_HOOKS)
+
+    def test_lint_always_available(self) -> None:
+        script = ZScript(Path(self._tmpdir.name))
+        self.assertIn("lint", script.available_subcommands())
+
+    def test_format_always_available(self) -> None:
+        script = ZScript(Path(self._tmpdir.name))
+        self.assertIn("format", script.available_subcommands())
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,12 @@ dependencies = [
     { name = "tomli-w" },
 ]
 
+[package.optional-dependencies]
+lint = [
+    { name = "black" },
+    { name = "pyright" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "black" },
@@ -90,7 +96,12 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "tomli-w", specifier = ">=1.2.0" }]
+requires-dist = [
+    { name = "black", marker = "extra == 'lint'" },
+    { name = "pyright", marker = "extra == 'lint'" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+]
+provides-extras = ["lint"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Add `lint` and `format` as auto-implemented ZScript hooks so consumer
repos get `./z lint` (black --check + pyright) and `./z format` (black)
on `.nanvix/*.py` files out of the box.

## Script changes
- Add `lint()` and `format()` to `ZScript` with `AUTO_HOOKS` registration.
- Add `_run_tool()` helper that checks tool availability, logs the
  command, runs it, and exits with the appropriate code on failure.
- Pass `--config .nanvix/black.toml` so the synced config is used.
- Add canonical `configs/black.toml` synced to consumers via setup.
- Wire `format --check` flag with special dispatch in `main()`.

## CLI changes
- Register `lint` and `format` subcommands with help text.
- Add `--check` flag to `format` subcommand.

## Bootstrap wrappers
- Install `nanvix-zutil[lint]` extra in consumer venvs (templates +
  examples) so black and pyright are available at runtime.
- Use `$($wheelUrl)[lint]` in PowerShell to avoid bracket
  interpretation.

## Packaging
- Add `[project.optional-dependencies] lint = ["black", "pyright"]`
  to `pyproject.toml`.

## Docs
- Update `README.md` and `doc/setup.md` with new subcommands, dependency
  groups table, and project layout refresh.

## Tests
- Add `TestLintFormatSubcommands` (CLI registration, `--check` flag).
- Add `TestZScriptLint` (runs tools, warns on no files, exits on
  failure, exits on missing tool).
- Add `TestZScriptFormat` (runs black, check mode, warns, exits).
- Add `TestZScriptLintInAutoHooks` (`AUTO_HOOKS` + `available_subcommands`).

## Issues

Closes #151 