### PR TITLE
Fix PYTHONPATH resolution in example integration tests

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -84,15 +84,26 @@ _SKIP_NO_DOCKER = "Docker lifecycle not available (no daemon or Windows host)"
 
 
 def _run_z(
-    cwd: Path, *args: str, timeout: int = _TIMEOUT
+    cwd: Path,
+    *args: str,
+    timeout: int = _TIMEOUT,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Invoke ``nanvix-zutil`` in *cwd* and return the completed process."""
+    env = os.environ.copy()
+    # Ensure the source tree is importable regardless of subprocess cwd.
+    src_dir = str(_REPO_ROOT / "src")
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{src_dir}{os.pathsep}{existing}" if existing else src_dir
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         [sys.executable, "-m", "nanvix_zutil", *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
         timeout=timeout,
+        env=env,
     )
 
 


### PR DESCRIPTION
## Summary

Fix a pre-existing bug in `tests/test_examples.py` where the `_run_z()` helper failed to resolve `nanvix_zutil` in subprocesses.

## Problem

`_run_z()` spawns `python -m nanvix_zutil` with `cwd` set to an example directory (e.g. `examples/lib-hello/`). The parent's `PYTHONPATH=src` is relative and resolves against the subprocess cwd, pointing to `examples/lib-hello/src/` instead of the repo's `src/`. This caused `No module named nanvix_zutil` unless the package was installed via `pip install -e .`.

## Fix

- Compute an absolute path to `_REPO_ROOT / "src"` and inject it into the subprocess environment explicitly.
- Add an `extra_env` parameter to `_run_z()` for future test-specific overrides.
- Bump `_NANVIX_VERSION` from `0.12.410` to `0.13.19` (latest nightly with standalone sysroot release assets).