### PR TITLE
Add RefKind.LOCAL for filesystem path overrides

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -38,6 +38,7 @@ name (e.g. `zlib`); the repo is inferred as `nanvix/<name>`.
 | `dep = { tag = "v1.0" }` | `TAG` | no | Tag `v1.0` (exact) |
 | `dep = { commitish = "abc1234" }` | `COMMITISH` | no | Search `target_commitish` |
 | `dep = { id = 12345678 }` | `ID` | no | `GET /releases/12345678` |
+| *(env override is a path)* | `LOCAL` | no | Filesystem path — no GitHub resolution |
 
 Only **one** specifier key is allowed per table.
 
@@ -56,8 +57,12 @@ If that tag is not found and the sysroot commitish hash is available,
 the resolver falls back to `1.2.3-nanvix-{hash}` (e.g.
 `1.2.3-nanvix-e63706b`).
 
-`TAG`, `COMMITISH`, and `ID` refs are never suffixed — they resolve
-exactly as written.
+`TAG`, `COMMITISH`, `ID`, and `LOCAL` refs are never suffixed — they
+resolve exactly as written.
+
+When the sysroot ref is `LOCAL` (i.e. `NANVIX_VERSION` is a filesystem
+path), the auto-suffix step is skipped entirely — `VERSION` deps keep
+their bare version string.
 
 Refs that already contain `-nanvix-` are rejected to prevent accidental
 double-suffixing.
@@ -70,8 +75,11 @@ double-suffixing.
 | `NANVIX_VERSION_<NAME>` | Dependency `<name>` ref value (uppercase) |
 
 Overrides replace the **value** but keep the `RefKind` from the
-manifest.  `NANVIX_VERSION` bypasses semver validation (intended for
-development use).
+manifest — **unless** the override value looks like a filesystem path
+(absolute Unix path, Windows drive path, or relative `./`/`../` path),
+in which case the `RefKind` is changed to `LOCAL`.
+`NANVIX_VERSION` bypasses semver validation (intended for development
+use).
 
 ## Full example
 

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -70,6 +70,7 @@ class RefKind(Enum):
     COMMITISH = "commitish"
     ID = "id"
     VERSION = "version"
+    LOCAL = "local"
 
 
 @dataclass
@@ -79,8 +80,9 @@ class Ref:
     Attributes:
         kind: The specifier type — :attr:`RefKind.TAG` (exact tag match),
             :attr:`RefKind.COMMITISH` (match ``target_commitish``),
-            :attr:`RefKind.ID` (direct release fetch), or
-            :attr:`RefKind.VERSION` (suffixed with nanvix version).
+            :attr:`RefKind.ID` (direct release fetch),
+            :attr:`RefKind.VERSION` (suffixed with nanvix version), or
+            :attr:`RefKind.LOCAL` (filesystem path, no GitHub resolution).
         value: The version string, tag name, commitish, or release ID.
     """
 
@@ -122,8 +124,9 @@ class Dependency:
 def suffix_dep(dep: Dependency, version: str) -> Dependency:
     """Return a copy of *dep* with its VERSION ref suffixed with *version*.
 
-    If *dep* has a non-VERSION ref kind, or its value already contains
-    ``-nanvix-`` (e.g. from an env-var override), it is returned unchanged.
+    If *dep* has a non-VERSION ref kind (e.g. TAG, COMMITISH, ID, or
+    LOCAL), or its value already contains ``-nanvix-`` (e.g. from an
+    env-var override), it is returned unchanged.
 
     Args:
         dep: The dependency to suffix.

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -24,6 +24,7 @@ deferred to the resolver (which resolves the actual version first).
 from __future__ import annotations
 
 import os
+import re
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -65,6 +66,29 @@ class Manifest:
 # We are intentionally keeping the semver matching simple for now.
 _SPECIFIER_KEYS = frozenset({"version", "tag", "commitish", "id"})
 _URL_UNSAFE = set("/\\#?%")
+
+# Matches absolute Unix paths, Windows drive paths, and relative ./ or ../ paths.
+_LOCAL_PATH_RE = re.compile(
+    r"^(?:/|\./|\.\./|[A-Za-z]:[/\\])",
+)
+
+
+def is_local_path(value: str) -> bool:
+    """Return ``True`` if *value* looks like a filesystem path.
+
+    Recognised patterns:
+
+    - Absolute Unix paths: ``/home/me/build``
+    - Windows drive paths: ``C:\\Users\\me\\build`` or ``C:/build``
+    - Relative paths: ``./build`` or ``../build``
+
+    Args:
+        value: The raw environment variable value.
+
+    Returns:
+        ``True`` if *value* matches a filesystem path pattern.
+    """
+    return _LOCAL_PATH_RE.match(value) is not None
 
 
 def _validate_version_string(raw: str, context: str, path: Path) -> str:
