### PR TITLE
Add make_initrd() helper for standalone deployment mode

### DIFF
--- a/examples/bin-hello/.nanvix/nanvix.toml
+++ b/examples/bin-hello/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bin-hello"
 version = "0.1.0"
-nanvix-version = "0.12.410"
+nanvix-version = "0.13.19"
 
 [dependencies]
 lib-hello = { commitish = "HEAD" }

--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -110,6 +110,11 @@ class BinHello(ZScript):
             f" && {cc} {cflags} {ldflags} -o hello.elf main.o {libs}",
         )
 
+        # For standalone deployment mode, produce an initrd image
+        # containing the system daemons and the application binary.
+        if self.config.deployment_mode == "standalone":
+            self.make_initrd("hello.elf")
+
     def test(self) -> None:
         """Run the test suite (smoke + integration + functional).
 
@@ -202,7 +207,7 @@ class BinHello(ZScript):
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        for name in ("main.o", "hello.elf"):
+        for name in ("main.o", "hello.elf", "hello.img"):
             artifact = self.repo_root / name
             if artifact.exists():
                 artifact.unlink()

--- a/examples/bin-hello/README.md
+++ b/examples/bin-hello/README.md
@@ -6,7 +6,7 @@ dependencies.
 
 ## Structure
 
-```
+```text
 bin-hello/
 ├── z                # Bash bootstrap wrapper
 ├── z.ps1            # PowerShell bootstrap wrapper
@@ -22,6 +22,7 @@ bin-hello/
 ## Prerequisites
 
 One of:
+
 - **Native toolchain** — `i686-nanvix-gcc` (default path: `/opt/nanvix/`)
 - **Docker** with `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image (pass via `./z setup --with-docker IMAGE`)
 
@@ -34,9 +35,16 @@ One of:
 ./z clean    # remove build artifacts
 ```
 
+For standalone deployment mode (produces an initrd image with system daemons):
+
+```bash
+NANVIX_DEPLOYMENT_MODE=standalone ./z setup
+NANVIX_DEPLOYMENT_MODE=standalone ./z build   # also produces hello.img
+```
+
 ## Dependency Chain
 
-```
+```text
 bin-hello
   └── lib-hello (libhello.a + hello.h)
 ```

--- a/examples/lib-hello/.nanvix/.gitignore
+++ b/examples/lib-hello/.nanvix/.gitignore
@@ -1,7 +1,9 @@
+__pycache__/
 venv/
 cache/
 sysroot/
 buildroot/
+.yamllint.yml
+black.toml
 env.json
-nanvix.lock
-__pycache__/
+pyrightconfig.json

--- a/examples/lib-hello/.nanvix/nanvix.toml
+++ b/examples/lib-hello/.nanvix/nanvix.toml
@@ -1,4 +1,4 @@
 [package]
 name = "lib-hello"
 version = "0.1.0"
-nanvix-version = "0.12.410"
+nanvix-version = "0.13.19"

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -123,6 +123,20 @@ class ZScript:
         "bin/uservm.elf",
     )
 
+    SYSROOT_STANDALONE_FILES: tuple[str, ...] = (
+        "bin/mkimage.elf",
+        "bin/procd.elf",
+        "bin/memd.elf",
+        "bin/vfsd.elf",
+    )
+
+    SYSROOT_STANDALONE_FILES_WINDOWS: tuple[str, ...] = (
+        "bin/mkimage.exe",
+        "bin/procd.elf",
+        "bin/memd.elf",
+        "bin/vfsd.elf",
+    )
+
     #: Hooks that are auto-implemented in the base class and always
     #: available in the CLI, regardless of subclass overrides.
     AUTO_HOOKS: tuple[str, ...] = (
@@ -150,6 +164,8 @@ class ZScript:
         Uses Windows binary names (``nanvixd.exe``, ``mkramfs.exe``) on
         Windows; Linux names on other platforms.  Multi-process mode
         additionally requires ``linuxd.elf`` and ``uservm.elf``.
+        Standalone mode additionally requires ``mkimage``, ``procd.elf``,
+        ``memd.elf``, and ``vfsd.elf``.
         Subclasses can extend by overriding the class attributes or
         this method.
         """
