### PR TITLE
[build] Make `--with-docker IMAGE` required for `setup`, remove default Docker image

### DIFF
--- a/examples/lib-hello/.nanvix/.gitignore
+++ b/examples/lib-hello/.nanvix/.gitignore
@@ -1,7 +1,6 @@
 __pycache__/
 venv/
 cache/
-sysroot
 sysroot/
 buildroot/
 .yamllint.yml

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -62,7 +62,6 @@ from nanvix_zutil.config import (
 )
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
-    DEFAULT_DOCKER_IMAGE,
     SYSROOT_CONTAINER_PATH,
     TOOLCHAIN_CONTAINER_PATH,
     WORKSPACE_CONTAINER_PATH,
@@ -108,7 +107,6 @@ __all__ = [
     "CFG_TOOLCHAIN",
     "Config",
     "DEFAULT_DEPLOYMENT_MODE",
-    "DEFAULT_DOCKER_IMAGE",
     "DEFAULT_FORMATS",
     "DEFAULT_MACHINE",
     "DEFAULT_MEMORY_SIZE",

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -42,11 +42,9 @@ SUBCOMMANDS: tuple[str, ...] = (
 
 #: Subcommands that accept the ``--with-docker`` flag.
 #:
-#: Docker mode is always enabled for ``setup``, ``build``, ``release``,
-#: and ``clean`` — if Docker or the image is unavailable the command
-#: fails immediately.  The ``--with-docker`` flag on ``setup`` allows
-#: the consumer to override the default Docker image with a custom one.
-#: ``test`` and ``benchmark`` run natively on the host.
+#: ``--with-docker IMAGE`` is required on ``setup`` to specify the Docker
+#: image.  ``build``, ``release``, and ``clean`` load the image from
+#: persisted config (set during ``setup``).
 DOCKER_SUBCOMMANDS: tuple[str, ...] = ("setup",)
 
 #: Human-readable descriptions for each subcommand.
@@ -152,17 +150,15 @@ def build_parser(
         if name in DOCKER_SUBCOMMANDS:
             sub.add_argument(
                 "--with-docker",
-                nargs="?",
-                const=True,
-                default=None,
+                type=str,
+                required=True,
                 metavar="IMAGE",
                 dest="with_docker",
-                help="Override the default Docker image"
-                " (nanvix/toolchain:latest-minimal). Docker mode is"
-                " always enabled for setup/build/release/clean; this"
-                " flag only changes the image. The image is persisted"
-                " to .nanvix/env.json so that subsequent commands use"
-                " it. test and benchmark always run on the host.",
+                help="Docker image to use for containerised builds."
+                " The image is persisted to .nanvix/env.json so that"
+                " subsequent build/release/clean commands use it"
+                " automatically. test and benchmark always run on"
+                " the host.",
             )
 
     return parser

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -9,10 +9,9 @@ Docker mode is always enabled for ``setup``, ``build``, ``release``, and
 ``clean`` — if Docker or the required image is unavailable the command
 fails immediately.  ``test`` and ``benchmark`` run natively on the host.
 
-Use ``--with-docker IMAGE`` during setup to override the default image::
+Use ``--with-docker IMAGE`` during setup to specify the Docker image::
 
-    ./z setup                                     # default image
-    ./z setup --with-docker nanvix/toolchain:v1.2.3  # custom image
+    ./z setup --with-docker nanvix/toolchain:v1.2.3
 """
 
 from __future__ import annotations
@@ -41,11 +40,6 @@ BUILDROOT_CONTAINER_PATH: PurePosixPath = PurePosixPath("/mnt/buildroot")
 
 #: Container path for the Nanvix cross-compilation toolchain.
 TOOLCHAIN_CONTAINER_PATH: PurePosixPath = PurePosixPath("/opt/nanvix")
-
-#: Default Docker image used when ``--with-docker`` is passed
-#: without an explicit image argument.
-DEFAULT_DOCKER_IMAGE: str = "nanvix/toolchain:latest-minimal"
-
 
 # ---------------------------------------------------------------------------
 # Platform helpers

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -46,7 +46,6 @@ from nanvix_zutil.cli import build_parser
 from nanvix_zutil.config import CFG_DOCKER_IMAGE, CFG_GH_TOKEN, CFG_SYSROOT, Config
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
-    DEFAULT_DOCKER_IMAGE,
     SYSROOT_CONTAINER_PATH,
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
@@ -203,17 +202,6 @@ class ZScript:
     # ------------------------------------------------------------------
     # Docker hooks — override in subclass to customise
     # ------------------------------------------------------------------
-
-    def docker_image(self) -> str:
-        """Return the default Docker image name for this build script.
-
-        Override in a subclass to change the default.  The value is only
-        used when ``--with-docker`` is passed without an explicit image.
-
-        Returns:
-            Docker image reference string.
-        """
-        return DEFAULT_DOCKER_IMAGE
 
     def docker_config(self, image: str) -> DockerConfig:
         """Build the :class:`~nanvix_zutil.DockerConfig` for *image*.
@@ -819,11 +807,10 @@ class ZScript:
         # ------------------------------------------------------------------
         # Resolve Docker image from CLI flags or persisted config.
         #
-        # Docker mode is always enabled for setup, build, release, and
-        # clean.  The --with-docker flag on setup allows overriding the
-        # default image.  If Docker or the image is unavailable the
-        # command fails immediately — there is no fallback to native
-        # execution.  test and benchmark run natively on the host.
+        # setup requires --with-docker IMAGE explicitly.  build, release,
+        # and clean load the persisted image from .nanvix/env.json (set
+        # during setup).  If no persisted image exists the command fails.
+        # test and benchmark run natively on the host.
         # ------------------------------------------------------------------
         docker_image: str | None = None
         subcommand_name_for_docker: str | None = args.subcommand
@@ -833,37 +820,34 @@ class ZScript:
             {"setup", "build", "release", "clean"}
         )
 
-        # Subcommand-level flag (only present for setup).
+        # Subcommand-level flag (only present for setup — now required).
         with_docker_val = getattr(args, "with_docker", None)
         if isinstance(with_docker_val, str):
-            # --with-docker IMAGE  (explicit custom image)
             docker_image = with_docker_val
-        elif with_docker_val is True:
-            # --with-docker  (no argument → use default image)
-            docker_image = instance.docker_image()
 
-        # For build/release/clean, load persisted image or fall back to
-        # the default.  setup uses the default when --with-docker was
-        # not supplied.
+        # For build/release/clean, load persisted image.
         #
         # Exception: on Windows, setup downloads host-native binaries
         # via the GitHub API and does not invoke Docker.  Skip Docker
-        # auto-loading for setup on Windows unless the user explicitly
-        # requested it via --with-docker.
-        _skip_docker = (
-            is_windows()
-            and subcommand_name_for_docker == "setup"
-            and with_docker_val is None
-        )
+        # entirely for setup on Windows — the image is still persisted
+        # to .nanvix/env.json so that subsequent commands can use it,
+        # but we do not require Docker to be installed or the image to
+        # exist locally.
+        _skip_docker = is_windows() and subcommand_name_for_docker == "setup"
         if (
             docker_image is None
             and subcommand_name_for_docker in _DOCKER_COMMANDS
             and not _skip_docker
         ):
             persisted_image = instance.config.get(CFG_DOCKER_IMAGE)
-            docker_image = persisted_image or instance.docker_image()
+            if not persisted_image:
+                log.fatal(
+                    "No Docker image configured — run 'setup --with-docker IMAGE' first.",
+                    code=EXIT_INVALID_ARGS,
+                )
+            docker_image = persisted_image
 
-        if docker_image is not None:
+        if docker_image is not None and not _skip_docker:
             if not docker_available():
                 log.fatal(
                     "Docker is not available — install Docker to continue.",
@@ -877,11 +861,12 @@ class ZScript:
                 )
             instance.docker = instance.docker_config(docker_image)
 
-            # Persist Docker image on setup so subsequent commands
-            # automatically use the same image.
-            if subcommand_name_for_docker == "setup":
-                instance.config.set(CFG_DOCKER_IMAGE, docker_image)
-                instance.config.save()
+        # Persist Docker image on setup so subsequent commands
+        # automatically use the same image.  This runs even on
+        # Windows where Docker checks are skipped.
+        if docker_image is not None and subcommand_name_for_docker == "setup":
+            instance.config.set(CFG_DOCKER_IMAGE, docker_image)
+            instance.config.save()
 
         # ------------------------------------------------------------------
         # Dispatch to lifecycle hook

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,10 @@ class TestBuildParser(unittest.TestCase):
     def test_subcommands_registered(self) -> None:
         parser = build_parser()
         for cmd in SUBCOMMANDS:
-            args = parser.parse_args([cmd])
+            argv = [cmd]
+            if cmd == "setup":
+                argv += ["--with-docker", "test/image:tag"]
+            args = parser.parse_args(argv)
             self.assertEqual(args.subcommand, cmd)
 
     def test_no_subcommand(self) -> None:
@@ -56,7 +59,10 @@ class TestBuildParser(unittest.TestCase):
         parser = build_parser(available=available)
         # Registered commands parse correctly.
         for cmd in ("setup", "distclean", "build", "help"):
-            args = parser.parse_args([cmd])
+            argv = [cmd]
+            if cmd == "setup":
+                argv += ["--with-docker", "test/image:tag"]
+            args = parser.parse_args(argv)
             self.assertEqual(args.subcommand, cmd)
         # Unregistered command raises SystemExit.
         with self.assertRaises(SystemExit):
@@ -66,27 +72,35 @@ class TestBuildParser(unittest.TestCase):
         """available=None (default) registers every subcommand."""
         parser = build_parser(available=None)
         for cmd in SUBCOMMANDS:
-            args = parser.parse_args([cmd])
+            argv = [cmd]
+            # setup requires --with-docker IMAGE
+            if cmd == "setup":
+                argv += ["--with-docker", "test/image:tag"]
+            args = parser.parse_args(argv)
             self.assertEqual(args.subcommand, cmd)
 
 
 class TestDockerFlags(unittest.TestCase):
     """Tests for Docker CLI flags (subcommand-level)."""
 
-    def test_with_docker_flag(self) -> None:
+    def test_with_docker_requires_image(self) -> None:
+        """--with-docker without an image argument is rejected."""
         parser = build_parser()
-        args = parser.parse_args(["setup", "--with-docker"])
-        self.assertTrue(args.with_docker)
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["setup", "--with-docker"])
+        self.assertEqual(ctx.exception.code, 2)
 
     def test_with_docker_custom_image(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["setup", "--with-docker", "my/image:tag"])
         self.assertEqual(args.with_docker, "my/image:tag")
 
-    def test_docker_flags_default_to_off(self) -> None:
+    def test_setup_requires_with_docker(self) -> None:
+        """setup without --with-docker is rejected."""
         parser = build_parser()
-        args = parser.parse_args(["setup"])
-        self.assertIsNone(args.with_docker)
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["setup"])
+        self.assertEqual(ctx.exception.code, 2)
 
     def test_docker_flags_rejected_on_build(self) -> None:
         """build subcommand does not accept Docker flags (moved to setup)."""

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
-    DEFAULT_DOCKER_IMAGE,
     SYSROOT_CONTAINER_PATH,
     TOOLCHAIN_CONTAINER_PATH,
     WORKSPACE_CONTAINER_PATH,
