### PR TITLE
build: use GHCR toolchain-gcc image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: nanvix/toolchain:latest-minimal
+      image: ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3
     env:
       NANVIX_TOOLCHAIN: /opt/nanvix
       USER: runner

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ All code must pass before merging:
 - **Formatting** — `black` with no configuration overrides.
 - **Type checking** — `pyright` in strict mode. Every public function
   needs a complete type signature.
-- **Tests** — `pytest`. Functional tests require the `nanvix/toolchain`
+- **Tests** — `pytest`. Functional tests require the `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`
   Docker image.
 - **Docstrings** — all public functions must have docstrings.
 
@@ -47,7 +47,7 @@ uv run tasks.py ci lint       # lint & type check only
 uv run tasks.py ci test       # tests only
 ```
 
-Requires Docker with the `nanvix/toolchain:latest-minimal` image available
+Requires Docker with the `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image available
 locally, plus the `gh act` extension (`gh extension install nektos/gh-act`).
 
 ## Cutting a Release

--- a/doc/test.md
+++ b/doc/test.md
@@ -68,7 +68,7 @@ filesystem, Docker). These run quickly without network access or Docker.
 with real example projects. These may require:
 
 - Network access (for GitHub API calls)
-- Docker with the `nanvix/toolchain:latest-minimal` image
+- Docker with the `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image
 
 ### Running CI Locally
 
@@ -81,7 +81,7 @@ uv run tasks.py ci test       # tests only
 ```
 
 This requires:
-- Docker with `nanvix/toolchain:latest-minimal` image available locally
+- Docker with `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image available locally
 - The `gh` CLI with the `act` extension (`gh extension install nektos/gh-act`)
 
 ## Code Coverage

--- a/docs/design.md
+++ b/docs/design.md
@@ -80,9 +80,9 @@ Standard keys: `NANVIX_TARGET`, `NANVIX_MACHINE`,
 ### `docker.py` — Docker Integration
 
 Per-command Docker wrapping for cross-compilation. Docker mode is always
-enabled for `setup`, `build`, `release`, and `clean`. The
-`--with-docker IMAGE` flag on `setup` allows consumers to override the
-default image (`nanvix/toolchain:latest-minimal`). Key types:
+enabled for `setup`, `build`, `release`, and `clean`. On `setup`, the
+`--with-docker IMAGE` flag requires consumers to provide the Docker
+image explicitly (e.g. `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`). Key types:
 
 - **`DockerConfig`**: Image name, mounts, UID/GID, workdir, extra env
   vars. Builds `docker run` command lines.

--- a/examples/bin-hello/README.md
+++ b/examples/bin-hello/README.md
@@ -23,7 +23,7 @@ bin-hello/
 
 One of:
 - **Native toolchain** — `i686-nanvix-gcc` (default path: `/opt/nanvix/`)
-- **Docker** with `nanvix/toolchain:latest-minimal` image (auto-detected fallback)
+- **Docker** with `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image (pass via `./z setup --with-docker IMAGE`)
 
 ## Running
 

--- a/examples/lib-hello/README.md
+++ b/examples/lib-hello/README.md
@@ -23,7 +23,7 @@ lib-hello/
 
 One of:
 - **Native toolchain** — `i686-nanvix-gcc` (default path: `/opt/nanvix/`)
-- **Docker** with `nanvix/toolchain:latest-minimal` image (auto-detected fallback)
+- **Docker** with `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image (pass via `./z setup --with-docker IMAGE`)
 
 If you built the Nanvix toolchain locally (e.g. from `nanvix/nanvix`), point
 `NANVIX_TOOLCHAIN` at it:
@@ -32,7 +32,7 @@ If you built the Nanvix toolchain locally (e.g. from `nanvix/nanvix`), point
 export NANVIX_TOOLCHAIN=~/repos/nanvix/nanvix/toolchain
 ```
 
-In CI, the workflow runs inside the `nanvix/toolchain:latest-minimal` Docker
+In CI, the workflow runs inside the `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` Docker
 container where the toolchain is pre-installed at `/opt/nanvix`.
 
 ## Running

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -11,7 +11,7 @@ fails immediately.  ``test`` and ``benchmark`` run natively on the host.
 
 Use ``--with-docker IMAGE`` during setup to specify the Docker image::
 
-    ./z setup --with-docker nanvix/toolchain:v1.2.3
+    ./z setup --with-docker ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 """
 
 from __future__ import annotations
@@ -136,7 +136,7 @@ class DockerConfig:
     ``docker run`` invocation.
 
     Attributes:
-        image: Docker image name (e.g. ``"nanvix/toolchain:latest-minimal"``).
+        image: Docker image name (e.g. ``"ghcr.io/nanvix/toolchain-gcc:sha-34a3641"``).
         mounts: Ordered list of volume mounts.
         uid: User ID passed to ``--user``.  Defaults to the current process UID,
             or ``0`` on platforms where ``os.getuid`` is unavailable (e.g. Windows).
@@ -388,7 +388,7 @@ def image_exists(image: str) -> bool:
 
     Args:
         image: Docker image reference (e.g.
-            ``"nanvix/toolchain:latest-minimal"``).
+            ``"ghcr.io/nanvix/toolchain-gcc:sha-34a3641"``).
 
     Returns:
         ``True`` when the image is present locally, ``False`` otherwise or

--- a/tasks.py
+++ b/tasks.py
@@ -106,8 +106,11 @@ def ci() -> int:
     """Run CI locally using gh act (requires Docker + nanvix toolchain image).
 
     Runs the specified CI job (or all jobs) locally using nektos/act via the