@@ -257,7 +281,10 @@ def _parse_dependencies(
         if env_val is not None:
             # Env overrides MAY include "-nanvix-" for full control.
             # suffix_dep() will skip values that already contain it.
-            ref = Ref(kind=ref.kind, value=env_val)
+            if is_local_path(env_val):
+                ref = Ref(kind=RefKind.LOCAL, value=env_val)
+            else:
+                ref = Ref(kind=ref.kind, value=env_val)
 
         deps.append(Dependency(name=name, repo=f"nanvix/{name}", ref=ref))
     return deps
@@ -347,7 +374,10 @@ def load_manifest(path: Path) -> Manifest:
         # NOTE: NANVIX_VERSION intentionally bypasses semver validation.
         # This is a development escape hatch — CI may pass with a non-semver
         # sysroot version if this env var is set.
-        sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot)
+        if is_local_path(env_sysroot):
+            sysroot_ref = Ref(kind=RefKind.LOCAL, value=env_sysroot)
+        else:
+            sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot)
 
     # --- [dependencies] (optional) ---
     deps_raw: object = data.get("dependencies", {})
@@ -376,7 +406,11 @@ def load_manifest(path: Path) -> Manifest:
     # (which resolves the sysroot first and knows the actual version).
     # Strip the leading "v" from the sysroot version to match the release
     # tag format used by nanvix-zutil (e.g. "1.3.1-nanvix-0.12.291").
-    if sysroot_ref.value != "latest" and isinstance(sysroot_ref.value, str):
+    if (
+        sysroot_ref.value != "latest"
+        and isinstance(sysroot_ref.value, str)
+        and sysroot_ref.kind != RefKind.LOCAL
+    ):
         version_suffix = sysroot_ref.value.removeprefix("v")
         for dep in [*dependencies, *system_dependencies]:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -37,6 +37,7 @@ from nanvix_zutil import log
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
+    RefKind,
     extract_nanvix_version,
     extract_nanvix_version_base,
     suffix_dep,
