### PR TITLE
Detect stale sysroot and Windows binaries on setup

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -333,6 +333,7 @@ class ZScript:
                 deployment_mode=self.config.deployment_mode,
                 memory_size=self.config.memory_size,
                 gh_token=self.config.get(CFG_GH_TOKEN),
+                config=self.config,
             )
 
         # When --with-nanvix PATH is passed, overlay local build artifacts

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -10,6 +10,7 @@ machine, deployment mode, and memory-size configuration.
 
 from __future__ import annotations
 
+import shutil
 import tarfile
 from pathlib import Path
 
@@ -100,13 +101,8 @@ class Sysroot:
         """
         sysroot_dir = dest if dest is not None else _DEFAULT_SYSROOT_DIR
 
-        if sysroot_dir.exists():
-            if sysroot_dir.is_dir():
-                log.info(f"Sysroot already present at {sysroot_dir}")
-                cached_tag = (
-                    config.get("sysroot_tag", "") or "" if config is not None else ""
-                )
-                return Sysroot(sysroot_dir.resolve(), tag=cached_tag)
+        # Fail early if the path exists but is not a directory.
+        if sysroot_dir.exists() and not sysroot_dir.is_dir():
             log.fatal(
                 f"Sysroot path '{sysroot_dir}' exists but is not a directory.",
                 code=EXIT_MISSING_DEP,
@@ -114,9 +110,25 @@ class Sysroot:
                 " `./z setup` to download the Nanvix sysroot.",
             )
 
+        # Resolve the requested specifier to a canonical release tag so
+        # that comparisons against the cached tag are format-independent
+        # (e.g. "0.12.410" vs. "v0.12.410", or "latest").
         release = github.resolve_release(_SYSROOT_REPO, tag, gh_token, semver=True)
         tag_name = release.get("tag_name", "")
         resolved_tag = tag_name if isinstance(tag_name, str) else ""
+
+        if sysroot_dir.is_dir():
+            cached_tag = (
+                (config.get("sysroot_tag", "") or "") if config is not None else ""
+            )
+            if cached_tag and resolved_tag == cached_tag:
+                log.info(f"Sysroot already present at {sysroot_dir}")
+                return Sysroot(sysroot_dir.resolve(), tag=cached_tag)
+            log.info(
+                f"Sysroot tag mismatch (cached={cached_tag!r},"
+                f" resolved={resolved_tag!r}), re-downloading…"
+            )
+            shutil.rmtree(sysroot_dir)
 
         asset_prefix = _SYSROOT_ASSET_PREFIX.format(
             target=target,
@@ -159,6 +171,7 @@ class Sysroot:
         memory_size: str,
         gh_token: str | None = None,
         target: str = DEFAULT_TARGET,
+        config: Config | None = None,
     ) -> None:
         """Download Windows host binaries from the Nanvix release.
 
@@ -168,14 +181,33 @@ class Sysroot:
         ``mkramfs.exe``, and ``kernel.elf`` into the sysroot ``bin/``
         directory.
 