@@ -159,6 +175,11 @@ class ZScript:
             files = list(self.SYSROOT_REQUIRED_FILES)
         if self.config.deployment_mode == "multi-process":
             files.extend(self.SYSROOT_MULTI_PROCESS_FILES)
+        if self.config.deployment_mode == "standalone":
+            if is_windows():
+                files.extend(self.SYSROOT_STANDALONE_FILES_WINDOWS)
+            else:
+                files.extend(self.SYSROOT_STANDALONE_FILES)
         return files
 
     def __init__(self, repo_root: Path) -> None:
@@ -641,6 +662,117 @@ class ZScript:
                 if p.is_file():
                     p.unlink()
                     log.info(f"Removed {name}")
+
+    # ------------------------------------------------------------------
+    # Image helpers
+    # ------------------------------------------------------------------
+
+    def make_initrd(
+        self,
+        app: str,
+        *,
+        app_args: list[str] | None = None,
+        procd_args: list[str] | None = None,
+        memd_args: list[str] | None = None,
+        vfsd_args: list[str] | None = None,
+        kernel_args: list[str] | None = None,
+        bin_dir: Path | None = None,
+    ) -> Path:
+        """Build a standalone initrd image for *app*.
+
+        Invokes ``mkimage`` from the sysroot ``bin/`` directory to produce
+        an image containing the system daemons (``procd``, ``memd``,
+        ``vfsd``) and the application binary.
+
+        Each program entry in the image has the format
+        ``<path>;<argv0> [arg1 arg2 ...]``.
+
+        Args:
+            app: A bare application binary filename (e.g. ``"my-app.elf"``).
+                Must include the extension and must not contain path
+                separators (``/`` or ``\\``).
+            app_args: Optional CLI arguments appended to the app's argv.
+            procd_args: Optional CLI arguments appended to ``procd``'s argv.
+            memd_args: Optional CLI arguments appended to ``memd``'s argv.
+            vfsd_args: Optional CLI arguments appended to ``vfsd``'s argv.
+            kernel_args: Optional arguments passed to the kernel via
+                ``-kernel-args``.
+            bin_dir: Directory containing the ELF binaries and
+                ``mkimage``.  Defaults to the sysroot ``bin/`` directory.
+
+        Returns:
+            Path to the generated ``.img`` file.
+
+        Raises:
+            SystemExit: If *app* contains path separators, the sysroot
+                is unavailable, or ``mkimage`` is missing.
+        """
+        # Validate that app is a bare filename — no directory components.
+        if "/" in app or "\\" in app:
+            log.fatal(
+                f"app must be a bare filename without path separators, got: {app!r}",
+                code=EXIT_MISSING_DEP,
+            )
+
+        if bin_dir is None:
+            if self.sysroot is not None:
+                bin_dir = self.sysroot.path / "bin"
+            else:
+                sysroot_str = self.config.get(CFG_SYSROOT)
+                if sysroot_str:
+                    bin_dir = Path(sysroot_str) / "bin"
+                else:
+                    log.fatal(
+                        "Sysroot not available; run setup first.",
+                        code=EXIT_MISSING_DEP,
+                    )
+
+        if is_windows():
+            mkimage = bin_dir / "mkimage.exe"
+        else:
+            mkimage = bin_dir / "mkimage.elf"
+
+        # Verify mkimage exists before attempting to run it.
+        if not mkimage.exists():
+            log.fatal(
+                f"mkimage not found at {mkimage}; run setup first.",
+                code=EXIT_MISSING_DEP,
+                hint="Ensure the sysroot contains mkimage by running ./z setup.",
+            )
+
+        app_stem = Path(app).stem
+        output = self.repo_root / f"{app_stem}.img"
+
+        def _escape(arg: str) -> str:
+            return arg.replace(";", "\\;")
+
+        def _entry(elf: str | Path, argv0: str, extra: list[str] | None) -> str:
+            parts = [_escape(argv0)] + [_escape(a) for a in (extra or [])]
+            argv = " ".join(parts)
+            return f"{_escape(str(elf))};{argv}"
+
+        cmd: list[str] = [
+            str(mkimage),
+            "-o",
+            str(output),
+        ]
+
+        if kernel_args:
+            escaped = [_escape(a) for a in kernel_args]
+            cmd.extend(["-kernel-args", " ".join(escaped)])
+
+        cmd.extend(
+            [
+                _entry(bin_dir / "procd.elf", "procd", procd_args),
+                _entry(bin_dir / "memd.elf", "memd", memd_args),
+                _entry(bin_dir / "vfsd.elf", "vfsd", vfsd_args),
+                _entry(self.repo_root / app, app_stem, app_args),
+            ]
+        )
+
+        self.run(*cmd, docker=False)
+
+        return output
 
     # ------------------------------------------------------------------
     # Subprocess helper

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -37,7 +37,7 @@ _WINDOWS_SYSROOT_ASSET_PREFIX = "nanvix-windows-{target}-{machine}-{mode}-releas
 
 # Host binaries needed from the Windows release to run VMs on Windows.
 # kernel.elf is a *guest* binary (i686) — nanvixd.exe loads it directly.
