### PR TITLE
Support tar.gz and zip dependency archives

### DIFF
--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -116,7 +116,7 @@ class Dependency:
     name: str
     repo: str
     ref: Ref
-    artifact_pattern: str = "{name}-{machine}-{mode}-{mem}.tar.bz2"
+    artifact_pattern: str = "{name}-{machine}-{mode}-{mem}"
     install_libs: list[str] | None = None
     install_headers: list[str] | None = None
 
@@ -292,11 +292,12 @@ class Buildroot:
             asset_name=asset_name,
             dest=cache_dir,
             gh_token=gh_token,
+            match_prefix=True,
             _release=_release,
         )
 
-        log.info(f"Extracting {asset_name}...")
-        with tarfile.open(asset_path, "r:bz2") as tf:
+        log.info(f"Extracting {asset_path.name}...")
+        with tarfile.open(asset_path, "r:*") as tf:
             for member in tf.getmembers():
                 member_path = Path(member.name)
                 if member.isfile():

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -10,7 +10,9 @@ describes a single library fetched from a GitHub release.
 
 from __future__ import annotations
 
+import shutil
 import tarfile
+import zipfile
 from dataclasses import dataclass, replace as _dc_replace
 from enum import Enum
 from pathlib import Path
@@ -297,6 +299,19 @@ class Buildroot:
         )
 
         log.info(f"Extracting {asset_path.name}...")
+        if zipfile.is_zipfile(asset_path):
+            self._extract_dep_zip(asset_path, dep)
+        else:
+            self._extract_dep_tar(asset_path, dep)
+
+        log.success(f"Installed {dep.name} into buildroot")
+
+    # ------------------------------------------------------------------
+    # Archive extraction helpers
+    # ------------------------------------------------------------------
+
+    def _extract_dep_tar(self, asset_path: Path, dep: Dependency) -> None:
+        """Extract libraries and headers from a tarball."""
         with tarfile.open(asset_path, "r:*") as tf:
             for member in tf.getmembers():
                 member_path = Path(member.name)
@@ -316,7 +331,34 @@ class Buildroot:
                                 member, path=self.path / "include", filter="data"
                             )
 
