### PR TITLE
[build] Fix duplicate release asset

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -262,8 +262,11 @@ def _create_github_release(version: str) -> None:
     """Create a GitHub release with build and template artifacts."""
     tag = f"v{version}"
     dist = _REPO_ROOT / "dist"
+    template_names = {"templates.tar.gz", "templates.zip"}
     assets: list[str] = sorted(
-        str(p) for p in (*dist.glob("*.whl"), *dist.glob("*.tar.gz"))
+        str(p)
+        for p in (*dist.glob("*.whl"), *dist.glob("*.tar.gz"))
+        if p.name not in template_names
     )
     assets.append(str(dist / "templates.tar.gz"))
     assets.append(str(dist / "templates.zip"))


### PR DESCRIPTION
## Problem

The release workflow run [25644365630](https://github.com/nanvix/zutils/actions/runs/25644365630) failed with:

```
HTTP 422: Validation Failed
ReleaseAsset.name already exists
```

## Root Cause

`_create_github_release()` in `tasks.py` collects release assets via `dist.glob('*.tar.gz')`, which matches both the sdist archive (`nanvix_zutil-X.Y.Z.tar.gz`) **and** `templates.tar.gz`. It then explicitly appends `templates.tar.gz` and `templates.zip`, causing `templates.tar.gz` to appear twice in the `gh release create` command. GitHub rejects the duplicate upload.

## Fix

Filter out template archives from the glob comprehension so they are only included by the explicit appends below.