### PR TITLE
Fix consumer update dispatch failing with HTTP 422

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -282,7 +282,7 @@ def _create_github_release(version: str) -> None:
     )
 
 
-def _update_consumers(tag: str) -> None:
+def _update_consumers() -> None:
     """Trigger the consumer-update workflow in nanvix/workflows."""
     _run_checked(
         "gh",
@@ -291,8 +291,6 @@ def _update_consumers(tag: str) -> None:
         "nanvix-update-zutils.yml",
         "--repo",
         "nanvix/workflows",
-        "-f",
-        f"tag={tag}",
     )
 
 
@@ -463,7 +461,7 @@ def release() -> int:
             _create_github_release(new)
 
             _step("Updating consumer repos")
-            _update_consumers(tag)
+            _update_consumers()
 
         _tag_and_push(tag)
 


### PR DESCRIPTION
## Problem

Workflow run [25644785535](https://github.com/nanvix/zutils/actions/runs/25644785535) (release v0.8.0) failed at the consumer-update step with:

```
HTTP 422: Unexpected inputs provided: ["tag"]
```

`_update_consumers()` in `tasks.py` dispatches `nanvix-update-zutils.yml` via `gh workflow run` (which triggers `workflow_dispatch`), passing `-f tag=<version>`. However, that workflow only declares the `tag` input under `workflow_call`, not `workflow_dispatch`.

## Fix

Remove the `-f tag=...` argument from the dispatch command. The workflow already auto-resolves the latest `nanvix/zutils` release tag when no explicit tag is provided.