### PR TITLE
[script] Add environment variable support to make_initrd

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -672,9 +672,13 @@ class ZScript:
         app: str,
         *,
         app_args: list[str] | None = None,
+        app_env: list[str] | None = None,
         procd_args: list[str] | None = None,
+        procd_env: list[str] | None = None,
         memd_args: list[str] | None = None,
+        memd_env: list[str] | None = None,
         vfsd_args: list[str] | None = None,
+        vfsd_env: list[str] | None = None,
         kernel_args: list[str] | None = None,
         bin_dir: Path | None = None,
     ) -> Path:
@@ -685,16 +689,26 @@ class ZScript:
         ``vfsd``) and the application binary.
 
         Each program entry in the image has the format
-        ``<path>;<argv0> [arg1 arg2 ...]``.
+        ``<path>;<argv0> [arg1 arg2 ...][;KEY=VAL ...]``.  An unescaped
+        ``;`` separates CLI arguments from environment variables (see
+        ``run-linux.md`` for the full protocol).
 
         Args:
             app: A bare application binary filename (e.g. ``"my-app.elf"``).
                 Must include the extension and must not contain path
                 separators (``/`` or ``\\``).
             app_args: Optional CLI arguments appended to the app's argv.
+            app_env: Optional environment variables for the app as
+                ``KEY=VALUE`` strings.
             procd_args: Optional CLI arguments appended to ``procd``'s argv.
+            procd_env: Optional environment variables for ``procd`` as
+                ``KEY=VALUE`` strings.
             memd_args: Optional CLI arguments appended to ``memd``'s argv.
+            memd_env: Optional environment variables for ``memd`` as
+                ``KEY=VALUE`` strings.
             vfsd_args: Optional CLI arguments appended to ``vfsd``'s argv.
+            vfsd_env: Optional environment variables for ``vfsd`` as
+                ``KEY=VALUE`` strings.
             kernel_args: Optional arguments passed to the kernel via
                 ``-kernel-args``.
             bin_dir: Directory containing the ELF binaries and
@@ -746,9 +760,17 @@ class ZScript:
         def _escape(arg: str) -> str:
             return arg.replace(";", "\\;")
 
-        def _entry(elf: str | Path, argv0: str, extra: list[str] | None) -> str:
+        def _entry(
+            elf: str | Path,
+            argv0: str,
+            extra: list[str] | None,
+            env: list[str] | None = None,
+        ) -> str:
             parts = [_escape(argv0)] + [_escape(a) for a in (extra or [])]
             argv = " ".join(parts)