-WINDOWS_HOST_BINARIES = ("nanvixd.exe", "mkramfs.exe", "kernel.elf")
+WINDOWS_HOST_BINARIES = ("nanvixd.exe", "mkramfs.exe", "mkimage.exe", "kernel.elf")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -31,7 +31,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _LIB_HELLO = _REPO_ROOT / "examples" / "lib-hello"
 _BIN_HELLO = _REPO_ROOT / "examples" / "bin-hello"
 _DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
-_NANVIX_VERSION = "0.12.410"
+_NANVIX_VERSION = "0.13.19"
 _TIMEOUT = 300
 
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1679,5 +1679,242 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 3)
 
 
+class TestMakeInitrd(unittest.TestCase):
+    """ZScript.make_initrd() builds the correct mkimage command."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_script(self) -> ZScript:
+        repo_root = Path(self._tmpdir.name)
+        script = ZScript(repo_root)
+        # Set up a fake sysroot with a bin/ directory and mkimage stub.
+        sysroot_bin = repo_root / ".nanvix" / "sysroot" / "bin"
+        sysroot_bin.mkdir(parents=True, exist_ok=True)
+        (sysroot_bin / "mkimage.elf").touch()
+        (sysroot_bin / "mkimage.exe").touch()
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = repo_root / ".nanvix" / "sysroot"
+        script.sysroot = fake_sysroot
+        return script
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_basic_invocation_linux(self, _mock: object) -> None:
+        """Produces the expected command on Linux."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            result = script.make_initrd("my-app.elf")
+
+        self.assertEqual(result, script.repo_root / "my-app.img")
+        cmd = captured[0]
+        bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
+        self.assertEqual(cmd[0], str(bin_dir / "mkimage.elf"))
+        self.assertEqual(cmd[1], "-o")
+        self.assertEqual(cmd[2], str(script.repo_root / "my-app.img"))
+        self.assertEqual(cmd[3], f"{bin_dir / 'procd.elf'};procd")
+        self.assertEqual(cmd[4], f"{bin_dir / 'memd.elf'};memd")
+        self.assertEqual(cmd[5], f"{bin_dir / 'vfsd.elf'};vfsd")
+        self.assertEqual(cmd[6], f"{script.repo_root / 'my-app.elf'};my-app")
+
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    def test_basic_invocation_windows(self, _mock: object) -> None:
+        """Uses mkimage.exe on Windows."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf")
+
+        bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
+        self.assertEqual(captured[0][0], str(bin_dir / "mkimage.exe"))
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_app_args(self, _mock: object) -> None:
+        """App arguments are appended to the app entry."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf", app_args=["--verbose", "--port=8080"])
+
+        app_entry = captured[0][6]
+        self.assertEqual(
+            app_entry, f"{script.repo_root / 'my-app.elf'};my-app --verbose --port=8080"
+        )
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_daemon_args(self, _mock: object) -> None:
+        """Daemon arguments are appended to respective entries."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd(
+                "my-app.elf",
+                procd_args=["--debug"],
+                memd_args=["--heap=64m"],
+                vfsd_args=["--cache=off"],
+            )
+
+        bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
+        self.assertEqual(captured[0][3], f"{bin_dir / 'procd.elf'};procd --debug")
+        self.assertEqual(captured[0][4], f"{bin_dir / 'memd.elf'};memd --heap=64m")
+        self.assertEqual(captured[0][5], f"{bin_dir / 'vfsd.elf'};vfsd --cache=off")
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_kernel_args(self, _mock: object) -> None:
+        """Kernel arguments are passed via --kernel-args."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf", kernel_args=["console=ttyS0", "debug"])
+
+        cmd = captured[0]
+        # -kernel-args should appear after -o <output>
+        ka_idx = cmd.index("-kernel-args")
+        self.assertEqual(cmd[ka_idx + 1], "console=ttyS0 debug")
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_semicolons_escaped_in_args(self, _mock: object) -> None:
+        """Semicolons in arguments are escaped as \\;."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf", app_args=["--sep=;"])
+
+        app_entry = captured[0][6]
+        self.assertEqual(
+            app_entry, f"{script.repo_root / 'my-app.elf'};my-app --sep=\\;"
+        )
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_semicolons_escaped_in_kernel_args(self, _mock: object) -> None:
+        """Semicolons in kernel arguments are escaped."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf", kernel_args=["a;b"])
+
+        cmd = captured[0]
+        ka_idx = cmd.index("-kernel-args")
+        self.assertEqual(cmd[ka_idx + 1], "a\\;b")
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_custom_bin_dir(self, _mock: object) -> None:
+        """A custom bin_dir is used instead of the sysroot."""
+        script = self._make_script()
+        custom_bin = Path(self._tmpdir.name) / "custom" / "bin"
+        custom_bin.mkdir(parents=True)
+        (custom_bin / "mkimage.elf").touch()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf", bin_dir=custom_bin)
+
+        self.assertEqual(captured[0][0], str(custom_bin / "mkimage.elf"))
+        self.assertIn(str(custom_bin / "procd.elf"), captured[0][3])
+
+    def test_no_sysroot_exits(self) -> None:
+        """Exits with EXIT_MISSING_DEP when sysroot is None."""
+        script = ZScript(Path(self._tmpdir.name))
+        script.sysroot = None
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                script.make_initrd("my-app.elf")
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_app_stem_derived_from_filename(self, _mock: object) -> None:
+        """The output .img and argv0 use the stem of the app filename."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            result = script.make_initrd("hello-world.elf")
+
+        self.assertEqual(result, script.repo_root / "hello-world.img")
+        self.assertEqual(
+            captured[0][6], f"{script.repo_root / 'hello-world.elf'};hello-world"
+        )
+
+    def test_app_with_path_separator_exits(self) -> None:
+        """Exits with EXIT_MISSING_DEP when app contains path separators."""
+        script = self._make_script()
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                script.make_initrd("build/hello.elf")
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_mkimage_not_found_exits(self, _mock: object) -> None:
+        """Exits with EXIT_MISSING_DEP when mkimage binary is missing."""
+        repo_root = Path(self._tmpdir.name)
+        script = ZScript(repo_root)
+        # Sysroot bin dir exists but mkimage.elf does not.
+        sysroot_bin = repo_root / ".nanvix" / "sysroot" / "bin"
+        sysroot_bin.mkdir(parents=True, exist_ok=True)
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = repo_root / ".nanvix" / "sysroot"
+        script.sysroot = fake_sysroot
+        log_mod.set_json_mode(True)
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                script.make_initrd("my-app.elf")
+            self.assertEqual(ctx.exception.code, 3)
+        finally:
+            log_mod.set_json_mode(False)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Introduce `ZScript.make_initrd()` to build standalone initrd images containing system daemons (`procd`, `memd`, `vfsd`) and an application binary via the `mkimage` tool from the sysroot.

## Changes

- Add `SYSROOT_STANDALONE_FILES` and `SYSROOT_STANDALONE_FILES_WINDOWS` class attributes listing the required binaries for standalone mode
- Extend `sysroot_required_files()` to include standalone binaries when `deployment_mode` is `"standalone"`
- Add `make_initrd()` method that invokes `mkimage` with the correct program entries (`path;argv` format), supports optional per-daemon and kernel arguments, and escapes semicolons in user-provided args
- Add `mkimage.exe` to `WINDOWS_HOST_BINARIES` in `sysroot.py`
- Update `bin-hello` example to call `make_initrd()` in standalone mode and clean the resulting `.img` artifact
- Bump `nanvix-version` from `0.12.410` to `0.13.19` in example manifests
- Update `lib-hello` `.gitignore` to track generated config files
- Add comprehensive unit tests for `make_initrd()` covering Linux/Windows, custom args, semicolon escaping, custom `bin_dir`, and error paths