@@ -264,9 +263,6 @@ class TestWellKnownPaths(unittest.TestCase):
 
     def test_toolchain_path(self) -> None:
         self.assertEqual(TOOLCHAIN_CONTAINER_PATH, PurePosixPath("/opt/nanvix"))
-
-    def test_default_image(self) -> None:
-        self.assertEqual(DEFAULT_DOCKER_IMAGE, "nanvix/toolchain:latest-minimal")
 
 
 class TestPlatformUidGid(unittest.TestCase):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -236,7 +236,7 @@ class TestLibHelloLifecycle(unittest.TestCase):
     def test_full_lifecycle(self) -> None:
         """Run setup → build → test and verify each step."""
         # setup
-        r = _run_z(_LIB_HELLO, "setup", "--with-docker")
+        r = _run_z(_LIB_HELLO, "setup", "--with-docker", _DOCKER_IMAGE)
         self.assertEqual(r.returncode, 0, r.stderr)
 
         # build

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -88,6 +88,18 @@ class TestIntegrationLifecycle(unittest.TestCase):
         fake_script = str(self._repo_root / ".nanvix" / "z.py")
         argv = [fake_script, subcommand] + (extra_argv or [])
 
+        # setup requires --with-docker IMAGE on the CLI.
+        if subcommand == "setup" and "--with-docker" not in argv:
+            argv += ["--with-docker", "test/image:tag"]
+
+        # build/release/clean need a persisted Docker image.
+        _DOCKER_COMMANDS = {"build", "release", "clean"}
+        if subcommand in _DOCKER_COMMANDS:
+            nanvix_dir = self._repo_root / ".nanvix"
+            env_json = nanvix_dir / "env.json"
+            if not env_json.exists():
+                env_json.write_text('{"NANVIX_DOCKER_IMAGE": "test/image:tag"}')
+
         created: list[_MockConsumer] = []
         original_init = _MockConsumer.__init__
 