-        log.success(f"Installed {dep.name} into buildroot")
+    def _extract_dep_zip(self, asset_path: Path, dep: Dependency) -> None:
+        """Extract libraries and headers from a zip archive."""
+        with zipfile.ZipFile(asset_path, "r") as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                member_path = Path(info.filename)
+                # Reject absolute paths and directory traversal.
+                if member_path.is_absolute() or ".." in member_path.parts:
+                    continue
+                if member_path.suffix == ".a":
+                    if dep.install_libs is None or member_path.name in (
+                        dep.install_libs
+                    ):
+                        rel = _relative_to_segment(member_path, "lib")
+                        dest = self.path / "lib" / rel
+                        dest.parent.mkdir(parents=True, exist_ok=True)
+                        with zf.open(info) as src, dest.open("wb") as dst:
+                            shutil.copyfileobj(src, dst)
+                elif member_path.suffix == ".h":
+                    if dep.install_headers is None or member_path.name in (
+                        dep.install_headers
+                    ):
+                        rel = _relative_to_segment(member_path, "include")
+                        dest = self.path / "include" / rel
+                        dest.parent.mkdir(parents=True, exist_ok=True)
+                        with zf.open(info) as src, dest.open("wb") as dst:
+                            shutil.copyfileobj(src, dst)
 
     def install_local_nanvix(
         self,

--- a/src/nanvix_zutil/github.py
+++ b/src/nanvix_zutil/github.py
@@ -640,6 +640,13 @@ def download_release_asset(
             code=EXIT_NETWORK_ERROR,
         )
     assets = cast(list[object], raw_assets)
+
+    # When using prefix matching, collect all candidates first so we can
+    # pick deterministically (prefer .tar.bz2 over .tar.gz).
+    _PREFIX_PREFERENCE = (".tar.bz2", ".tar.gz")
+
+    prefix_candidates: list[tuple[str, str]] = []  # (name, url)
+
     for item in assets:
         if not isinstance(item, dict):
             continue
@@ -649,7 +656,6 @@ def download_release_asset(
             continue
         if match_prefix:
             if name.startswith(asset_name):
-                resolved_name = name
                 raw_url = asset.get("browser_download_url")
                 if not isinstance(raw_url, str) or not raw_url:
                     log.fatal(
@@ -657,8 +663,7 @@ def download_release_asset(
                         code=EXIT_NETWORK_ERROR,
                         hint="GitHub returned an asset without a usable browser_download_url; this may indicate an API change or a corrupted release.",
                     )
-                asset_url = raw_url
-                break
+                prefix_candidates.append((name, raw_url))
         else:
             if name == asset_name:
                 raw_url = asset.get("browser_download_url")
@@ -671,6 +676,18 @@ def download_release_asset(
                 resolved_name = name
                 asset_url = raw_url
                 break
+
+    # When prefix-matching, pick the best candidate by preferred extension.
+    if match_prefix and prefix_candidates and asset_url is None:
+
+        def _ext_rank(n: str) -> int:
+            for i, ext in enumerate(_PREFIX_PREFERENCE):
+                if n.endswith(ext):
+                    return i
+            return len(_PREFIX_PREFERENCE)
+
+        prefix_candidates.sort(key=lambda c: (_ext_rank(c[0]), c[0]))
+        resolved_name, asset_url = prefix_candidates[0]
 
     if asset_url is None:
         if allow_missing:

--- a/src/nanvix_zutil/github.py
+++ b/src/nanvix_zutil/github.py
@@ -642,8 +642,8 @@ def download_release_asset(
     assets = cast(list[object], raw_assets)
 
     # When using prefix matching, collect all candidates first so we can
-    # pick deterministically (prefer .tar.bz2 over .tar.gz).
-    _PREFIX_PREFERENCE = (".tar.bz2", ".tar.gz")
+    # pick deterministically (prefer .tar.bz2 over .tar.gz over .zip).
+    _PREFIX_PREFERENCE = (".tar.bz2", ".tar.gz", ".zip")
 
     prefix_candidates: list[tuple[str, str]] = []  # (name, url)
 

--- a/src/nanvix_zutil/lockfile.py
+++ b/src/nanvix_zutil/lockfile.py
@@ -69,7 +69,7 @@ class ResolvedPackage:
             full SHA, branch name, or tag name.
         release_id: GitHub release ID.
         dependencies: Names of packages this package depends on.
-        assets: List of downloadable tarball assets.
+        assets: List of downloadable archive assets.
         transitive: ``True`` if this package was discovered transitively.
         required_by: Names of packages that pulled this one in.
     """

--- a/src/nanvix_zutil/lockfile.py
+++ b/src/nanvix_zutil/lockfile.py
@@ -69,7 +69,7 @@ class ResolvedPackage:
             full SHA, branch name, or tag name.
         release_id: GitHub release ID.
         dependencies: Names of packages this package depends on.
-        assets: List of downloadable ``.tar.bz2`` assets.
+        assets: List of downloadable tarball assets.
         transitive: ``True`` if this package was discovered transitively.
         required_by: Names of packages that pulled this one in.
     """

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -61,16 +61,17 @@ class _QueueItem:
 
 
 def _collect_assets(release: dict[str, object]) -> list[ResolvedAsset]:
-    """Extract ``.tar.bz2`` assets from a GitHub release.
+    """Extract tarball assets from a GitHub release.
 
-    Filters out ``nanvix.lock``, source archives (``*.tar.gz``,
-    ``*.zip``), and any non-``.tar.bz2`` files.
+    Keeps ``.tar.bz2`` and ``.tar.gz`` archives.  Filters out
+    ``nanvix.lock``, source archives (``*.zip``), and any
+    non-tarball files.
 
     Args:
         release: GitHub release metadata dictionary.
 
     Returns:
-        List of :class:`ResolvedAsset` for ``.tar.bz2`` files.
+        List of :class:`ResolvedAsset` for tarball files.
     """
     raw_assets: object = release.get("assets", [])
     if not isinstance(raw_assets, list):
@@ -85,7 +86,7 @@ def _collect_assets(release: dict[str, object]) -> list[ResolvedAsset]:
         url = asset.get("browser_download_url")
         if not isinstance(name, str) or not isinstance(url, str):
             continue
-        if not name.endswith(".tar.bz2"):
+        if not (name.endswith(".tar.bz2") or name.endswith(".tar.gz")):
             continue
         result.append(ResolvedAsset(name=name, url=url))
     return result

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -60,18 +60,20 @@ class _QueueItem:
     required_by: str = ""
 
 
-def _collect_assets(release: dict[str, object]) -> list[ResolvedAsset]:
-    """Extract tarball assets from a GitHub release.
+_ARCHIVE_EXTENSIONS = (".tar.bz2", ".tar.gz", ".zip")
 
-    Keeps ``.tar.bz2`` and ``.tar.gz`` archives.  Filters out
-    ``nanvix.lock``, source archives (``*.zip``), and any
-    non-tarball files.
+
+def _collect_assets(release: dict[str, object]) -> list[ResolvedAsset]:
+    """Extract archive assets from a GitHub release.
+
+    Keeps ``.tar.bz2``, ``.tar.gz``, and ``.zip`` archives.  Filters out
+    ``nanvix.lock`` and any non-archive files.
 
     Args:
         release: GitHub release metadata dictionary.
 
     Returns:
-        List of :class:`ResolvedAsset` for tarball files.
+        List of :class:`ResolvedAsset` for archive files.
     """
     raw_assets: object = release.get("assets", [])
     if not isinstance(raw_assets, list):
@@ -86,7 +88,7 @@ def _collect_assets(release: dict[str, object]) -> list[ResolvedAsset]:
         url = asset.get("browser_download_url")
         if not isinstance(name, str) or not isinstance(url, str):
             continue
-        if not (name.endswith(".tar.bz2") or name.endswith(".tar.gz")):
+        if not any(name.endswith(ext) for ext in _ARCHIVE_EXTENSIONS):
             continue
         result.append(ResolvedAsset(name=name, url=url))
     return result

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -4,8 +4,8 @@
 """Nanvix runtime sysroot management.
 
 :class:`Sysroot` downloads and verifies the Nanvix runtime artifact from
-GitHub releases.  The artifact is a tarball (either ``.tar.bz2`` or
-``.tar.gz``) identified by machine, deployment mode, and memory-size
+GitHub releases.  The artifact is an archive (``.tar.bz2``, ``.tar.gz``,
+or ``.zip``) identified by machine, deployment mode, and memory-size
 configuration.
 """
 
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import shutil
 import tarfile
+import zipfile
 from pathlib import Path
 
 from nanvix_zutil import github, log
@@ -180,8 +181,17 @@ class Sysroot:
 
         log.info(f"Extracting sysroot from {asset_path.name}…")
         sysroot_dir.mkdir(parents=True, exist_ok=True)
-        with tarfile.open(asset_path, "r:*") as tf:
-            tf.extractall(path=sysroot_dir, filter="data")
+        if zipfile.is_zipfile(asset_path):
+            resolved_sysroot = sysroot_dir.resolve()
+            with zipfile.ZipFile(asset_path, "r") as zf:
+                for member in zf.namelist():
+                    target_path = (sysroot_dir / member).resolve()
+                    if not target_path.is_relative_to(resolved_sysroot):
+                        continue
+                    zf.extract(member, path=sysroot_dir)
+        else:
+            with tarfile.open(asset_path, "r:*") as tf:
+                tf.extractall(path=sysroot_dir, filter="data")
 
         log.success(f"Sysroot extracted to {sysroot_dir}")
         if config is not None:

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -4,8 +4,9 @@
 """Nanvix runtime sysroot management.
 
 :class:`Sysroot` downloads and verifies the Nanvix runtime artifact from
-GitHub releases.  The artifact is a ``.tar.bz2`` archive identified by
-machine, deployment mode, and memory-size configuration.
+GitHub releases.  The artifact is a tarball (either ``.tar.bz2`` or
+``.tar.gz``) identified by machine, deployment mode, and memory-size
+configuration.
 """
 
 from __future__ import annotations
@@ -179,7 +180,7 @@ class Sysroot:
 
         log.info(f"Extracting sysroot from {asset_path.name}…")
         sysroot_dir.mkdir(parents=True, exist_ok=True)
-        with tarfile.open(asset_path, "r:bz2") as tf:
+        with tarfile.open(asset_path, "r:*") as tf:
             tf.extractall(path=sysroot_dir, filter="data")
 
         log.success(f"Sysroot extracted to {sysroot_dir}")

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -56,7 +56,7 @@ class TestDependency(unittest.TestCase):
         dep = Dependency(
             name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
         )
-        expected = "{name}-{machine}-{mode}-{mem}.tar.bz2"
+        expected = "{name}-{machine}-{mode}-{mem}"
         self.assertEqual(dep.artifact_pattern, expected)
 
     def test_default_install_libs_none(self) -> None:
@@ -297,7 +297,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
                 memory_size="256mb",
             )
 
-        self.assertEqual(captured[0], "zlib-microvm-single-process-256mb.tar.bz2")
+        self.assertEqual(captured[0], "zlib-microvm-single-process-256mb")
 
     def test_install_dep_preserves_header_subdirectory(self) -> None:
         """Headers in subdirectories are extracted with directory structure preserved."""

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -7,6 +7,7 @@ import io
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -38,6 +39,22 @@ def _make_tar_bz2(members: dict[str, bytes]) -> bytes:
             info = tarfile.TarInfo(name=name)
             info.size = len(data)
             tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _make_zip(members: dict[str, bytes]) -> bytes:
+    """Return a ``.zip`` archive containing the given *members*.
+
+    Args:
+        members: Mapping of archive member name → file contents.
+
+    Returns:
+        Zip archive bytes.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
     return buf.getvalue()
 
 
@@ -536,6 +553,123 @@ class TestRefKindLocal(unittest.TestCase):
         result = suffix_dep(dep, "0.12.410")
         self.assertEqual(result.ref.kind, RefKind.LOCAL)
         self.assertEqual(result.ref.value, "/tmp/zlib")
+
+
+class TestBuildrootInstallDepZip(unittest.TestCase):
+    """Buildroot.install_dep() extracts libs and headers from .zip archives."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def _setup_buildroot(self) -> Buildroot:
+        dest = Path(self._tmpdir.name) / "br"
+        return Buildroot.create(dest=dest)
+
+    def test_install_dep_zip_extracts_lib(self) -> None:
+        br = self._setup_buildroot()
+        archive = _make_zip(
+            {
+                "sysroot/lib/libz.a": b"lib-content",
+                "sysroot/include/zlib.h": b"header-content",
+            }
+        )
+        dep = Dependency(
+            name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
+        )
+        archive_path = Path(self._tmpdir.name) / "zlib.zip"
+        archive_path.write_bytes(archive)
+
+        with patch(
+            "nanvix_zutil.github.download_release_asset",
+            return_value=archive_path,
+        ):
+            br.install_dep(dep)
+
+        self.assertTrue((br.path / "lib" / "libz.a").exists())
+        self.assertEqual((br.path / "lib" / "libz.a").read_bytes(), b"lib-content")
+
+    def test_install_dep_zip_extracts_header(self) -> None:
+        br = self._setup_buildroot()
+        archive = _make_zip(
+            {
+                "sysroot/lib/libz.a": b"lib-content",
+                "sysroot/include/zlib.h": b"header-content",
+            }
+        )
+        dep = Dependency(
+            name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
+        )
+        archive_path = Path(self._tmpdir.name) / "zlib.zip"
+        archive_path.write_bytes(archive)
+
+        with patch(
+            "nanvix_zutil.github.download_release_asset",
+            return_value=archive_path,
+        ):
+            br.install_dep(dep)
+
+        self.assertTrue((br.path / "include" / "zlib.h").exists())
+        self.assertEqual(
+            (br.path / "include" / "zlib.h").read_bytes(), b"header-content"
+        )
+
+    def test_install_dep_zip_selective_libs(self) -> None:
+        br = self._setup_buildroot()
+        archive = _make_zip(
+            {
+                "sysroot/lib/libz.a": b"libz",
+                "sysroot/lib/libextra.a": b"libextra",
+            }
+        )
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+            install_libs=["libz.a"],
+        )
+        archive_path = Path(self._tmpdir.name) / "zlib.zip"
+        archive_path.write_bytes(archive)
+
+        with patch(
+            "nanvix_zutil.github.download_release_asset",
+            return_value=archive_path,
+        ):
+            br.install_dep(dep)
+
+        self.assertTrue((br.path / "lib" / "libz.a").exists())
+        self.assertFalse((br.path / "lib" / "libextra.a").exists())
+
+    def test_install_dep_zip_preserves_header_subdirectory(self) -> None:
+        br = self._setup_buildroot()
+        archive = _make_zip(
+            {
+                "sysroot/include/openssl/ssl.h": b"ssl-header",
+                "sysroot/include/openssl/crypto.h": b"crypto-header",
+                "sysroot/lib/libssl.a": b"ssl-lib",
+            }
+        )
+        dep = Dependency(
+            name="openssl",
+            repo="nanvix/openssl",
+            ref=Ref(kind=RefKind.TAG, value="v3.5.0"),
+        )
+        archive_path = Path(self._tmpdir.name) / "openssl.zip"
+        archive_path.write_bytes(archive)
+
+        with patch(
+            "nanvix_zutil.github.download_release_asset",
+            return_value=archive_path,
+        ):
+            br.install_dep(dep)
+
+        self.assertTrue((br.path / "include" / "openssl" / "ssl.h").exists())
+        self.assertTrue((br.path / "include" / "openssl" / "crypto.h").exists())
+        self.assertTrue((br.path / "lib" / "libssl.a").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -539,6 +539,62 @@ class TestDownloadReleaseAssetPrefixPreference(unittest.TestCase):
 
         self.assertEqual(result.name, bz2_name)
 
+    def test_prefers_tar_over_zip(self) -> None:
+        """Tarballs are preferred over .zip."""
+        dest = Path(self._tmpdir.name)
+        prefix = "zlib-microvm-standalone-256mb"
+        zip_name = f"{prefix}.zip"
+        gz_name = f"{prefix}.tar.gz"
+        file_content = b"gz-content"
+
+        metadata_resp = _make_urlopen_response(
+            self._make_multi_asset_release(
+                [
+                    (zip_name, f"https://example.com/{zip_name}"),
+                    (gz_name, f"https://example.com/{gz_name}"),
+                ]
+            )
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        with patch("urllib.request.urlopen", side_effect=[metadata_resp, file_resp]):
+            result = github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                version_specifier="v1.0.0",
+                asset_name=prefix,
+                dest=dest,
+                match_prefix=True,
+            )
+
+        self.assertEqual(result.name, gz_name)
+
+    def test_falls_back_to_zip_when_no_tarballs(self) -> None:
+        """When only .zip matches the prefix, it is selected."""
+        dest = Path(self._tmpdir.name)
+        prefix = "zlib-microvm-standalone-256mb"
+        zip_name = f"{prefix}.zip"
+        file_content = b"zip-content"
+
+        metadata_resp = _make_urlopen_response(
+            self._make_multi_asset_release(
+                [
+                    (zip_name, f"https://example.com/{zip_name}"),
+                ]
+            )
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        with patch("urllib.request.urlopen", side_effect=[metadata_resp, file_resp]):
+            result = github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                version_specifier="v1.0.0",
+                asset_name=prefix,
+                dest=dest,
+                match_prefix=True,
+            )
+
+        self.assertEqual(result.name, zip_name)
+
 
 # ---------------------------------------------------------------------------
 # _is_commit_hash

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -404,6 +404,142 @@ class TestDownloadReleaseAssetPrefixMatch(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 3)
 
 
+class TestDownloadReleaseAssetPrefixPreference(unittest.TestCase):
+    """Prefix matching picks .tar.bz2 over .tar.gz deterministically."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def _make_multi_asset_release(self, assets: list[tuple[str, str]]) -> bytes:
+        """Build a release payload with multiple assets."""
+        return json.dumps(
+            {
+                "assets": [
+                    {"name": name, "browser_download_url": url} for name, url in assets
+                ]
+            }
+        ).encode()
+
+    def test_prefers_tar_bz2_over_tar_gz(self) -> None:
+        """When both .tar.bz2 and .tar.gz exist, .tar.bz2 is selected."""
+        dest = Path(self._tmpdir.name)
+        prefix = "zlib-microvm-standalone-256mb"
+        bz2_name = f"{prefix}.tar.bz2"
+        gz_name = f"{prefix}.tar.gz"
+        file_content = b"bz2-content"
+
+        metadata_resp = _make_urlopen_response(
+            self._make_multi_asset_release(
+                [
+                    (gz_name, f"https://example.com/{gz_name}"),
+                    (bz2_name, f"https://example.com/{bz2_name}"),
+                ]
+            )
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        with patch("urllib.request.urlopen", side_effect=[metadata_resp, file_resp]):
+            result = github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                version_specifier="v1.0.0",
+                asset_name=prefix,
+                dest=dest,
+                match_prefix=True,
+            )
+
+        self.assertEqual(result.name, bz2_name)
+
+    def test_prefers_tar_bz2_regardless_of_api_order(self) -> None:
+        """Preference holds even when .tar.bz2 appears first in the API."""
+        dest = Path(self._tmpdir.name)
+        prefix = "zlib-microvm-standalone-256mb"
+        bz2_name = f"{prefix}.tar.bz2"
+        gz_name = f"{prefix}.tar.gz"
+        file_content = b"bz2-content"
+
+        metadata_resp = _make_urlopen_response(
+            self._make_multi_asset_release(
+                [
+                    (bz2_name, f"https://example.com/{bz2_name}"),
+                    (gz_name, f"https://example.com/{gz_name}"),
+                ]
+            )
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        with patch("urllib.request.urlopen", side_effect=[metadata_resp, file_resp]):
+            result = github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                version_specifier="v1.0.0",
+                asset_name=prefix,
+                dest=dest,
+                match_prefix=True,
+            )
+
+        self.assertEqual(result.name, bz2_name)
+
+    def test_falls_back_to_tar_gz_when_no_bz2(self) -> None:
+        """When only .tar.gz matches the prefix, it is selected."""
+        dest = Path(self._tmpdir.name)
+        prefix = "zlib-microvm-standalone-256mb"
+        gz_name = f"{prefix}.tar.gz"
+        file_content = b"gz-content"
+
+        metadata_resp = _make_urlopen_response(
+            self._make_multi_asset_release(
+                [
+                    (gz_name, f"https://example.com/{gz_name}"),
+                ]
+            )
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        with patch("urllib.request.urlopen", side_effect=[metadata_resp, file_resp]):
+            result = github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                version_specifier="v1.0.0",
+                asset_name=prefix,
+                dest=dest,
+                match_prefix=True,
+            )
+
+        self.assertEqual(result.name, gz_name)
+
+    def test_prefix_with_sha_prefers_bz2(self) -> None:
+        """SHA-suffixed assets still prefer .tar.bz2."""
+        dest = Path(self._tmpdir.name)
+        prefix = "nanvix-hyperlight-multi-process-release-128mb"
+        bz2_name = f"{prefix}-abc123.tar.bz2"
+        gz_name = f"{prefix}-abc123.tar.gz"
+        file_content = b"bz2-content"
+
+        metadata_resp = _make_urlopen_response(
+            self._make_multi_asset_release(
+                [
+                    (gz_name, f"https://example.com/{gz_name}"),
+                    (bz2_name, f"https://example.com/{bz2_name}"),
+                ]
+            )
+        )
+        file_resp = _make_urlopen_response(file_content, chunked=True)
+
+        with patch("urllib.request.urlopen", side_effect=[metadata_resp, file_resp]):
+            result = github_mod.download_release_asset(
+                repo="nanvix/nanvix",
+                version_specifier="latest",
+                asset_name=prefix,
+                dest=dest,
+                match_prefix=True,
+            )
+
+        self.assertEqual(result.name, bz2_name)
+
+
 # ---------------------------------------------------------------------------
 # _is_commit_hash
 # ---------------------------------------------------------------------------

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -618,7 +618,7 @@ class TestResolveLatestSysroot(unittest.TestCase):
 @patch("nanvix_zutil.resolver.download_lockfile_asset")
 @patch("nanvix_zutil.resolver.github.resolve_release")
 class TestAssetFiltering(unittest.TestCase):
-    """Resolver filters out non-tarball assets and nanvix.lock."""
+    """Resolver filters out non-archive assets and nanvix.lock."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -645,11 +645,8 @@ class TestAssetFiltering(unittest.TestCase):
             assets=[
                 _archive_asset("nanvix-hyperlight-multi-process-release-128mb.tar.bz2"),
                 _archive_asset("nanvix-hyperlight-multi-process-release-128mb.tar.gz"),
+                _archive_asset("nanvix-hyperlight-multi-process-release-128mb.zip"),
                 _lockfile_asset(),
-                {
-                    "name": "source.zip",
-                    "browser_download_url": "https://example.com/source.zip",
-                },
                 {
                     "name": "notes.txt",
                     "browser_download_url": "https://example.com/notes.txt",
@@ -667,11 +664,12 @@ class TestAssetFiltering(unittest.TestCase):
         )
 
         sysroot_pkg = lockfile.packages[0]
-        # Both .tar.bz2 and .tar.gz are collected; .zip, .txt, and nanvix.lock are not.
-        self.assertEqual(len(sysroot_pkg.assets), 2)
+        # .tar.bz2, .tar.gz, and .zip are collected; .txt and nanvix.lock are not.
+        self.assertEqual(len(sysroot_pkg.assets), 3)
         names = {a.name for a in sysroot_pkg.assets}
         self.assertIn("nanvix-hyperlight-multi-process-release-128mb.tar.bz2", names)
         self.assertIn("nanvix-hyperlight-multi-process-release-128mb.tar.gz", names)
+        self.assertIn("nanvix-hyperlight-multi-process-release-128mb.zip", names)
 
 
 class TestUnsuffixDeps(unittest.TestCase):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -53,8 +53,8 @@ def _make_manifest(
     )
 
 
-def _tar_asset(name: str) -> dict[str, object]:
-    """Build a fake .tar.bz2 asset entry."""
+def _archive_asset(name: str) -> dict[str, object]:
+    """Build a fake archive asset entry."""
     return {
         "name": name,
         "browser_download_url": f"https://example.com/{name}",
@@ -98,7 +98,7 @@ class TestResolveSysrootOnly(unittest.TestCase):
             commitish="aaa111",
             release_id=100,
             assets=[
-                _tar_asset(
+                _archive_asset(
                     "nanvix-hyperlight-multi-process-release-128mb-aaa111.tar.bz2"
                 )
             ],
@@ -152,7 +152,7 @@ class TestResolveDirectDep(unittest.TestCase):
             tag="v1.0.0",
             commitish="bbb222",
             release_id=200,
-            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
         mock_resolve.side_effect = [sysroot_release, zlib_release]
         mock_download.return_value = None
@@ -216,7 +216,7 @@ class TestResolveTransitive(unittest.TestCase):
             commitish="ccc333",
             release_id=300,
             assets=[
-                _tar_asset("libfoo-hyperlight-multi-process-128mb.tar.bz2"),
+                _archive_asset("libfoo-hyperlight-multi-process-128mb.tar.bz2"),
                 _lockfile_asset(),
             ],
         )
@@ -224,7 +224,7 @@ class TestResolveTransitive(unittest.TestCase):
             tag="v2.0.0",
             commitish="ddd444",
             release_id=400,
-            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
 
         mock_resolve.side_effect = [sysroot_release, libfoo_release, zlib_release]
@@ -569,7 +569,7 @@ class TestResolveLatestSysroot(unittest.TestCase):
             tag="v1.3.1-nanvix-0.12.277",
             commitish="bbb222",
             release_id=200,
-            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
         # resolve_release is only called for sysroot — zlib is served
         # from the probe cache, eliminating a duplicate API call.
@@ -618,7 +618,7 @@ class TestResolveLatestSysroot(unittest.TestCase):
 @patch("nanvix_zutil.resolver.download_lockfile_asset")
 @patch("nanvix_zutil.resolver.github.resolve_release")
 class TestAssetFiltering(unittest.TestCase):
-    """Resolver filters out non-.tar.bz2 assets and nanvix.lock."""
+    """Resolver filters out non-tarball assets and nanvix.lock."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -643,15 +643,16 @@ class TestAssetFiltering(unittest.TestCase):
             tag="v0.1.0",
             release_id=100,
             assets=[
-                _tar_asset("nanvix-hyperlight-multi-process-release-128mb.tar.bz2"),
+                _archive_asset("nanvix-hyperlight-multi-process-release-128mb.tar.bz2"),
+                _archive_asset("nanvix-hyperlight-multi-process-release-128mb.tar.gz"),
                 _lockfile_asset(),
-                {
-                    "name": "source.tar.gz",
-                    "browser_download_url": "https://example.com/source.tar.gz",
-                },
                 {
                     "name": "source.zip",
                     "browser_download_url": "https://example.com/source.zip",
+                },
+                {
+                    "name": "notes.txt",
+                    "browser_download_url": "https://example.com/notes.txt",
                 },
             ],
         )
@@ -666,8 +667,11 @@ class TestAssetFiltering(unittest.TestCase):
         )
 
         sysroot_pkg = lockfile.packages[0]
-        self.assertEqual(len(sysroot_pkg.assets), 1)
-        self.assertTrue(sysroot_pkg.assets[0].name.endswith(".tar.bz2"))
+        # Both .tar.bz2 and .tar.gz are collected; .zip, .txt, and nanvix.lock are not.
+        self.assertEqual(len(sysroot_pkg.assets), 2)
+        names = {a.name for a in sysroot_pkg.assets}
+        self.assertIn("nanvix-hyperlight-multi-process-release-128mb.tar.bz2", names)
+        self.assertIn("nanvix-hyperlight-multi-process-release-128mb.tar.gz", names)
 
 
 class TestUnsuffixDeps(unittest.TestCase):
@@ -742,7 +746,7 @@ class TestResolveVersionFallback(unittest.TestCase):
             tag="v1.3.1-nanvix-0.12.291",
             commitish="ccc333",
             release_id=200,
-            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
         # resolve_release: (1) sysroot@latest, (2) sysroot@0.12.291, (3) zlib
         mock_resolve.side_effect = [latest_sysroot, downgraded_sysroot, zlib_release]
@@ -859,7 +863,7 @@ class TestResolveVersionFallback(unittest.TestCase):
             tag="v1.3.1-nanvix-0.12.337",
             commitish="ccc333",
             release_id=200,
-            assets=[_tar_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
+            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
         )
         # resolve_release only called for sysroot — zlib served from
         # probe cache.

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -7,6 +7,7 @@ import io
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -30,6 +31,22 @@ def _make_tar_bz2(members: dict[str, bytes]) -> bytes:
             info = tarfile.TarInfo(name=name)
             info.size = len(data)
             tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _make_zip(members: dict[str, bytes]) -> bytes:
+    """Return a ``.zip`` archive containing the given *members*.
+
+    Args:
+        members: Mapping of archive member name \u2192 file contents.
+
+    Returns:
+        Zip archive bytes.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
     return buf.getvalue()
 
 
@@ -559,6 +576,48 @@ class TestSysrootFromLocal(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             Sysroot.from_local(file_path)
         self.assertEqual(ctx.exception.code, 3)
+
+
+class TestSysrootDownloadZip(unittest.TestCase):
+    """Sysroot.download() extracts .zip archives correctly."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        log_mod.set_json_mode(False)
+        self._resolve_patcher = patch(
+            "nanvix_zutil.github.resolve_release",
+            return_value={"target_commitish": "abc1234def5678"},
+        )
+        self._resolve_patcher.start()
+
+    def tearDown(self) -> None:
+        self._resolve_patcher.stop()
+        self._tmpdir.cleanup()
+        log_mod.set_json_mode(False)
+
+    def test_downloads_and_extracts_zip(self) -> None:
+        dest = Path(self._tmpdir.name) / "sysroot"
+        archive = _make_zip({"lib/libposix.a": b"posix-lib"})
+        archive_path = Path(self._tmpdir.name) / "nanvix.zip"
+        archive_path.write_bytes(archive)
+
+        with patch(
+            "nanvix_zutil.github.download_release_asset",
+            return_value=archive_path,
+        ):
+            sysroot = Sysroot.download(
+                machine="hyperlight",
+                deployment_mode="multi-process",
+                memory_size="128mb",
+                tag="v1.0.0",
+                dest=dest,
+            )
+
+        self.assertTrue(sysroot.path.is_dir())
+        self.assertTrue((sysroot.path / "lib" / "libposix.a").exists())
+        self.assertEqual(
+            (sysroot.path / "lib" / "libposix.a").read_bytes(), b"posix-lib"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Broaden dependency archive format support from `.tar.bz2`-only to also accept `.tar.gz` and `.zip` archives across buildroot, sysroot, and resolver modules.

## Changes

### Commit 1: tar.gz support
- Remove hardcoded `.tar.bz2` extension from `Dependency.artifact_pattern`; use `match_prefix=True` to resolve the actual asset name at download time
- Switch `tarfile.open` from `r:bz2` to `r:*` for auto-detection of compression in buildroot and sysroot extraction
- Update resolver `_collect_assets()` to accept both `.tar.bz2` and `.tar.gz`
- Add deterministic prefix-match preference (`.tar.bz2` > `.tar.gz`) in `download_release_asset` to avoid API ordering dependence
- Add tests for prefix preference ordering

### Commit 2: zip support
- Add `zipfile` import and `_extract_dep_zip()` helper to buildroot
- Dispatch extraction via `zipfile.is_zipfile()` in buildroot and sysroot
- Extend resolver `_ARCHIVE_EXTENSIONS` to include `.zip`
- Add `.zip` to prefix-match preference order (`.tar.bz2` > `.tar.gz` > `.zip`)
- Add zip extraction tests for buildroot, sysroot, github, and resolver

## Design decisions
- **Preference order**: When multiple formats exist for the same prefix, `.tar.bz2` is preferred over `.tar.gz` over `.zip`. This ensures deterministic behavior regardless of GitHub API asset ordering.
- **Windows compatibility**: The existing `download_windows_binaries()` path already used `zipfile.ZipFile` directly — these changes bring the Linux/generic paths to parity.