### PR TITLE
Use PEP 508 syntax for pip install with extras from URL

### DIFF
--- a/examples/bin-hello/z.ps1
+++ b/examples/bin-hello/z.ps1
@@ -70,7 +70,7 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
-    & $venvPython -m pip install --quiet "$($wheelUrl)[lint]"
+    & $venvPython -m pip install --quiet "nanvix-zutil[lint] @ $($wheelUrl)"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }

--- a/examples/bin-hello/z.sh
+++ b/examples/bin-hello/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "nanvix_zutil[lint] @ ${WHEEL_URL}"
+    "$VENV_PYTHON" -m pip install --quiet "nanvix-zutil[lint] @ ${WHEEL_URL}"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/examples/bin-hello/z.sh
+++ b/examples/bin-hello/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"
+    "$VENV_PYTHON" -m pip install --quiet "nanvix_zutil[lint] @ ${WHEEL_URL}"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/examples/lib-hello/z.ps1
+++ b/examples/lib-hello/z.ps1
@@ -70,7 +70,7 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
-    & $venvPython -m pip install --quiet "$($wheelUrl)[lint]"
+    & $venvPython -m pip install --quiet "nanvix-zutil[lint] @ $($wheelUrl)"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }

--- a/examples/lib-hello/z.sh
+++ b/examples/lib-hello/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "nanvix_zutil[lint] @ ${WHEEL_URL}"
+    "$VENV_PYTHON" -m pip install --quiet "nanvix-zutil[lint] @ ${WHEEL_URL}"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/examples/lib-hello/z.sh
+++ b/examples/lib-hello/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"
+    "$VENV_PYTHON" -m pip install --quiet "nanvix_zutil[lint] @ ${WHEEL_URL}"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -70,7 +70,7 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
-    & $venvPython -m pip install --quiet "$($wheelUrl)[lint]"
+    & $venvPython -m pip install --quiet "nanvix-zutil[lint] @ $($wheelUrl)"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "nanvix_zutil[lint] @ ${WHEEL_URL}"
+    "$VENV_PYTHON" -m pip install --quiet "nanvix-zutil[lint] @ ${WHEEL_URL}"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -46,7 +46,7 @@ function bootstrap() {
     fi
     # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"
+    "$VENV_PYTHON" -m pip install --quiet "nanvix_zutil[lint] @ ${WHEEL_URL}"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.


### PR DESCRIPTION
## Problem

The bootstrap in `z.sh` was using `"${WHEEL_URL}[lint]"` to install nanvix-zutil with the `[lint]` extras. This caused pip to URL-encode the brackets (`%5B`, `%5D`) as part of the wheel filename, resulting in a **404 error** when attempting to download:

```
ERROR: HTTP error 404 while getting https://github.com/nanvix/zutils/releases/download/v0.7.36/nanvix_zutil-0.7.36-py3-none-any.whl%5Blint%5D
```

## Fix

Use the correct PEP 508 direct-reference syntax:

```bash
# Before (broken)
"$VENV_PYTHON" -m pip install --quiet "${WHEEL_URL}[lint]"

# After (correct)
"$VENV_PYTHON" -m pip install --quiet "nanvix_zutil[lint] @ ${WHEEL_URL}"
```

This separates the package name + extras specifier from the download URL, which pip handles correctly.

## Files changed

- `templates/z.sh`
- `examples/lib-hello/z.sh`
- `examples/bin-hello/z.sh`