### PR TITLE
Add timeout parameter to ZScript.run()

### DIFF
--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -196,6 +196,7 @@ class BinHello(ZScript):
             str(sysroot / "bin"),
             "--",
             str(binary),
+            timeout=60,
         )
         log.success("PASS: bin-hello functional tests")
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -652,6 +652,7 @@ class ZScript:
         cwd: Path | None = None,
         env: dict[str, str] | None = None,
         docker: bool = True,
+        timeout: int | None = None,
     ) -> "subprocess.CompletedProcess[str]":
         """Run a subprocess, logging the command before execution.
 
@@ -672,13 +673,16 @@ class ZScript:
             docker: When ``False``, always runs on the host even if Docker
                 mode is active.  Use this for commands that must run locally
                 (e.g. ``clean``).
+            timeout: Maximum seconds to wait for the process to finish.
+                ``None`` means wait indefinitely.  When the timeout expires
+                the process tree is killed and a fatal error is raised.
 
         Returns:
             The completed process result.
 
         Raises:
             SystemExit: With exit code ``5`` if the process exits with a
-                non-zero status.
+                non-zero status or the timeout expires.
         """
         if self.docker is not None and docker:
             cfg = self.docker
@@ -707,6 +711,12 @@ class ZScript:
                 env=subprocess_env,
                 text=True,
                 check=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            log.fatal(
+                f"Command timed out after {timeout}s: {' '.join(args)}",
+                code=EXIT_BUILD_FAILURE,
             )
         except subprocess.CalledProcessError as exc:
             log.fatal(

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -576,6 +576,18 @@ class TestZScriptRun(unittest.TestCase):
         finally:
             log_mod.set_json_mode(False)
 
+    def test_run_timeout_exits(self) -> None:
+        script = ZScript(Path(self._tmpdir.name))
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                script.run(
+                    sys.executable, "-c", "import time; time.sleep(10)", timeout=1
+                )
+            self.assertEqual(ctx.exception.code, 5)
+        finally:
+            log_mod.set_json_mode(False)
+
     @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_run_uses_windows_cmd_on_windows(self, _mock: object) -> None:
         """run() delegates to build_windows_run_cmd on Windows."""


### PR DESCRIPTION
## Problem

The Windows functional test for `bin-hello` calls `nanvixd.exe` which does not self-terminate. Unlike the Docker variant (which wraps the call with `timeout --foreground 60`), the Windows path had no timeout — causing CI to hang indefinitely on the "Integration Tests (windows-latest)" job.

## Root Cause

`ZScript.run()` had no `timeout` parameter, so `subprocess.run()` would block forever waiting for `nanvixd.exe` to exit. On Windows, when the outer test timeout fires and kills the Python child process, the grandchild (`nanvixd.exe`) keeps pipe handles open, preventing the pytest process from ever reading EOF.

## Fix

- Add a `timeout: int | None` keyword argument to `ZScript.run()` that forwards to `subprocess.run()`. On expiry the process is killed and `log.fatal()` raises with exit code 5.
- Use `timeout=60` in `bin-hello`'s `_test_functional_windows()` to match the Docker behavior.
- Add unit test for timeout behavior.