-        Skips silently if all required binaries are already present.
+        Skips silently if all required binaries are already present
+        and the persisted tag matches the current sysroot tag.  When
+        *config* is ``None`` the check falls back to file presence
+        alone (no tag comparison).
+
+        Args:
+            machine: Target machine identifier.
+            deployment_mode: Deployment mode string.
+            memory_size: Memory size string.
+            gh_token: Optional GitHub personal access token.
+            target: Target architecture (default: ``"x86"``).
+            config: Optional :class:`Config` used to persist the
+                ``windows_binaries_tag``.  When provided the tag is
+                checked on entry and written back on success.
         """
         import zipfile
 
         bin_dir = self.path / "bin"
-        if all((bin_dir / b).is_file() for b in WINDOWS_HOST_BINARIES):
-            log.info("Windows host binaries already present in sysroot")
-            return
+        all_present = all((bin_dir / b).is_file() for b in WINDOWS_HOST_BINARIES)
+        if all_present:
+            if config is None:
+                log.info("Windows host binaries already present in sysroot")
+                return
+            cached_win_tag = config.get("windows_binaries_tag", "") or ""
+            if cached_win_tag == self.tag:
+                log.info("Windows host binaries already present in sysroot")
+                return
 
         tag = self.tag
         if not tag:
@@ -218,8 +250,6 @@ class Sysroot:
                 if basename in wanted:
                     dest = bin_dir / basename
                     with zf.open(entry) as src, open(dest, "wb") as dst:
-                        import shutil
-
                         shutil.copyfileobj(src, dst)
                     log.info(f"Extracted {basename} to sysroot/bin/")
 
@@ -235,6 +265,9 @@ class Sysroot:
                 ),
             )
         else:
+            if config is not None:
+                config.set("windows_binaries_tag", tag)
+                config.save()
             log.success("Windows host binaries installed")
 
     # ------------------------------------------------------------------
@@ -264,8 +297,6 @@ class Sysroot:
                 f"--with-nanvix path is not a directory: {local_path}",
                 code=EXIT_MISSING_DEP,
             )
-
-        import shutil
 
         overlaid: list[str] = []
         for subdir in ("bin", "lib"):

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
-from nanvix_zutil.config import DEFAULT_TARGET
-from nanvix_zutil.sysroot import Sysroot
+from nanvix_zutil.config import Config, DEFAULT_TARGET
+from nanvix_zutil.sysroot import WINDOWS_HOST_BINARIES, Sysroot
 
 
 def _make_tar_bz2(members: dict[str, bytes]) -> bytes:
@@ -45,21 +45,250 @@ class TestSysrootDownloadSkipsIfExists(unittest.TestCase):
         log_mod.set_json_mode(False)
 
     def test_skips_download_when_dest_exists(self) -> None:
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir.mkdir()
         dest = Path(self._tmpdir.name) / "sysroot"
         dest.mkdir()
 
-        with patch("nanvix_zutil.github.download_release_asset") as mock_dl:
+        config = Config(nanvix_dir)
+        config.set("sysroot_tag", "v1.0.0")
+        config.save()
+
+        with (
+            patch(
+                "nanvix_zutil.github.resolve_release",
+                return_value={"tag_name": "v1.0.0"},
+            ),
+            patch("nanvix_zutil.github.download_release_asset") as mock_dl,
+        ):
             sysroot = Sysroot.download(
                 machine="hyperlight",
                 deployment_mode="multi-process",
                 memory_size="128mb",
                 tag="v1.0.0",
                 dest=dest,
+                config=config,
             )
             mock_dl.assert_not_called()
 
         self.assertEqual(sysroot.path, dest.resolve())
-        self.assertEqual(sysroot.tag, "")
+        self.assertEqual(sysroot.tag, "v1.0.0")
+
+
+class TestSysrootDownloadStaleDetection(unittest.TestCase):
+    """Sysroot.download() re-downloads when the cached tag differs from the requested tag."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_redownloads_when_tag_mismatches(self) -> None:
+        """If sysroot exists but cached tag != requested tag, re-download."""
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir.mkdir()
+        dest = Path(self._tmpdir.name) / "sysroot"
+        dest.mkdir()
+        (dest / "lib").mkdir()
+        (dest / "lib" / "old.a").write_bytes(b"old")
+
+        config = Config(nanvix_dir)
+        config.set("sysroot_tag", "v1.0.0")
+        config.save()
+
+        archive = _make_tar_bz2({"lib/new.a": b"new"})
+        archive_path = Path(self._tmpdir.name) / "nanvix.tar.bz2"
+        archive_path.write_bytes(archive)
+
+        with (
+            patch(
+                "nanvix_zutil.github.resolve_release",
+                return_value={"tag_name": "v2.0.0"},
+            ),
+            patch(
+                "nanvix_zutil.github.download_release_asset",
+                return_value=archive_path,
+            ) as mock_dl,
+        ):
+            sysroot = Sysroot.download(
+                machine="microvm",
+                deployment_mode="standalone",
+                memory_size="256mb",
+                tag="v2.0.0",
+                dest=dest,
+                config=config,
+            )
+            mock_dl.assert_called_once()
+
+        self.assertEqual(sysroot.tag, "v2.0.0")
+        self.assertTrue((sysroot.path / "lib" / "new.a").exists())
+
+    def test_skips_download_when_tag_matches(self) -> None:
+        """If sysroot exists and cached tag == requested tag, skip download."""
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir.mkdir()
+        dest = Path(self._tmpdir.name) / "sysroot"
+        dest.mkdir()
+
+        config = Config(nanvix_dir)
+        config.set("sysroot_tag", "v1.0.0")
+        config.save()
+
+        with (
+            patch(
+                "nanvix_zutil.github.resolve_release",
+                return_value={"tag_name": "v1.0.0"},
+            ),
+            patch("nanvix_zutil.github.download_release_asset") as mock_dl,
+        ):
+            sysroot = Sysroot.download(
+                machine="microvm",
+                deployment_mode="standalone",
+                memory_size="256mb",
+                tag="v1.0.0",
+                dest=dest,
+                config=config,
+            )
+            mock_dl.assert_not_called()
+
+        self.assertEqual(sysroot.tag, "v1.0.0")
+
+    def test_skips_when_bare_semver_resolves_to_cached_v_tag(self) -> None:
+        """Requesting '1.0.0' that resolves to 'v1.0.0' should cache-hit."""
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir.mkdir()
+        dest = Path(self._tmpdir.name) / "sysroot"
+        dest.mkdir()
+
+        config = Config(nanvix_dir)
+        config.set("sysroot_tag", "v1.0.0")
+        config.save()
+
+        with (
+            patch(
+                "nanvix_zutil.github.resolve_release",
+                return_value={"tag_name": "v1.0.0"},
+            ),
+            patch("nanvix_zutil.github.download_release_asset") as mock_dl,
+        ):
+            sysroot = Sysroot.download(
+                machine="microvm",
+                deployment_mode="standalone",
+                memory_size="256mb",
+                tag="1.0.0",
+                dest=dest,
+                config=config,
+            )
+            mock_dl.assert_not_called()
+
+        self.assertEqual(sysroot.tag, "v1.0.0")
+
+    def test_skips_when_latest_resolves_to_cached_tag(self) -> None:
+        """Requesting 'latest' that resolves to the cached tag should cache-hit."""
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir.mkdir()
+        dest = Path(self._tmpdir.name) / "sysroot"
+        dest.mkdir()
+
+        config = Config(nanvix_dir)
+        config.set("sysroot_tag", "v0.12.410")
+        config.save()
+
+        with (
+            patch(
+                "nanvix_zutil.github.resolve_release",
+                return_value={"tag_name": "v0.12.410"},
+            ),
+            patch("nanvix_zutil.github.download_release_asset") as mock_dl,
+        ):
+            sysroot = Sysroot.download(
+                machine="microvm",
+                deployment_mode="standalone",
+                memory_size="256mb",
+                tag="latest",
+                dest=dest,
+                config=config,
+            )
+            mock_dl.assert_not_called()
+
+        self.assertEqual(sysroot.tag, "v0.12.410")
+
+
+class TestWindowsBinariesStaleDetection(unittest.TestCase):
+    """download_windows_binaries() re-downloads when the tag changes."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_redownloads_when_tag_changes(self) -> None:
+        """If Windows binaries exist but persisted tag differs, re-download."""
+        import zipfile
+
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir.mkdir()
+        sysroot_dir = Path(self._tmpdir.name) / "sysroot"
+        bin_dir = sysroot_dir / "bin"
+        bin_dir.mkdir(parents=True)
+        for b in WINDOWS_HOST_BINARIES:
+            (bin_dir / b).write_bytes(b"old-binary")
+
+        config = Config(nanvix_dir)
+        config.set("windows_binaries_tag", "v1.0.0")
+        config.save()
+
+        sysroot = Sysroot(sysroot_dir, tag="v2.0.0")
+
+        zip_path = Path(self._tmpdir.name) / "win.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for b in WINDOWS_HOST_BINARIES:
+                zf.writestr(f"bin/{b}", "new-binary")
+
+        with (
+            patch(
+                "nanvix_zutil.github.resolve_release",
+                return_value={"tag_name": "v2.0.0"},
+            ),
+            patch(
+                "nanvix_zutil.github.download_release_asset",
+                return_value=zip_path,
+            ) as mock_dl,
+        ):
+            sysroot.download_windows_binaries(
+                machine="microvm",
+                deployment_mode="standalone",
+                memory_size="256mb",
+                config=config,
+            )
+            mock_dl.assert_called_once()
+
+        self.assertEqual((bin_dir / "nanvixd.exe").read_bytes(), b"new-binary")
+        self.assertEqual(config.get("windows_binaries_tag"), "v2.0.0")
+
+    def test_skips_without_config_when_files_present(self) -> None:
+        """When config is None, skip based on file presence alone."""
+        sysroot_dir = Path(self._tmpdir.name) / "sysroot"
+        bin_dir = sysroot_dir / "bin"
+        bin_dir.mkdir(parents=True)
+        for b in WINDOWS_HOST_BINARIES:
+            (bin_dir / b).write_bytes(b"binary")
+
+        sysroot = Sysroot(sysroot_dir, tag="v1.0.0")
+
+        with patch("nanvix_zutil.github.download_release_asset") as mock_dl:
+            sysroot.download_windows_binaries(
+                machine="microvm",
+                deployment_mode="standalone",
+                memory_size="256mb",
+            )
+            mock_dl.assert_not_called()
 
 
 class TestSysrootDownloadFetches(unittest.TestCase):


### PR DESCRIPTION
## Summary

`Sysroot.download()` unconditionally reused any existing sysroot directory regardless of which release tag it came from. When a consumer bumped its `nanvix.toml` sysroot ref, `./z setup` would silently keep the old artifacts, leading to hard-to-diagnose build or runtime failures.

Similarly, `download_windows_binaries()` only checked whether binary files existed on disk, never whether they matched the current release tag.

## Changes

- **Sysroot staleness detection** — `Sysroot.download()` now compares the requested tag against the persisted `sysroot_tag` in Config. On mismatch the stale directory is removed and re-downloaded.
- **Windows binaries staleness detection** — `download_windows_binaries()` accepts an optional `config` parameter, reads/writes `windows_binaries_tag` in `env.json`, and skips download only when both the files exist and the persisted tag matches.
- **Import cleanup** — Consolidate scattered `import shutil` into a single top-level import.
- **Precedence fix** — Parenthesise the `or ""` fallback in `cached_tag` so it groups before the ternary.
- **Call site update** — `ZScript._do_setup()` passes `config=self.config` to `download_windows_binaries()`.
- **Tests** — `TestSysrootDownloadStaleDetection`, `TestWindowsBinariesStaleDetection`, updated `TestSysrootDownloadSkipsIfExists`.

## Issues

Closes #125 