@@ -313,15 +314,21 @@ class ZScript:
         """
         self._used_fallback = False
 
-        self.sysroot = Sysroot.download(
-            machine=self.config.machine,
-            deployment_mode=self.config.deployment_mode,
-            memory_size=self.config.memory_size,
-            tag=self.manifest.sysroot_ref.value,
-            gh_token=self.config.get(CFG_GH_TOKEN),
-            dest=self.nanvix_dir / "sysroot",
-            config=self.config,
-        )
+        if self.manifest.sysroot_ref.kind == RefKind.LOCAL:
+            self.sysroot = Sysroot.from_local(
+                Path(str(self.manifest.sysroot_ref.value)),
+                config=self.config,
+            )
+        else:
+            self.sysroot = Sysroot.download(
+                machine=self.config.machine,
+                deployment_mode=self.config.deployment_mode,
+                memory_size=self.config.memory_size,
+                tag=self.manifest.sysroot_ref.value,
+                gh_token=self.config.get(CFG_GH_TOKEN),
+                dest=self.nanvix_dir / "sysroot",
+                config=self.config,
+            )
         self.config.set(CFG_SYSROOT, str(self.sysroot.path))
 
         # On Windows, download host-native binaries (nanvixd.exe, mkramfs.exe)
@@ -362,6 +369,19 @@ class ZScript:
         if deps:
             self.buildroot = Buildroot.create(self.nanvix_dir / "buildroot")
             for dep in deps:
+                # LOCAL deps: install from the filesystem path directly.
+                if dep.ref.kind == RefKind.LOCAL:
+                    local_dep_path = Path(str(dep.ref.value))
+                    if not self.buildroot.install_local_nanvix(dep, local_dep_path):
+                        log.fatal(
+                            f"Local dependency path has no artifacts for"
+                            f" '{dep.name}': {local_dep_path}",
+                            code=EXIT_MISSING_DEP,
+                            hint=f"Ensure '{local_dep_path}/deps/{dep.name}/' "
+                            "contains lib/ and/or include/ directories.",
+                        )
+                    continue
+
                 # When --with-nanvix is active, try local artifacts first (only for nanvix-owned
                 # dependencies).
                 if (

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -65,6 +65,34 @@ class Sysroot:
     # ------------------------------------------------------------------
 
     @staticmethod
+    def from_local(local_path: Path, config: Config | None = None) -> "Sysroot":
+        """Use an existing local directory as the sysroot (no download).
+
+        Args:
+            local_path: Absolute or relative path to the sysroot directory.
+            config: Optional :class:`Config` instance; if provided the
+                resolved sysroot path is persisted.
+
+        Returns:
+            A :class:`Sysroot` pointing at *local_path*.
+
+        Raises:
+            SystemExit: If *local_path* does not exist or is not a directory.
+        """
+        resolved = Path(local_path).resolve()
+        if not resolved.is_dir():
+            log.fatal(
+                f"Local sysroot path is not a directory: {local_path}",
+                code=EXIT_MISSING_DEP,
+                hint="Set NANVIX_VERSION to a valid sysroot directory path.",
+            )
+        log.info(f"Using local sysroot at {resolved}")
+        if config is not None:
+            config.set("sysroot_tag", "")
+            config.save()
+        return Sysroot(resolved, tag="")
+
+    @staticmethod
     def download(
         machine: str,
         deployment_mode: str,

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -510,5 +510,33 @@ class TestInstallDepPreResolvedRelease(unittest.TestCase):
         self.assertEqual(captured_releases[0], fake_release)
 
 
+class TestRefKindLocal(unittest.TestCase):
+    """RefKind.LOCAL exists and round-trips correctly."""
+
+    def test_local_variant_exists(self) -> None:
+        self.assertEqual(RefKind.LOCAL.value, "local")
+
+    def test_local_ref_round_trip(self) -> None:
+        ref = Ref(kind=RefKind.LOCAL, value="/home/me/zlib-build")
+        self.assertEqual(ref.kind, RefKind.LOCAL)
+        self.assertEqual(ref.value, "/home/me/zlib-build")
+
+    def test_local_ref_windows_path(self) -> None:
+        ref = Ref(kind=RefKind.LOCAL, value="C:\\Users\\me\\build")
+        self.assertEqual(ref.kind, RefKind.LOCAL)
+        self.assertEqual(ref.value, "C:\\Users\\me\\build")
+
+    def test_suffix_dep_skips_local(self) -> None:
+        """suffix_dep returns LOCAL refs unchanged."""
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.LOCAL, value="/tmp/zlib"),
+        )
+        result = suffix_dep(dep, "0.12.410")
+        self.assertEqual(result.ref.kind, RefKind.LOCAL)
+        self.assertEqual(result.ref.value, "/tmp/zlib")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import RefKind
-from nanvix_zutil.manifest import load_manifest
+from nanvix_zutil.manifest import load_manifest, is_local_path
 
 from tests.testutils import make_toml
 
@@ -658,6 +658,152 @@ class TestLoadManifestTypeValidation(unittest.TestCase):
             load_manifest(path)
 
         self.assertEqual(ctx.exception.code, 2)
+
+
+class TestIsLocalPath(unittest.TestCase):
+    """is_local_path detects filesystem paths correctly."""
+
+    def test_unix_absolute(self) -> None:
+        self.assertTrue(is_local_path("/home/me/zlib-build"))
+
+    def test_unix_root(self) -> None:
+        self.assertTrue(is_local_path("/"))
+
+    def test_windows_drive_backslash(self) -> None:
+        self.assertTrue(is_local_path("C:\\Users\\me\\build"))
+
+    def test_windows_drive_forward_slash(self) -> None:
+        self.assertTrue(is_local_path("D:/builds/zlib"))
+
+    def test_windows_lowercase_drive(self) -> None:
+        self.assertTrue(is_local_path("c:\\builds"))
+
+    def test_relative_dot_slash(self) -> None:
+        self.assertTrue(is_local_path("./build"))
+
+    def test_relative_dot_dot_slash(self) -> None:
+        self.assertTrue(is_local_path("../build"))
+
+    def test_semver_not_path(self) -> None:
+        self.assertFalse(is_local_path("1.3.1"))
+
+    def test_tag_not_path(self) -> None:
+        self.assertFalse(is_local_path("v1.0.0"))
+
+    def test_commitish_not_path(self) -> None:
+        self.assertFalse(is_local_path("b7a6a3c"))
+
+    def test_latest_not_path(self) -> None:
+        self.assertFalse(is_local_path("latest"))
+
+    def test_empty_not_path(self) -> None:
+        self.assertFalse(is_local_path(""))
+
+
+class TestLoadManifestLocalRef(unittest.TestCase):
+    """Env var overrides with filesystem paths produce RefKind.LOCAL."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_dep_env_unix_path_produces_local(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/some/path"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "/some/path")
+
+    def test_dep_env_windows_path_produces_local(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "C:\\Users\\me\\build"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "C:\\Users\\me\\build")
+
+    def test_dep_env_relative_path_produces_local(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "./build/zlib"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "./build/zlib")
+
+    def test_dep_env_version_string_still_works(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "2.0.0"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
+
+    def test_sysroot_env_unix_path_produces_local(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml())
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "/path/to/sysroot"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.sysroot_ref.value, "/path/to/sysroot")
+
+    def test_sysroot_env_windows_path_produces_local(self) -> None:
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml())
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "C:\\nanvix\\sysroot"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.sysroot_ref.value, "C:\\nanvix\\sysroot")
+
+    def test_sysroot_env_version_still_works(self) -> None:
+        # make_toml default nanvix-version is a semver string, which
+        # _parse_nanvix_version maps to RefKind.TAG.  The env override
+        # keeps the manifest RefKind (TAG) and only replaces the value.
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml(nanvix_version="0.12.257"))
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "0.12.258"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
+
+    def test_local_sysroot_skips_dep_suffix(self) -> None:
+        """When sysroot is LOCAL, VERSION deps must NOT be auto-suffixed."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": "/path/to/sysroot"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
+        # Dep should NOT be suffixed — sysroot is local.
+        self.assertEqual(m.dependencies[0].ref.value, "1.3.1")
+
+    def test_local_dep_no_suffix(self) -> None:
+        """LOCAL dep refs are never suffixed, even with a concrete sysroot."""
+        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path.write_text(make_toml(nanvix_version="0.12.410", deps={"zlib": '"1.3.1"'}))
+
+        with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/my/zlib"}):
+            m = load_manifest(path)
+
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
+        self.assertEqual(m.dependencies[0].ref.value, "/my/zlib")
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.log as log_mod
+from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
     DEFAULT_DOCKER_IMAGE,
@@ -1497,6 +1498,147 @@ class TestZScriptLintInAutoHooks(unittest.TestCase):
     def test_format_always_available(self) -> None:
         script = ZScript(Path(self._tmpdir.name))
         self.assertIn("format", script.available_subcommands())
+
+
+class TestZScriptSetupLocalSysroot(unittest.TestCase):
+    """setup() with RefKind.LOCAL sysroot uses from_local, no GitHub."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_local_sysroot_skips_github(self) -> None:
+        """When sysroot ref is LOCAL, Sysroot.from_local is used."""
+        repo_root = Path(self._tmpdir.name)
+        # Create a local sysroot directory.
+        local_sysroot = repo_root / "my-sysroot"
+        local_sysroot.mkdir()
+
+        write_manifest(repo_root)
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
+            script = ZScript(repo_root)
+
+        # Verify manifest parsed as LOCAL.
+        self.assertEqual(script.manifest.sysroot_ref.kind, RefKind.LOCAL)
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download") as mock_download,
+            patch(
+                "nanvix_zutil.script.Sysroot.from_local",
+                return_value=MagicMock(path=local_sysroot, tag=""),
+            ) as mock_from_local,
+        ):
+            script.setup()
+            mock_download.assert_not_called()
+            mock_from_local.assert_called_once()
+
+    def test_local_sysroot_no_dep_suffix(self) -> None:
+        """When sysroot is LOCAL, VERSION deps are not suffixed."""
+        repo_root = Path(self._tmpdir.name)
+        local_sysroot = repo_root / "my-sysroot"
+        local_sysroot.mkdir()
+
+        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+
+        with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
+            script = ZScript(repo_root)
+
+        # VERSION dep should NOT be suffixed (sysroot is LOCAL).
+        self.assertEqual(script.manifest.dependencies[0].ref.value, "1.0")
+
+
+class TestZScriptSetupLocalDep(unittest.TestCase):
+    """setup() with RefKind.LOCAL dep installs from filesystem."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_local_dep_uses_install_local_nanvix(self) -> None:
+        """LOCAL deps call install_local_nanvix instead of GitHub."""
+        repo_root = Path(self._tmpdir.name)
+        local_dep_path = repo_root / "local-zlib"
+        # Create the expected local layout.
+        (local_dep_path / "deps" / "zlib" / "lib").mkdir(parents=True)
+        (local_dep_path / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
+
+        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        fake_sysroot.tag = "v0.1.0"
+
+        with (
+            patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": str(local_dep_path)}),
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+        ):
+            script = ZScript(repo_root)
+            script.setup()
+
+        # Dep was installed locally, buildroot should exist.
+        self.assertIsNotNone(script.buildroot)
+        # The local lib should have been copied into the buildroot.
+        buildroot_lib = script.buildroot.path / "lib" / "libz.a"  # type: ignore[union-attr]
+        self.assertTrue(buildroot_lib.exists())
+
+    def test_local_dep_no_github_call(self) -> None:
+        """LOCAL deps do not call resolve_release or download_release_asset."""
+        repo_root = Path(self._tmpdir.name)
+        local_dep_path = repo_root / "local-zlib"
+        (local_dep_path / "deps" / "zlib" / "lib").mkdir(parents=True)
+        (local_dep_path / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
+
+        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        fake_sysroot.tag = "v0.1.0"
+
+        with (
+            patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": str(local_dep_path)}),
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.resolve_release") as mock_resolve,
+            patch("nanvix_zutil.script.resolve_release_with_fallback") as mock_fallback,
+        ):
+            script = ZScript(repo_root)
+            script.setup()
+
+        mock_resolve.assert_not_called()
+        mock_fallback.assert_not_called()
+
+    def test_local_dep_missing_artifacts_exits(self) -> None:
+        """LOCAL dep with no artifacts at the path exits with code 3."""
+        repo_root = Path(self._tmpdir.name)
+        local_dep_path = repo_root / "empty-dir"
+        local_dep_path.mkdir()
+
+        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        fake_sysroot.tag = "v0.1.0"
+
+        log_mod.set_json_mode(True)
+        with (
+            patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": str(local_dep_path)}),
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            script = ZScript(repo_root)
+            script.setup()
+
+        self.assertEqual(ctx.exception.code, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -284,5 +284,53 @@ class TestSysrootOverlayLocal(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 3)
 
 
+class TestSysrootFromLocal(unittest.TestCase):
+    """Sysroot.from_local() uses a directory as-is, no download."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_returns_sysroot_pointing_at_path(self) -> None:
+        sysroot_dir = Path(self._tmpdir.name) / "my-sysroot"
+        sysroot_dir.mkdir()
+
+        sysroot = Sysroot.from_local(sysroot_dir)
+
+        self.assertEqual(sysroot.path, sysroot_dir.resolve())
+        self.assertEqual(sysroot.tag, "")
+
+    def test_does_not_call_github(self) -> None:
+        sysroot_dir = Path(self._tmpdir.name) / "my-sysroot"
+        sysroot_dir.mkdir()
+
+        with patch("nanvix_zutil.github.resolve_release") as mock_resolve:
+            with patch("nanvix_zutil.github.download_release_asset") as mock_dl:
+                Sysroot.from_local(sysroot_dir)
+                mock_resolve.assert_not_called()
+                mock_dl.assert_not_called()
+
+    def test_exits_if_path_not_directory(self) -> None:
+        log_mod.set_json_mode(True)
+        bad_path = Path(self._tmpdir.name) / "nonexistent"
+
+        with self.assertRaises(SystemExit) as ctx:
+            Sysroot.from_local(bad_path)
+        self.assertEqual(ctx.exception.code, 3)
+
+    def test_exits_if_path_is_file(self) -> None:
+        log_mod.set_json_mode(True)
+        file_path = Path(self._tmpdir.name) / "a-file"
+        file_path.write_text("not a dir")
+
+        with self.assertRaises(SystemExit) as ctx:
+            Sysroot.from_local(file_path)
+        self.assertEqual(ctx.exception.code, 3)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When `NANVIX_VERSION` or `NANVIX_VERSION_<NAME>` environment variables contain a filesystem path (absolute Unix path, Windows drive path, or relative `./`/`../` path), the manifest parser now produces `RefKind.LOCAL` instead of preserving the manifest's original `RefKind`.

`LOCAL` refs bypass GitHub release resolution entirely and skip the automatic nanvix version suffixing applied to `VERSION` refs.

## Changes

- **buildroot**: add `RefKind.LOCAL` enum variant; update `Ref` and `suffix_dep` docstrings to explicitly list all non-`VERSION` kinds
- **manifest**: add `is_local_path()` helper with regex detection for Unix absolute, Windows drive, and relative path patterns; apply `LOCAL` override logic in both `_parse_dependencies()` and `load_manifest()`; guard auto-suffix loop with `LOCAL` check
- **docs/manifest.md**: document `LOCAL` ref kind in specifier table, resolution rules, and env override semantics
- **tests**: add `TestRefKindLocal` (round-trip, suffix skip), `TestIsLocalPath` (positive/negative cases), and `TestLoadManifestLocalRef` (dep + sysroot overrides, suffix skipping, non-path values unchanged)