### PR TITLE
Stop auto-enabling Docker for `clean`

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -807,9 +807,9 @@ class ZScript:
         # ------------------------------------------------------------------
         # Resolve Docker image from CLI flags or persisted config.
         #
-        # setup requires --with-docker IMAGE explicitly.  build, release,
-        # and clean load the persisted image from .nanvix/env.json (set
-        # during setup).  If no persisted image exists the command fails.
+        # setup requires --with-docker IMAGE explicitly.  build and release
+        # load the persisted image from .nanvix/env.json (set during setup).
+        # If no persisted image exists the command fails.
         # test and benchmark run natively on the host.
         # ------------------------------------------------------------------
         docker_image: str | None = None
@@ -817,7 +817,7 @@ class ZScript:
 
         #: Subcommands that always run inside Docker.
         _DOCKER_COMMANDS: frozenset[str | None] = frozenset(
-            {"setup", "build", "release", "clean"}
+            {"setup", "build", "release"}
         )
 
         # Subcommand-level flag (only present for setup — now required).
@@ -825,7 +825,7 @@ class ZScript:
         if isinstance(with_docker_val, str):
             docker_image = with_docker_val
 
-        # For build/release/clean, load persisted image.
+        # For build/release, load persisted image.
         #
         # Exception: on Windows, setup downloads host-native binaries
         # via the GitHub API and does not invoke Docker.  Skip Docker

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -912,7 +912,7 @@ class TestZScriptDockerIntegration(unittest.TestCase):
 
 
 class TestZScriptAutoDocker(unittest.TestCase):
-    """Docker is always enabled for setup/build/release/clean (hard fail)."""
+    """Docker is always enabled for setup/build/release (hard fail)."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -984,6 +984,29 @@ class TestZScriptAutoDocker(unittest.TestCase):
             BuildScript.main(repo_root=Path(self._tmpdir.name))
 
         self.assertTrue(docker_configured)
+
+    def test_clean_does_not_require_docker_image(self) -> None:
+        """clean runs without Docker image configuration."""
+
+        class CleanScript(ZScript):
+            def clean(self) -> None:
+                pass
+
+        cleaned = False
+
+        def _fake_clean(self_inner: ZScript) -> None:
+            nonlocal cleaned
+            cleaned = True
+            self.assertIsNone(self_inner.docker)
+
+        with (
+            patch("sys.argv", ["z.py", "clean"]),
+            patch.object(CleanScript, "clean", _fake_clean),
+            patch("nanvix_zutil.script.log"),
+        ):
+            CleanScript.main(repo_root=Path(self._tmpdir.name))
+
+        self.assertTrue(cleaned)
 
 
 class TestZScriptCleanWindows(unittest.TestCase):


### PR DESCRIPTION
Skip Docker auto-enable for the `clean` command to avoid unnecessary Docker requirements when cleaning build artifacts.