### PR TITLE
Drop dead [tool.pyright] from pyproject.toml

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -76,9 +76,7 @@ zutils/
 
 ## IDE Configuration
 
-The project uses `pyright` in strict mode. Configuration lives in both
-`pyrightconfig.json` (root, takes precedence) and `[tool.pyright]` in
-`pyproject.toml` — the two are kept in sync:
+The project uses `pyright` in strict mode. Configuration lives in `pyrightconfig.json` 
 
 ```toml
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,3 @@ testpaths = ["tests"]
 line-length = 88
 target-version = ["py312"]
 
-[tool.pyright]
-include = ["src", "tests"]
-pythonVersion = "3.12"
-typeCheckingMode = "strict"
-venvPath = "."
-venv = ".venv"


### PR DESCRIPTION
Closes #175

## Findings

Three separate pyright configurations exist in this repo, not two:

1. ** (repo root)** — the authoritative config for developing zutils itself (`include: ["src","tests"]`, `venv: ".venv"`). Pyright always prefers a standalone `pyrightconfig.json` over any `[tool.pyright]` section in `pyproject.toml`, so the inline TOML entry was silently dead and never read.

2. **`src/nanvix_zutil/configs/pyrightconfig.json`** — a *distinct* config (different `include` and `venv` values) that is shipped as a package resource and copied into downstream consumers' `.nanvix/` directories by `_sync_configs()` in `script.py`. This is the one that actually reaches downstream consumers, not the repo-root file.

3. **`[tool.pyright]` in `pyproject.toml`** (removed here) — an exact duplicate of the repo-root `pyrightconfig.json` settings, unreachable because of pyright's config-file precedence. `test_script.py` further confirms the design intent: it explicitly asserts that no `pyrightconfig.json` is ever written to a consumer repo root, only into `.nanvix/`.