### PR TITLE
Remove venv after distclean on Windows

### DIFF
--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -155,4 +155,14 @@ if ($bin -eq $venvZutil) {
 else {
     & $bin @filteredArray
 }
-exit $LASTEXITCODE
+
+$ec = $LASTEXITCODE
+
+# On Windows the venv's python.exe is locked while it runs, so the Python
+# distclean command cannot delete it.  Now that the interpreter has exited the
+# lock is released and the shell can safely remove the venv directory.
+if ($filteredArray -and $filteredArray[0] -eq "distclean" -and (Test-Path $venvDir)) {
+    Remove-Item $venvDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+exit $ec

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -107,4 +107,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# On Windows (Git Bash / MSYS2) the venv's python.exe is locked while it runs,
+# so the Python distclean command cannot delete it.  Run without exec so the
+# shell can remove the venv after the interpreter exits.
+if [[ "${ARGS[0]:-}" == "distclean" ]]; then
+    "$BIN" "${ARGS[@]}"
+    EC=$?
+    if [ -d "$VENV" ]; then
+        rm -rf "$VENV" 2>/dev/null || true
+    fi
+    exit $EC
+fi
+
 exec "$BIN" "${ARGS[@]}"


### PR DESCRIPTION
## Problem

On Windows, a running `.exe` cannot be deleted while the OS holds a file lock on it. Since `z.ps1` invokes Python from `.nanvix/venv/Scripts/python.exe`, the Python-level `distclean` command cannot delete the venv directory — it fails with:

```n PermissionError: [WinError 5] Access is denied: '...\\.nanvix\\venv\\Scripts\\python.exe'
```

## Solution

After the Python process exits (and the file lock is released), have the shell wrapper (`z.ps1` / `z.sh`) remove the venv directory if the subcommand was `distclean`.

This is the simplest and most reliable fix because:
- The shell outlives the Python process, so the lock is guaranteed to be released
- No timing heuristics, background processes, or PID polling needed
- Works in `z.ps1` (PowerShell) and `z.sh` (Bash/Git Bash on Windows)

## Changes

- **templates/z.ps1**: After invoking the Python command, remove `.nanvix/venv` if the subcommand was `distclean`
- **templates/z.sh**: For `distclean`, avoid `exec` so the shell remains to clean up the venv afterward