### PR TITLE
[ci] Fix release workflow detached HEAD failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ secrets.DISPATCH_TOKEN }}
 


### PR DESCRIPTION
## Problem

The **Build & Publish** job in the release workflow (`release.yml`) fails at the
Release step with:

```
error: must be on 'dev' branch (currently on 'HEAD')
```

See [workflow run 25643909564](https://github.com/nanvix/zutils/actions/runs/25643909564).

## Root Cause

The checkout step uses `ref: ${{ github.sha }}`, which puts Git into a
**detached HEAD** state. The release task's `_check_preconditions()` then calls
`git rev-parse --abbrev-ref HEAD`, which returns `HEAD` instead of `dev`,
causing the release to abort.

## Fix

Change the checkout `ref` from `${{ github.sha }}` to `dev` so the working
tree lands on the actual branch and satisfies the precondition check.