-    gh CLI extension. The nanvix/toolchain:latest-minimal Docker image must
-    be available locally.
+    gh CLI extension. The ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+    Docker image must be available locally.
+
+    Example:
+        docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
     Usage:
         uv run tasks.py ci            # run all CI jobs

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -136,7 +136,7 @@ class TestDockerConfigBuildRunCmd(unittest.TestCase):
 
     def _make_config(self) -> DockerConfig:
         return DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
                     host_path=self._workspace,
@@ -161,7 +161,7 @@ class TestDockerConfigBuildRunCmd(unittest.TestCase):
     def test_contains_image(self, _mock: object) -> None:
         cfg = self._make_config()
         cmd = cfg.build_run_cmd("make", "all")
-        self.assertIn("nanvix/toolchain:latest-minimal", cmd)
+        self.assertIn("ghcr.io/nanvix/toolchain-gcc:sha-34a3641", cmd)
 
     def test_contains_user(self, _mock: object) -> None:
         cfg = self._make_config()
@@ -246,7 +246,7 @@ class TestImageExists(unittest.TestCase):
             patch("nanvix_zutil.docker.docker_available", return_value=True),
             patch("nanvix_zutil.docker.subprocess.run", return_value=fake_result),
         ):
-            self.assertTrue(image_exists("nanvix/toolchain:latest-minimal"))
+            self.assertTrue(image_exists("ghcr.io/nanvix/toolchain-gcc:sha-34a3641"))
 
 
 class TestWellKnownPaths(unittest.TestCase):
@@ -383,7 +383,7 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         output_files: list[str] | None = None,
     ) -> DockerConfig:
         return DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
                     host_path=self._workspace,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,7 +30,7 @@ from typing import cast
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _LIB_HELLO = _REPO_ROOT / "examples" / "lib-hello"
 _BIN_HELLO = _REPO_ROOT / "examples" / "bin-hello"
-_DOCKER_IMAGE = "nanvix/toolchain:latest-minimal"
+_DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
 _NANVIX_VERSION = "0.12.410"
 _TIMEOUT = 300
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -581,7 +581,7 @@ class TestZScriptRun(unittest.TestCase):
         """run() delegates to build_windows_run_cmd on Windows."""
         script = ZScript(Path(self._tmpdir.name))
         script.docker = DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
                     host_path=script.repo_root,
@@ -613,7 +613,7 @@ class TestZScriptRun(unittest.TestCase):
         these fields to be populated."""
         script = ZScript(Path(self._tmpdir.name))
         script.docker = DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
                     host_path=script.repo_root,
@@ -646,7 +646,7 @@ class TestZScriptRun(unittest.TestCase):
         """run() uses build_run_cmd on Linux (not the Windows tar-copy path)."""
         script = ZScript(Path(self._tmpdir.name))
         script.docker = DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
                     host_path=script.repo_root,
@@ -836,7 +836,7 @@ class TestZScriptDockerIntegration(unittest.TestCase):
         """When Docker is active, run() prepends docker run to the command."""
         script = self._make_script()
         script.docker = DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
                     host_path=script.repo_root,
@@ -866,7 +866,7 @@ class TestZScriptDockerIntegration(unittest.TestCase):
         """env vars passed to run() are forwarded as -e flags in Docker mode."""
         script = self._make_script()
         script.docker = DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[],
             uid=1000,
             gid=1000,
@@ -890,7 +890,7 @@ class TestZScriptDockerIntegration(unittest.TestCase):
         """env vars appear as -e KEY=VAL in the docker run command."""
         script = self._make_script()
         script.docker = DockerConfig(
-            image="nanvix/toolchain:latest-minimal",
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[],
             uid=1000,
             gid=1000,
@@ -939,7 +939,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
         # Pre-persist Docker image so build can find it.
         nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
         (nanvix_dir / "env.json").write_text(
-            '{"NANVIX_DOCKER_IMAGE": "nanvix/toolchain:latest-minimal"}'
+            '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"}'
         )
 
         with (
@@ -970,7 +970,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
         # Pre-persist Docker image so build can find it.
         nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
         (nanvix_dir / "env.json").write_text(
-            '{"NANVIX_DOCKER_IMAGE": "nanvix/toolchain:latest-minimal"}'
+            '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"}'
         )
 
         with (


### PR DESCRIPTION
## Summary

Migrate all Docker image references from the legacy `nanvix/toolchain:latest-minimal` (Docker Hub) to `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` (GitHub Container Registry).

## Changes

- **.github/workflows/release.yml**: Updated container image
- **src/nanvix_zutil/docker.py**: Updated docstring examples
- **tasks.py**: Updated documentation
- **doc/test.md**, **docs/design.md**, **CONTRIBUTING.md**: Updated documentation
- **examples/bin-hello/README.md**, **examples/lib-hello/README.md**: Updated examples
- **tests/test_docker.py**, **tests/test_script.py**, **tests/test_examples.py**: Updated test fixtures