+            if env:
+                env_str = " ".join(_escape(e) for e in env)
+                return f"{_escape(str(elf))};{argv};{env_str}"
             return f"{_escape(str(elf))};{argv}"
 
         cmd: list[str] = [
@@ -763,10 +785,10 @@ class ZScript:
 
         cmd.extend(
             [
-                _entry(bin_dir / "procd.elf", "procd", procd_args),
-                _entry(bin_dir / "memd.elf", "memd", memd_args),
-                _entry(bin_dir / "vfsd.elf", "vfsd", vfsd_args),
-                _entry(self.repo_root / app, app_stem, app_args),
+                _entry(bin_dir / "procd.elf", "procd", procd_args, procd_env),
+                _entry(bin_dir / "memd.elf", "memd", memd_args, memd_env),
+                _entry(bin_dir / "vfsd.elf", "vfsd", vfsd_args, vfsd_env),
+                _entry(self.repo_root / app, app_stem, app_args, app_env),
             ]
         )
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1915,6 +1915,139 @@ class TestMakeInitrd(unittest.TestCase):
         finally:
             log_mod.set_json_mode(False)
 
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_app_env(self, _mock: object) -> None:
+        """Environment variables are appended after a semicolon separator."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf", app_env=["VAR1=foo", "VAR2=bar"])
+
+        app_entry = captured[0][6]
+        self.assertEqual(
+            app_entry,
+            f"{script.repo_root / 'my-app.elf'};my-app;VAR1=foo VAR2=bar",
+        )
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_app_args_and_env(self, _mock: object) -> None:
+        """Both app arguments and environment variables are emitted."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd(
+                "my-app.elf",
+                app_args=["--verbose"],
+                app_env=["DEBUG=1"],
+            )
+
+        app_entry = captured[0][6]
+        self.assertEqual(
+            app_entry,
+            f"{script.repo_root / 'my-app.elf'};my-app --verbose;DEBUG=1",
+        )
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_daemon_env(self, _mock: object) -> None:
+        """Daemon environment variables are appended to respective entries."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd(
+                "my-app.elf",
+                procd_env=["LOG=debug"],
+                memd_env=["HEAP=64m"],
+                vfsd_env=["CACHE=off"],
+            )
+
+        bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
+        self.assertEqual(captured[0][3], f"{bin_dir / 'procd.elf'};procd;LOG=debug")
+        self.assertEqual(captured[0][4], f"{bin_dir / 'memd.elf'};memd;HEAP=64m")
+        self.assertEqual(captured[0][5], f"{bin_dir / 'vfsd.elf'};vfsd;CACHE=off")
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_env_semicolons_escaped(self, _mock: object) -> None:
+        """Semicolons in env values are escaped."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd("my-app.elf", app_env=["PATH=/a;/b"])
+
+        app_entry = captured[0][6]
+        self.assertEqual(
+            app_entry,
+            f"{script.repo_root / 'my-app.elf'};my-app;PATH=/a\\;/b",
+        )
+
+    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    def test_daemon_args_and_env(self, _mock: object) -> None:
+        """Daemon entries include both CLI arguments and environment variables."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd(
+                "my-app.elf",
+                procd_args=["--log-level", "trace"],
+                procd_env=["LOG=debug"],
+            )
+
+        bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
+        self.assertEqual(
+            captured[0][3],
+            f"{bin_dir / 'procd.elf'};procd --log-level trace;LOG=debug",
+        )
+
+    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    def test_env_windows(self, _mock: object) -> None:
+        """Environment variables work correctly on Windows (mkimage.exe)."""
+        script = self._make_script()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
+            script.make_initrd(
+                "my-app.elf",
+                app_args=["--verbose"],
+                app_env=["DEBUG=1"],
+                procd_env=["LOG=debug"],
+            )
+
+        bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
+        self.assertEqual(captured[0][0], str(bin_dir / "mkimage.exe"))
+        self.assertEqual(captured[0][3], f"{bin_dir / 'procd.elf'};procd;LOG=debug")
+        self.assertEqual(
+            captured[0][6],
+            f"{script.repo_root / 'my-app.elf'};my-app --verbose;DEBUG=1",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add `*_env` parameters (`app_env`, `procd_env`, `memd_env`, `vfsd_env`) to `make_initrd()` so callers can pass `KEY=VALUE` environment variables to programs in the initrd image.

## Motivation

`make_initrd` previously only supported CLI arguments for each program entry. The Nanvix runtime protocol (documented in `run-linux.md`) supports environment variables via an unescaped `;` separator in the entry's argv section:

```
<path>;<argv0> [arg1 ...];KEY=VAL KEY2=VAL2
```

However, the internal `_escape()` helper escaped **all** semicolons, making it impossible to pass environment variables through `make_initrd`.

## Changes

- **`script.py`**: Added `app_env`, `procd_env`, `memd_env`, `vfsd_env` keyword-only parameters to `make_initrd()`. Updated the `_entry()` helper to accept an optional `env` list and emit an unescaped `;` separator followed by space-joined `KEY=VALUE` pairs. Semicolons within individual env values are still escaped.
- **`test_script.py`**: Added 4 new test cases:
  - `test_app_env` — env vars appended after `;` separator
  - `test_app_args_and_env` — both args and env vars emitted correctly
  - `test_daemon_env` — env vars for procd/memd/vfsd
  - `test_env_semicolons_escaped` — semicolons in env values are escaped

## Usage

```python
self.make_initrd(
    "my-app.elf",
    app_args=["--verbose"],
    app_env=["VAR1=foo", "VAR2=bar"],
)
# produces entry: <path>/my-app.elf;my-app --verbose;VAR1=foo VAR2=bar
```