### PR TITLE
Allow package() to accept ad-hoc files

### DIFF
--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -11,7 +11,7 @@ generate distribution archives::
     from nanvix_zutil.release import ArchiveFormat, package
 
     archives = package(
-        source=Path("build/output"),
+        sources=[Path("build/output")],
         dest=Path("dist"),
         name="mylib-microvm-standalone-256mb",
     )
@@ -166,27 +166,33 @@ def _build_zip(source: Path, dest: Path) -> Path:
 
 
 def package(
-    source: list[Path],
+    sources: list[Path],
     dest: Path,
     name: str,
     formats: Sequence[ArchiveFormat] = DEFAULT_FORMATS,
     staging: Path | None = None,
 ) -> list[Path]:
-    """Package *source* directory into release archives.
+    """Package one or more sources into release archives.
 
     Creates one archive per requested format.  The output file names are
-    formed as ``<name>-<extension>`` (e.g. ``mylib-v1.0.tar.gz``,
+    formed as ``<name><extension>`` (e.g. ``mylib-v1.0.tar.gz``,
     ``mylib-v1.0.zip``).
 
     Args:
-        source: List of items to archive. May be a directory or file.
+        sources: Items to archive.  Each entry may be a file or a directory.
+            Directory contents are merged flat into the staging root;
+            individual files are placed at the staging root by their basename.
+            Duplicate staging paths across entries are rejected.
         dest: Output directory for archives.  Created if it does not exist.
         name: Base name for the archives (without extension). Must be a plain
             filename without path separators or parent directory traversal.
         formats: Archive formats to produce.  Defaults to
             :data:`DEFAULT_FORMATS` (tar.gz + zip).
-        staging: Temporary staging directory for archiving.  Defaults to a
-            fresh system-generated temporary directory per call.
+        staging: Directory to use as the staging area.  When supplied, sources
+            are copied directly into this directory (which must already exist)
+            and the caller is responsible for its lifetime.  When omitted, a
+            fresh temporary directory is created and removed automatically on
+            return.
 
     Returns:
         List of absolute paths to created archives, one per format, in
@@ -194,12 +200,16 @@ def package(
 
     Raises:
         SystemExit: With :data:`~nanvix_zutil.exitcodes.EXIT_GENERAL_ERROR`
-            if *source* does not exist or is not a directory, or if archive
-            creation fails. With :data:`~nanvix_zutil.exitcodes.EXIT_INVALID_ARGS`
-            if *name* is empty, whitespace-only, or contains path separators
-            or parent directory traversal, or if an unknown format is encountered.
+            if any entry in *sources* does not exist, if staging or copying
+            fails, or if archive creation fails.  With
+            :data:`~nanvix_zutil.exitcodes.EXIT_INVALID_ARGS` if *name* is
+            empty, whitespace-only, or contains path separators or parent
+            directory traversal, if two sources map to the same staging path,
+            or if an unknown format is encountered.
     """
-    for item in source:
+    if not sources:
+        log.warning("package() called with no source items; archives will be empty.")
+    for item in sources:
         if not item.exists():
             log.fatal(
                 f"Release source '{item}' does not exist.",
@@ -259,57 +269,73 @@ def package(
             code=EXIT_GENERAL_ERROR,
             hint="Check parent directory permissions and available disk space.",
         )
+
     created: list[Path] = []
-    call_staging = Path(mkdtemp(dir=staging)) if staging else Path(mkdtemp())
+    _cleanup_staging = staging is None
+    staging = staging if staging else Path(mkdtemp())
 
-    for item in source:
-        if item.is_dir():
-            shutil.copytree(item, call_staging, dirs_exist_ok=True, symlinks=True)
-        else:
-            shutil.copy2(item, call_staging / item.name)
-
-    for fmt in formats:
-        # Runtime validation: users could pass invalid types despite type hints
-        if not isinstance(fmt, ArchiveFormat):  # type: ignore[redundant-expr]
-            log.fatal(
-                f"Invalid archive format: {fmt!r} (expected ArchiveFormat)",
-                code=EXIT_INVALID_ARGS,
-                hint="Use one of the supported ArchiveFormat enum values (TAR_GZ, TAR_BZ2, ZIP).",
-            )
-
-        out = dest / f"{name}{fmt.extension}"
-
+    def package_sources() -> list[Path]:
         try:
-            if fmt is ArchiveFormat.TAR_GZ:
-                _build_tarball(call_staging, out, "gz")
-            elif fmt is ArchiveFormat.TAR_BZ2:
-                _build_tarball(call_staging, out, "bz2")
-            elif fmt is ArchiveFormat.ZIP:
-                _build_zip(call_staging, out)
-            else:
-                # This should never happen with a proper ArchiveFormat enum value
+            for item in sources:
+                if item.is_dir():
+                    shutil.copytree(item, staging, dirs_exist_ok=True, symlinks=True)
+                else:
+                    shutil.copy2(item, staging / item.name)
+        except (OSError, shutil.Error) as e:
+            log.fatal(
+                f"Failed to stage sources into '{staging}': {e}",
+                code=EXIT_GENERAL_ERROR,
+                hint="Check source file permissions and available disk space.",
+            )
+
+        for fmt in formats:
+            # Runtime validation: users could pass invalid types despite type hints
+            if not isinstance(fmt, ArchiveFormat):  # type: ignore[redundant-expr]
                 log.fatal(
-                    f"Unknown archive format: {fmt}",
+                    f"Invalid archive format: {fmt!r} (expected ArchiveFormat)",
                     code=EXIT_INVALID_ARGS,
-                    hint="Use one of the supported ArchiveFormat enum values.",
+                    hint="Use one of the supported ArchiveFormat enum values (TAR_GZ, TAR_BZ2, ZIP).",
                 )
-        except Exception as e:
-            log.fatal(
-                f"Failed to create {fmt.name} archive: {e}",
-                code=EXIT_GENERAL_ERROR,
-                hint="Check source directory access, disk space, and file permissions.",
-            )
 
-        # Verify the archive was actually created before logging success
-        if not out.exists():
-            log.fatal(
-                f"Failed to create archive: {out}",
-                code=EXIT_GENERAL_ERROR,
-                hint="Check disk space and permissions.",
-            )
+            out = dest / f"{name}{fmt.extension}"
 
-        log.info(f"Created {out}")
-        created.append(out.resolve())
+            try:
+                if fmt is ArchiveFormat.TAR_GZ:
+                    _build_tarball(staging, out, "gz")
+                elif fmt is ArchiveFormat.TAR_BZ2:
+                    _build_tarball(staging, out, "bz2")
+                elif fmt is ArchiveFormat.ZIP:
+                    _build_zip(staging, out)
+                else:
+                    # This should never happen with a proper ArchiveFormat enum value
+                    log.fatal(
+                        f"Unknown archive format: {fmt}",
+                        code=EXIT_INVALID_ARGS,
+                        hint="Use one of the supported ArchiveFormat enum values.",
+                    )
+            except Exception as e:
+                log.fatal(
+                    f"Failed to create {fmt.name} archive: {e}",
+                    code=EXIT_GENERAL_ERROR,
+                    hint="Check source directory access, disk space, and file permissions.",
+                )
 
-    log.success(f"Packaged {len(created)} archive(s) for '{name}' into {dest}")
-    return created
+            # Verify the archive was actually created before logging success
+            if not out.exists():
+                log.fatal(
+                    f"Failed to create archive: {out}",
+                    code=EXIT_GENERAL_ERROR,
+                    hint="Check disk space and permissions.",
+                )
+
+            log.info(f"Created {out}")
+            created.append(out.resolve())
+
+        log.success(f"Packaged {len(created)} archive(s) for '{name}' into {dest}")
+        return created
+
+    try:
+        return package_sources()
+    finally:
+        if _cleanup_staging:
+            shutil.rmtree(staging, ignore_errors=True)

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -83,6 +83,10 @@ def _build_tarball(source: Path, dest: Path, compression: Literal["gz", "bz2"]) 
 
     Returns:
         *dest* after the tarball has been written.
+
+    Note:
+        Symlinks are excluded from the archive. Symlinked directories are not
+        traversed.
     """
     mode: Literal["w:gz", "w:bz2"] = "w:gz" if compression == "gz" else "w:bz2"
     source_resolved = source.resolve()
@@ -134,6 +138,10 @@ def _build_zip(source: Path, dest: Path) -> Path:
 
     Returns:
         *dest* after the ZIP has been written.
+
+    Note:
+        Symlinks are excluded from the archive. Symlinked directories are not
+        traversed.
     """
     source_resolved = source.resolve()
 
@@ -182,7 +190,9 @@ def package(
         sources: Items to archive.  Each entry may be a file or a directory.
             Directory contents are merged flat into the staging root;
             individual files are placed at the staging root by their basename.
-            Duplicate staging paths across entries are rejected.
+            Duplicate items are clobbered.
+            Symlinks in *sources* and symlinks encountered inside source
+            directories are silently skipped.
         dest: Output directory for archives.  Created if it does not exist.
         name: Base name for the archives (without extension). Must be a plain
             filename without path separators or parent directory traversal.
@@ -207,8 +217,6 @@ def package(
             directory traversal, if two sources map to the same staging path,
             or if an unknown format is encountered.
     """
-    if not sources:
-        log.warning("package() called with no source items; archives will be empty.")
     for item in sources:
         if not item.exists():
             log.fatal(
@@ -270,16 +278,32 @@ def package(
             hint="Check parent directory permissions and available disk space.",
         )
 
-    created: list[Path] = []
     _cleanup_staging = staging is None
+    if staging is not None:
+        if not staging.exists():
+            log.fatal(
+                f"Staging directory '{staging}' does not exist.",
+                code=EXIT_INVALID_ARGS,
+                hint="Create the directory before passing it as 'staging', or omit the argument to use a temporary directory.",
+            )
+        if not staging.is_dir():
+            log.fatal(
+                f"Staging path '{staging}' exists but is not a directory.",
+                code=EXIT_INVALID_ARGS,
+                hint="Pass a directory path for 'staging', or omit the argument to use a temporary directory.",
+            )
     staging = staging if staging else Path(mkdtemp())
 
     def package_sources() -> list[Path]:
+        created: list[Path] = []
         try:
             for item in sources:
                 if item.is_dir():
                     shutil.copytree(item, staging, dirs_exist_ok=True, symlinks=True)
                 else:
+                    if item.is_symlink():
+                        log.warning(f"Skipping symlink source '{item}'.")
+                        continue
                     shutil.copy2(item, staging / item.name)
         except (OSError, shutil.Error) as e:
             log.fatal(

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -20,11 +20,13 @@ generate distribution archives::
 from __future__ import annotations
 
 import os
+import shutil
 import tarfile
 import zipfile
 from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
+from tempfile import mkdtemp
 from typing import Literal, Sequence
 
 from nanvix_zutil import log
@@ -164,24 +166,27 @@ def _build_zip(source: Path, dest: Path) -> Path:
 
 
 def package(
-    source: Path,
+    source: list[Path],
     dest: Path,
     name: str,
     formats: Sequence[ArchiveFormat] = DEFAULT_FORMATS,
+    staging: Path | None = None,
 ) -> list[Path]:
     """Package *source* directory into release archives.
 
     Creates one archive per requested format.  The output file names are
-    formed as ``<name><extension>`` (e.g. ``mylib-v1.0.tar.gz``,
+    formed as ``<name>-<extension>`` (e.g. ``mylib-v1.0.tar.gz``,
     ``mylib-v1.0.zip``).
 
     Args:
-        source: Directory to archive.  Must exist and be a directory.
+        source: List of items to archive. May be a directory or file.
         dest: Output directory for archives.  Created if it does not exist.
         name: Base name for the archives (without extension). Must be a plain
             filename without path separators or parent directory traversal.
         formats: Archive formats to produce.  Defaults to
             :data:`DEFAULT_FORMATS` (tar.gz + zip).
+        staging: Temporary staging directory for archiving.  Defaults to a
+            fresh system-generated temporary directory per call.
 
     Returns:
         List of absolute paths to created archives, one per format, in
@@ -194,13 +199,14 @@ def package(
             if *name* is empty, whitespace-only, or contains path separators
             or parent directory traversal, or if an unknown format is encountered.
     """
-    if not source.is_dir():
-        log.fatal(
-            f"Release source '{source}' does not exist or is not a directory.",
-            code=EXIT_GENERAL_ERROR,
-            hint="Ensure the build step has run and produced output in the"
-            " expected directory before calling 'release'.",
-        )
+    for item in source:
+        if not item.exists():
+            log.fatal(
+                f"Release source '{item}' does not exist.",
+                code=EXIT_GENERAL_ERROR,
+                hint="Ensure the build step has run and produced output in the"
+                " expected directory before calling 'release'.",
+            )
 
     # Validate name is a safe, non-empty filename
     if not name or not name.strip():
@@ -218,7 +224,6 @@ def package(
             hint="Use a simple basename like 'mylib-v1.0' instead of paths like '../evil' or 'dir/name'.",
         )
 
-    # Validate formats is a proper iterable (not None, str, or bytes)
     if formats is None:  # type: ignore[redundant-expr]
         log.fatal(
             "Invalid formats parameter: cannot be None",
@@ -255,6 +260,13 @@ def package(
             hint="Check parent directory permissions and available disk space.",
         )
     created: list[Path] = []
+    call_staging = Path(mkdtemp(dir=staging)) if staging else Path(mkdtemp())
+
+    for item in source:
+        if item.is_dir():
+            shutil.copytree(item, call_staging, dirs_exist_ok=True, symlinks=True)
+        else:
+            shutil.copy2(item, call_staging / item.name)
 
     for fmt in formats:
         # Runtime validation: users could pass invalid types despite type hints
@@ -269,11 +281,11 @@ def package(
 
         try:
             if fmt is ArchiveFormat.TAR_GZ:
-                _build_tarball(source, out, "gz")
+                _build_tarball(call_staging, out, "gz")
             elif fmt is ArchiveFormat.TAR_BZ2:
-                _build_tarball(source, out, "bz2")
+                _build_tarball(call_staging, out, "bz2")
             elif fmt is ArchiveFormat.ZIP:
-                _build_zip(source, out)
+                _build_zip(call_staging, out)
             else:
                 # This should never happen with a proper ArchiveFormat enum value
                 log.fatal(

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -214,9 +214,15 @@ def package(
             fails, or if archive creation fails.  With
             :data:`~nanvix_zutil.exitcodes.EXIT_INVALID_ARGS` if *name* is
             empty, whitespace-only, or contains path separators or parent
-            directory traversal, if two sources map to the same staging path,
-            or if an unknown format is encountered.
+            directory traversal, or if an unknown format is encountered,
+            or if *sources* is empty.
     """
+    if not sources:
+        log.fatal(
+            "package() requires at least one source item.",
+            code=EXIT_INVALID_ARGS,
+            hint="Pass one or more file or directory paths in the 'sources' list.",
+        )
     for item in sources:
         if not item.exists():
             log.fatal(

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -165,7 +165,7 @@ class TestPackage(unittest.TestCase):
             src = Path(tmp) / "src"
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
-            result = package(src, dest, "mylib-v1.0")
+            result = package([src], dest, "mylib-v1.0")
             self.assertEqual(len(result), 2)
             names = [p.name for p in result]
             self.assertIn("mylib-v1.0.tar.gz", names)
@@ -176,7 +176,7 @@ class TestPackage(unittest.TestCase):
             src = Path(tmp) / "src"
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
-            result = package(src, dest, "pkg", formats=(ArchiveFormat.TAR_BZ2,))
+            result = package([src], dest, "pkg", formats=(ArchiveFormat.TAR_BZ2,))
             self.assertEqual(len(result), 1)
             self.assertEqual(result[0].name, "pkg.tar.bz2")
 
@@ -186,7 +186,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             all_fmts = (ArchiveFormat.TAR_GZ, ArchiveFormat.TAR_BZ2, ArchiveFormat.ZIP)
-            result = package(src, dest, "all", formats=all_fmts)
+            result = package([src], dest, "all", formats=all_fmts)
             self.assertEqual(len(result), 3)
             names = {p.name for p in result}
             self.assertEqual(names, {"all.tar.gz", "all.tar.bz2", "all.zip"})
@@ -198,7 +198,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "nested" / "output" / "dist"
             self.assertFalse(dest.exists())
-            package(src, dest, "test")
+            package([src], dest, "test")
             self.assertTrue(dest.exists())
 
     def test_returns_absolute_paths(self) -> None:
@@ -206,7 +206,7 @@ class TestPackage(unittest.TestCase):
             src = Path(tmp) / "src"
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
-            result = package(src, dest, "abs")
+            result = package([src], dest, "abs")
             for p in result:
                 self.assertTrue(p.is_absolute(), f"expected absolute: {p}")
 
@@ -216,18 +216,20 @@ class TestPackage(unittest.TestCase):
             src = Path(tmp) / "nonexistent"
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "fail")
+                package([src], dest, "fail")
             self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
 
-    def test_source_is_file_exits(self) -> None:
-        """package() calls log.fatal when source is a file, not a directory."""
+    def test_source_is_file_packaged(self) -> None:
+        """package() accepts individual files (not just directories)."""
         with tempfile.TemporaryDirectory() as tmp:
             src = Path(tmp) / "afile.txt"
             src.write_text("not a directory")
             dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "fail")
-            self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
+            result = package([src], dest, "file-pkg")
+            self.assertEqual(len(result), 2)
+            names = [p.name for p in result]
+            self.assertIn("file-pkg.tar.gz", names)
+            self.assertIn("file-pkg.zip", names)
 
     def test_zip_and_tarball_have_same_file_set(self) -> None:
         """Both archive types should contain the same set of files."""
@@ -235,7 +237,7 @@ class TestPackage(unittest.TestCase):
             src = Path(tmp) / "src"
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
-            result = package(src, dest, "match")
+            result = package([src], dest, "match")
 
             tar_path = [p for p in result if p.name.endswith(".tar.gz")][0]
             zip_path = [p for p in result if p.name.endswith(".zip")][0]
@@ -254,7 +256,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             fmts = (ArchiveFormat.ZIP, ArchiveFormat.TAR_BZ2, ArchiveFormat.TAR_GZ)
-            result = package(src, dest, "order", formats=fmts)
+            result = package([src], dest, "order", formats=fmts)
             self.assertEqual(result[0].name, "order.zip")
             self.assertEqual(result[1].name, "order.tar.bz2")
             self.assertEqual(result[2].name, "order.tar.gz")
@@ -266,7 +268,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "bad/name")
+                package([src], dest, "bad/name")
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_name_with_backslash_exits(self) -> None:
@@ -276,7 +278,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "bad\\name")
+                package([src], dest, "bad\\name")
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_name_with_parent_traversal_exits(self) -> None:
@@ -286,7 +288,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "../evil")
+                package([src], dest, "../evil")
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_empty_name_exits(self) -> None:
@@ -296,7 +298,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "")
+                package([src], dest, "")
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_whitespace_only_name_exits(self) -> None:
@@ -306,7 +308,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "   ")
+                package([src], dest, "   ")
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_symlinks_excluded_from_archives(self) -> None:
@@ -326,7 +328,7 @@ class TestPackage(unittest.TestCase):
                 self.skipTest("Symlinks not supported on this platform")
 
             dest = Path(tmp) / "dist"
-            result = package(src, dest, "test")
+            result = package([src], dest, "test")
 
             # Check that symlinks are not included in either archive
             tar_path = [p for p in result if p.name.endswith(".tar.gz")][0]
@@ -347,7 +349,7 @@ class TestPackage(unittest.TestCase):
             dest = Path(tmp) / "dist"
             # Use a string instead of ArchiveFormat enum
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "test", formats=("invalid_format",))  # type: ignore
+                package([src], dest, "test", formats=("invalid_format",))  # type: ignore
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_invalid_format_mixed_tuple_exits(self) -> None:
@@ -358,7 +360,7 @@ class TestPackage(unittest.TestCase):
             dest = Path(tmp) / "dist"
             # Mix valid ArchiveFormat with invalid type
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "test", formats=(ArchiveFormat.ZIP, "bad_format"))  # type: ignore
+                package([src], dest, "test", formats=(ArchiveFormat.ZIP, "bad_format"))  # type: ignore
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_symlinked_directory_not_traversed(self) -> None:
@@ -388,7 +390,7 @@ class TestPackage(unittest.TestCase):
                 self.skipTest("Symlinks not supported on this platform")
 
             dest = Path(tmp) / "dist"
-            result = package(src, dest, "test")
+            result = package([src], dest, "test")
 
             # Verify external files are NOT included in either archive format
             tar_path = [p for p in result if p.name.endswith(".tar.gz")][0]
@@ -417,7 +419,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "test", formats=None)  # type: ignore
+                package([src], dest, "test", formats=None)  # type: ignore
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_formats_string_exits(self) -> None:
@@ -427,7 +429,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "test", formats="invalid")  # type: ignore
+                package([src], dest, "test", formats="invalid")  # type: ignore
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
     def test_formats_non_iterable_exits(self) -> None:
@@ -437,7 +439,7 @@ class TestPackage(unittest.TestCase):
             _make_source_tree(src)
             dest = Path(tmp) / "dist"
             with self.assertRaises(SystemExit) as ctx:
-                package(src, dest, "test", formats=42)  # type: ignore
+                package([src], dest, "test", formats=42)  # type: ignore
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -425,6 +425,32 @@ class TestPackage(unittest.TestCase):
                 self.assertNotIn("evil_link/", zip_names)
                 self.assertNotIn("evil_link", zip_names)
 
+    def test_multi_source_directories_merged(self) -> None:
+        """package() merges multiple source directories into a single archive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src_a = Path(tmp) / "a"
+            src_a.mkdir()
+            (src_a / "from_a.txt").write_bytes(b"alpha")
+
+            src_b = Path(tmp) / "b"
+            src_b.mkdir()
+            (src_b / "from_b.txt").write_bytes(b"beta")
+
+            dest = Path(tmp) / "dist"
+            result = package([src_a, src_b], dest, "merged")
+
+            tar_path = next(p for p in result if p.name.endswith(".tar.gz"))
+            zip_path = next(p for p in result if p.name.endswith(".zip"))
+
+            with tarfile.open(tar_path, "r:gz") as tf:
+                tar_files = {n for n in tf.getnames() if not tf.getmember(n).isdir()}
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                zip_files = set(zf.namelist())
+
+            for names in (tar_files, zip_files):
+                self.assertIn("from_a.txt", names)
+                self.assertIn("from_b.txt", names)
+
     def test_formats_none_exits(self) -> None:
         """package() with None formats parameter exits with error."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -231,6 +231,19 @@ class TestPackage(unittest.TestCase):
             self.assertIn("file-pkg.tar.gz", names)
             self.assertIn("file-pkg.zip", names)
 
+            tar_path = next(p for p in result if p.name.endswith(".tar.gz"))
+            zip_path = next(p for p in result if p.name.endswith(".zip"))
+
+            with tarfile.open(tar_path, "r:gz") as tf:
+                self.assertIn("afile.txt", tf.getnames())
+                member = tf.extractfile("afile.txt")
+                assert member is not None
+                self.assertEqual(member.read().decode(), "not a directory")
+
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                self.assertIn("afile.txt", zf.namelist())
+                self.assertEqual(zf.read("afile.txt").decode(), "not a directory")
+
     def test_zip_and_tarball_have_same_file_set(self) -> None:
         """Both archive types should contain the same set of files."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -210,6 +210,14 @@ class TestPackage(unittest.TestCase):
             for p in result:
                 self.assertTrue(p.is_absolute(), f"expected absolute: {p}")
 
+    def test_empty_sources_exits(self) -> None:
+        """package() with an empty sources list exits with error."""
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "dist"
+            with self.assertRaises(SystemExit) as ctx:
+                package([], dest, "empty")
+            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
+
     def test_missing_source_exits(self) -> None:
         """package() calls log.fatal when source doesn't exist."""
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
   Closes #172

   ## Change summary

   Allow the `package()` API to accept arbitrary files. This will enable a clean-up of downstream consumer code.

   ## Commits

   1. `[zutils] E: package() api multi-input` — Change `source` parameter from `Path` to `list[Path]`, copy items
 into an isolated staging directory before archiving. Files use `shutil.copy2`; directories use `shutil.copytree`
 with `symlinks=True` so symlink-exclusion logic in `_build_tarball`/`_build_zip` is preserved. Fix mutable
 default `staging` argument (was evaluated once at import). Restore dropped `formats is None` and non-iterable
 `formats` guards.
   2. `[tests] F: update TestPackage for multi-input source` — Update all `package(src, ...)` calls to
 `package([src], ...)`. Replace `test_source_is_file_exits` with `test_source_is_file_packaged` to reflect that
 individual files are now valid input.