@@ -138,10 +150,13 @@ class TestIntegrationLifecycle(unittest.TestCase):
         from io import StringIO
 
         fake_script = str(self._repo_root / ".nanvix" / "z.py")
-        # build hook records "build" but doesn't log — capture info from run()
-        # Instead verify that the --json flag propagates by checking log output
-        # of a info call that happens internally (e.g. no-op build emits nothing,
-        # but we can check the mode was set by attempting a direct log call).
+
+        # build needs a persisted Docker image.
+        nanvix_dir = self._repo_root / ".nanvix"
+        (nanvix_dir / "env.json").write_text(
+            '{"NANVIX_DOCKER_IMAGE": "test/image:tag"}'
+        )
+
         with (
             patch("sys.argv", [fake_script, "--json", "build"]),
             patch("nanvix_zutil.script.docker_available", return_value=True),
@@ -201,6 +216,12 @@ class TestIntegrationLifecycle(unittest.TestCase):
     def test_repo_root_inferred_from_nanvix_dir(self) -> None:
         """Repo root is the parent of the .nanvix/ directory."""
         fake_script = str(self._repo_root / ".nanvix" / "z.py")
+
+        # build needs a persisted Docker image.
+        nanvix_dir = self._repo_root / ".nanvix"
+        (nanvix_dir / "env.json").write_text(
+            '{"NANVIX_DOCKER_IMAGE": "test/image:tag"}'
+        )
 
         captured: list[Path] = []
         original_init = _MockConsumer.__init__

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -17,7 +17,6 @@ import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
-    DEFAULT_DOCKER_IMAGE,
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
@@ -751,10 +750,6 @@ class TestZScriptDockerIntegration(unittest.TestCase):
         script = self._make_script()
         self.assertIsNone(script.docker)
 
-    def test_docker_image_default(self) -> None:
-        script = self._make_script()
-        self.assertEqual(script.docker_image(), DEFAULT_DOCKER_IMAGE)
-
     def test_docker_config_returns_dockerconfig(self) -> None:
         script = self._make_script()
         cfg = script.docker_config("test-image")
@@ -929,7 +924,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
         self._tmpdir.cleanup()
 
     def test_build_auto_enables_docker_on_windows(self) -> None:
-        """build on Windows uses the default Docker image."""
+        """build on Windows uses the persisted Docker image."""
 
         class BuildScript(ZScript):
             def build(self) -> None:
@@ -940,6 +935,12 @@ class TestZScriptAutoDocker(unittest.TestCase):
         def _fake_build(self_inner: ZScript) -> None:
             nonlocal docker_configured
             docker_configured = self_inner.docker is not None
+
+        # Pre-persist Docker image so build can find it.
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        (nanvix_dir / "env.json").write_text(
+            '{"NANVIX_DOCKER_IMAGE": "nanvix/toolchain:latest-minimal"}'
+        )
 
         with (
             patch("sys.argv", ["z.py", "build"]),
@@ -954,7 +955,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
         self.assertTrue(docker_configured)
 
     def test_build_auto_enables_docker_on_linux(self) -> None:
-        """build on Linux also uses the default Docker image."""
+        """build on Linux uses the persisted Docker image."""
 
         class BuildScript(ZScript):
             def build(self) -> None:
@@ -965,6 +966,12 @@ class TestZScriptAutoDocker(unittest.TestCase):
         def _fake_build(self_inner: ZScript) -> None:
             nonlocal docker_configured
             docker_configured = self_inner.docker is not None
+
+        # Pre-persist Docker image so build can find it.
+        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        (nanvix_dir / "env.json").write_text(
+            '{"NANVIX_DOCKER_IMAGE": "nanvix/toolchain:latest-minimal"}'
+        )
 
         with (
             patch("sys.argv", ["z.py", "build"]),
@@ -1142,7 +1149,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
             return True
 
         with (
-            patch("sys.argv", ["z.py", "setup"]),
+            patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
             patch("nanvix_zutil.script.docker_available", return_value=True),
             patch("nanvix_zutil.script.image_exists", return_value=True),
             patch.object(ZScript, "setup", _setup_with_fallback),
@@ -1157,7 +1164,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
 
         with (
-            patch("sys.argv", ["z.py", "setup"]),
+            patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
             patch("nanvix_zutil.script.docker_available", return_value=True),
             patch("nanvix_zutil.script.image_exists", return_value=True),
             patch.object(ZScript, "setup", return_value=True),
@@ -1170,7 +1177,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
     def test_main_exits_0_on_clean_setup(self) -> None:
         """main() with setup subcommand completes normally when no fallback."""
         with (
-            patch("sys.argv", ["z.py", "setup"]),
+            patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
             patch("nanvix_zutil.script.docker_available", return_value=True),
             patch("nanvix_zutil.script.image_exists", return_value=True),
             patch.object(ZScript, "setup", return_value=False),
@@ -1197,7 +1204,10 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         sys.stderr = buf
         try:
             with (
-                patch("sys.argv", ["z.py", "--json", "setup"]),
+                patch(
+                    "sys.argv",
+                    ["z.py", "--json", "setup", "--with-docker", "test/image:tag"],
+                ),
                 patch("nanvix_zutil.script.docker_available", return_value=True),
                 patch("nanvix_zutil.script.image_exists", return_value=True),
                 patch.object(ZScript, "setup", return_value=True),


### PR DESCRIPTION
## Summary

Remove the `DEFAULT_DOCKER_IMAGE` constant and the `ZScript.docker_image()` hook. The `setup` subcommand now requires `--with-docker IMAGE` explicitly — there is no implicit default image.

`build`, `release`, and `clean` load the Docker image from persisted config (`.nanvix/env.json`) written during `setup`. If no persisted image exists, the command fails with `EXIT_INVALID_ARGS` instead of silently falling back to a default.

## Changes

- **cli.py**: change `--with-docker` from optional `nargs='?'` to required `type=str, required=True`; update help text.
- **docker.py**: remove `DEFAULT_DOCKER_IMAGE` constant and its docstring.
- **script.py**: remove `ZScript.docker_image()` method; replace fallback logic with a fatal error when no persisted image is found.
- **__init__.py**: remove `DEFAULT_DOCKER_IMAGE` from public re-exports.
- **tests**: supply `--with-docker IMAGE` where needed and pre-persist Docker image config for `build`/`release`/`clean` tests.
- **examples**: update `.gitignore` for lib-hello.