### PR TITLE
Add format & lint reusable workflow for consumers

### DIFF
--- a/templates/nanvix-ci.yml
+++ b/templates/nanvix-ci.yml
@@ -23,6 +23,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format-and-lint:
+    uses: nanvix/workflows/.github/workflows/nanvix-format-lint.yml@v{{WORKFLOW_VERSION}}
+    with:
+      zutil-version: "v{{ZUTIL_VERSION}}"
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v{{WORKFLOW_VERSION}}
     with:


### PR DESCRIPTION
## Summary

Adds a `nanvix-ci.yml` reusable workflow (`on: workflow_call`) that provides format and lint checks for downstream consumer repos.

## Checks Included

- **black** — Python format check (configurable paths, default: `.nanvix/z.py`)
- **pyright** — Type check using `.nanvix/pyrightconfig.json`
- **shfmt** — Shell script format check (configurable paths, default: `z z.sh`)
- **shellcheck** — Shell script linting
- **yamllint** — YAML lint on `.github/workflows/`

## Inputs

| Input | Required | Default | Description |
|-------|----------|---------|-------------|
| `zutil-version` | yes | — | nanvix-zutil version tag (e.g., `v0.7.41`) |
| `python-paths` | no | `.nanvix/z.py` | Space-separated Python paths for black |
| `shell-paths` | no | `z z.sh` | Space-separated shell scripts for shfmt/shellcheck |

## Template Update

The consumer template (`templates/nanvix-ci.yml`) now includes a `format-and-lint` job that calls this workflow.