### PR TITLE
[build] Auto-pull missing docker image

### DIFF
--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -22,8 +22,6 @@ Public re-exports:
 - :func:`~nanvix_zutil.resolver.is_stale` — check lockfile staleness
 - :class:`~nanvix_zutil.docker.DockerConfig` — Docker run configuration
 - :class:`~nanvix_zutil.docker.Mount` — Docker volume mount descriptor
-- :func:`~nanvix_zutil.docker.docker_available` — check Docker CLI presence
-- :func:`~nanvix_zutil.docker.image_exists` — check local image availability
 - :class:`~nanvix_zutil.info.NanvixInfo` — resolved Nanvix release information
 - :func:`~nanvix_zutil.info.get_nanvix_info` — query Nanvix release info
 - :func:`~nanvix_zutil.github.resolve_release` — resolve a release by version specifier
@@ -68,8 +66,6 @@ from nanvix_zutil.docker import (
     DockerConfig,
     Mount,
     is_windows,
-    docker_available,
-    image_exists,
 )
 from nanvix_zutil.exitcodes import (
     EXIT_BUILD_FAILURE,
@@ -136,11 +132,9 @@ __all__ = [
     "Sysroot",
     "ZScript",
     "is_windows",
-    "docker_available",
     "extract_nanvix_version",
     "extract_nanvix_version_base",
     "get_nanvix_info",
-    "image_exists",
     "is_stale",
     "load_manifest",
     "package",

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 import dataclasses
 import os
 import shlex
-import shutil
-import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -366,38 +364,3 @@ class DockerConfig:
         docker_cmd.append(self.image)
         docker_cmd += ["sh", "-c", shell_script]
         return docker_cmd
-
-
-# ---------------------------------------------------------------------------
-# Availability helpers
-# ---------------------------------------------------------------------------
-
-
-def docker_available() -> bool:
-    """Return ``True`` if the Docker CLI is present on ``PATH``.
-
-    Returns:
-        ``True`` when the ``docker`` executable can be found, ``False``
-        otherwise.
-    """
-    return shutil.which("docker") is not None
-
-
-def image_exists(image: str) -> bool:
-    """Return ``True`` if *image* is available in the local Docker image cache.
-
-    Args:
-        image: Docker image reference (e.g.
-            ``"ghcr.io/nanvix/toolchain-gcc:sha-34a3641"``).
-
-    Returns:
-        ``True`` when the image is present locally, ``False`` otherwise or
-        when Docker is unavailable.
-    """
-    if not docker_available():
-        return False
-    result = subprocess.run(
-        ["docker", "image", "inspect", image],
-        capture_output=True,
-    )
-    return result.returncode == 0

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -50,8 +50,6 @@ from nanvix_zutil.docker import (
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
-    docker_available,
-    image_exists,
     is_windows,
 )
 from nanvix_zutil.exitcodes import (
@@ -158,6 +156,11 @@ class ZScript:
         "clean",
     )
 
+    # Subcommands that always run inside Docker.
+    DOCKER_COMMANDS: frozenset[str | None] = frozenset(
+        {"setup", "build", "release", "clean"}
+    )
+
     def sysroot_required_files(self) -> list[str]:
         """Return the sysroot files required for the current platform and mode.
 
@@ -223,6 +226,41 @@ class ZScript:
     # ------------------------------------------------------------------
     # Docker hooks — override in subclass to customise
     # ------------------------------------------------------------------
+
+    def _check_docker(self, image: str) -> None:
+        """Ensure the Docker CLI and the requested *image* are available.
+
+        Verifies that the ``docker`` binary is on ``PATH``, then runs
+        ``docker image inspect`` to check whether *image* is present locally.
+        If the image is missing, ``docker pull`` is invoked to fetch it.
+
+        Args:
+            image: Fully qualified Docker image reference to ensure is
+                available locally.
+
+        Raises:
+            SystemExit: Calls :func:`log.fatal` with
+                :data:`EXIT_MISSING_DEP` if the ``docker`` CLI is not on
+                ``PATH`` or if the auto-pull of *image* fails.
+        """
+
+        if shutil.which("docker") is None:
+            log.fatal(
+                "Docker is not available. Install Docker to continue.",
+                code=EXIT_MISSING_DEP,
+            )
+
+        image_exists = (
+            subprocess.run(["docker", "image", "inspect", image]).returncode == 0
+        )
+
+        if not image_exists:
+            res = subprocess.run(["docker", "pull", image]).returncode
+            if res != 0:
+                log.fatal(
+                    f"Docker image '{image}' could not be pulled.",
+                    code=EXIT_MISSING_DEP,
+                )
 
     def docker_config(self, image: str) -> DockerConfig:
         """Build the :class:`~nanvix_zutil.DockerConfig` for *image*.
@@ -969,68 +1007,46 @@ class ZScript:
         args = parser.parse_args(framework_argv)
 
         # ------------------------------------------------------------------
-        # Resolve Docker image from CLI flags or persisted config.
-        #
-        # setup requires --with-docker IMAGE explicitly.  build, release,
-        # and clean load the persisted image from .nanvix/env.json (set
-        # during setup).  If no persisted image exists the command fails.
-        # test and benchmark run natively on the host.
+        # Docker: resolve image from CLI or persisted config, then check availability.
         # ------------------------------------------------------------------
-        docker_image: str | None = None
-        subcommand_name_for_docker: str | None = args.subcommand
 
-        #: Subcommands that always run inside Docker.
-        _DOCKER_COMMANDS: frozenset[str | None] = frozenset(
-            {"setup", "build", "release", "clean"}
-        )
-
-        # Subcommand-level flag (only present for setup — now required).
-        with_docker_val = getattr(args, "with_docker", None)
-        if isinstance(with_docker_val, str):
-            docker_image = with_docker_val
-
-        # For build/release/clean, load persisted image.
-        #
-        # Exception: on Windows, setup downloads host-native binaries
+        # On Windows, setup downloads host-native binaries
         # via the GitHub API and does not invoke Docker.  Skip Docker
         # entirely for setup on Windows — the image is still persisted
         # to .nanvix/env.json so that subsequent commands can use it,
         # but we do not require Docker to be installed or the image to
         # exist locally.
-        _skip_docker = is_windows() and subcommand_name_for_docker == "setup"
-        if (
-            docker_image is None
-            and subcommand_name_for_docker in _DOCKER_COMMANDS
-            and not _skip_docker
-        ):
+        if args.subcommand in ZScript.DOCKER_COMMANDS:
+            image: str | None = getattr(args, "with_docker", None)
             persisted_image = instance.config.get(CFG_DOCKER_IMAGE)
-            if not persisted_image:
-                log.fatal(
-                    "No Docker image configured — run 'setup --with-docker IMAGE' first.",
-                    code=EXIT_INVALID_ARGS,
-                )
-            docker_image = persisted_image
 
-        if docker_image is not None and not _skip_docker:
-            if not docker_available():
-                log.fatal(
-                    "Docker is not available — install Docker to continue.",
-                    code=EXIT_MISSING_DEP,
-                )
-            if not image_exists(docker_image):
-                log.fatal(
-                    f"Docker image '{docker_image}' not found locally."
-                    f"  Pull it with: docker pull {docker_image}",
-                    code=EXIT_MISSING_DEP,
-                )
-            instance.docker = instance.docker_config(docker_image)
+            if image is None:
+                if not persisted_image:
+                    log.fatal(
+                        "No Docker image configured — run 'setup --with-docker IMAGE' first.",
+                        code=EXIT_INVALID_ARGS,
+                    )
+                image = persisted_image
 
-        # Persist Docker image on setup so subsequent commands
-        # automatically use the same image.  This runs even on
-        # Windows where Docker checks are skipped.
-        if docker_image is not None and subcommand_name_for_docker == "setup":
-            instance.config.set(CFG_DOCKER_IMAGE, docker_image)
-            instance.config.save()
+            # TODO: Move into setup()
+            # https://github.com/nanvix/zutils/issues/187
+            # https://github.com/nanvix/zutils/issues/190
+            if args.subcommand == "setup":
+                if persisted_image is not None and persisted_image != image:
+                    log.warning(
+                        f"Overriding previously configured Docker image '{persisted_image}'"
+                        f" with '{image}'."
+                    )
+                instance.config.set(CFG_DOCKER_IMAGE, image)
+                instance.config.save()
+
+            if not is_windows():
+                # may exit if Docker is required but not available
+                instance._check_docker(image)
+
+            # Persist Docker image on setup so subsequent commands
+            # automatically use the same image.
+            instance.docker = instance.docker_config(image)
 
         # ------------------------------------------------------------------
         # Dispatch to lifecycle hook

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import tempfile
 import unittest
 from pathlib import Path, PurePosixPath
@@ -20,8 +19,6 @@ from nanvix_zutil.docker import (
     DockerConfig,
     Mount,
     is_windows,
-    docker_available,
-    image_exists,
 )
 
 
@@ -203,50 +200,6 @@ class TestDockerConfigBuildRunCmd(unittest.TestCase):
         cfg.extra_env["MY_VAR"] = "hello"
         cmd = cfg.build_run_cmd("echo")
         self.assertIn("MY_VAR=hello", cmd)
-
-
-class TestDockerAvailable(unittest.TestCase):
-    """Tests for docker_available()."""
-
-    def test_returns_bool(self) -> None:
-        result = docker_available()
-        self.assertIsInstance(result, bool)
-
-    def test_false_when_docker_not_on_path(self) -> None:
-        with patch("nanvix_zutil.docker.shutil.which", return_value=None):
-            self.assertFalse(docker_available())
-
-    def test_true_when_docker_on_path(self) -> None:
-        with patch("nanvix_zutil.docker.shutil.which", return_value="/usr/bin/docker"):
-            self.assertTrue(docker_available())
-
-
-class TestImageExists(unittest.TestCase):
-    """Tests for image_exists()."""
-
-    def test_false_when_docker_not_available(self) -> None:
-        with patch("nanvix_zutil.docker.docker_available", return_value=False):
-            self.assertFalse(image_exists("any-image"))
-
-    def test_false_when_inspect_fails(self) -> None:
-        fake_result: subprocess.CompletedProcess[bytes] = subprocess.CompletedProcess(
-            args=[], returncode=1
-        )
-        with (
-            patch("nanvix_zutil.docker.docker_available", return_value=True),
-            patch("nanvix_zutil.docker.subprocess.run", return_value=fake_result),
-        ):
-            self.assertFalse(image_exists("nonexistent-image"))
-
-    def test_true_when_inspect_succeeds(self) -> None:
-        fake_result: subprocess.CompletedProcess[bytes] = subprocess.CompletedProcess(
-            args=[], returncode=0
-        )
-        with (
-            patch("nanvix_zutil.docker.docker_available", return_value=True),
-            patch("nanvix_zutil.docker.subprocess.run", return_value=fake_result),
-        ):
-            self.assertTrue(image_exists("ghcr.io/nanvix/toolchain-gcc:sha-34a3641"))
 
 
 class TestWellKnownPaths(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -71,6 +71,9 @@ class TestIntegrationLifecycle(unittest.TestCase):
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
         log_mod.set_json_mode(False)
+        p = patch.object(ZScript, "_check_docker", return_value=None)
+        p.start()
+        self.addCleanup(p.stop)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
@@ -110,8 +113,6 @@ class TestIntegrationLifecycle(unittest.TestCase):
         with (
             patch.object(_MockConsumer, "__init__", capturing_init),
             patch("sys.argv", argv),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
         ):
             _MockConsumer.main()
 
@@ -157,11 +158,7 @@ class TestIntegrationLifecycle(unittest.TestCase):
             '{"NANVIX_DOCKER_IMAGE": "test/image:tag"}'
         )
 
-        with (
-            patch("sys.argv", [fake_script, "--json", "build"]),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
-        ):
+        with (patch("sys.argv", [fake_script, "--json", "build"]),):
             _MockConsumer.main()
 
         # After main(), log mode was set to True. Verify it produces JSON output.
@@ -233,8 +230,6 @@ class TestIntegrationLifecycle(unittest.TestCase):
         with (
             patch.object(_MockConsumer, "__init__", capturing_init),
             patch("sys.argv", [fake_script, "build"]),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
         ):
             _MockConsumer.main()
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,6 +1,7 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# pyright: reportPrivateUsage=false
 """Tests for nanvix_zutil.script (ZScript)."""
 
 import json
@@ -956,9 +957,6 @@ class TestZScriptAutoDocker(unittest.TestCase):
 
         with (
             patch("sys.argv", ["z.py", "build"]),
-            patch("nanvix_zutil.script.is_windows", return_value=True),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
             patch.object(BuildScript, "build", _fake_build),
             patch("nanvix_zutil.script.log"),
         ):
@@ -985,11 +983,14 @@ class TestZScriptAutoDocker(unittest.TestCase):
             '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"}'
         )
 
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
         with (
             patch("sys.argv", ["z.py", "build"]),
             patch("nanvix_zutil.script.is_windows", return_value=False),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
+            patch("nanvix_zutil.script.shutil.which", return_value="/usr/bin/docker"),
+            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
             patch.object(BuildScript, "build", _fake_build),
             patch("nanvix_zutil.script.log"),
         ):
@@ -1143,6 +1144,10 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
+        p = patch.object(ZScript, "_check_docker", return_value=None)
+        p.start()
+        self.addCleanup(p.stop)
+
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
 
@@ -1162,8 +1167,6 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
 
         with (
             patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
             patch.object(ZScript, "setup", _setup_with_fallback),
             self.assertRaises(SystemExit) as ctx,
         ):
@@ -1177,8 +1180,6 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
 
         with (
             patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
             patch.object(ZScript, "setup", return_value=True),
             self.assertRaises(SystemExit) as ctx,
         ):
@@ -1190,8 +1191,6 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         """main() with setup subcommand completes normally when no fallback."""
         with (
             patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
-            patch("nanvix_zutil.script.docker_available", return_value=True),
-            patch("nanvix_zutil.script.image_exists", return_value=True),
             patch.object(ZScript, "setup", return_value=False),
             patch("nanvix_zutil.script.log") as mock_log,
         ):
@@ -1220,8 +1219,6 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
                     "sys.argv",
                     ["z.py", "--json", "setup", "--with-docker", "test/image:tag"],
                 ),
-                patch("nanvix_zutil.script.docker_available", return_value=True),
-                patch("nanvix_zutil.script.image_exists", return_value=True),
                 patch.object(ZScript, "setup", return_value=True),
                 self.assertRaises(SystemExit) as ctx,
             ):
@@ -2047,6 +2044,122 @@ class TestMakeInitrd(unittest.TestCase):
             captured[0][6],
             f"{script.repo_root / 'my-app.elf'};my-app --verbose;DEBUG=1",
         )
+
+
+class TestZScriptCheckDocker(unittest.TestCase):
+    """_check_docker() probes for the image and auto-pulls when missing."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        write_manifest(Path(self._tmpdir.name))
+        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _make_script(self) -> ZScript:
+        return ZScript(Path(self._tmpdir.name))
+
+    def test_missing_docker_binary_exits_fatal(self) -> None:
+        """No `docker` on PATH -> fatal EXIT_MISSING_DEP, no subprocess calls."""
+        from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+
+        script = self._make_script()
+        mock_run = MagicMock()
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                patch("nanvix_zutil.script.shutil.which", return_value=None),
+                patch("nanvix_zutil.script.subprocess.run", mock_run),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                script._check_docker("test/image:tag")
+            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+        finally:
+            log_mod.set_json_mode(False)
+        mock_run.assert_not_called()
+        self.assertIsNone(script.docker)
+
+    def test_image_present_skips_pull(self) -> None:
+        """`docker image inspect` returns 0 -> no pull, no fatal."""
+        script = self._make_script()
+        image = "test/image:tag"
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            calls.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with (
+            patch("nanvix_zutil.script.shutil.which", return_value="/usr/bin/docker"),
+            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+        ):
+            script._check_docker(image)  # pyright: ignore[reportPrivateUsage]
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0], ["docker", "image", "inspect", image])
+
+    def test_image_missing_pull_succeeds(self) -> None:
+        """`image inspect` fails, `docker pull` succeeds -> no fatal."""
+        script = self._make_script()
+        image = "test/image:tag"
+
+        calls: list[list[str]] = []
+        returncodes = iter([1, 0])  # inspect: miss, pull: ok
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            calls.append(cmd)
+            return sp.CompletedProcess(
+                args=cmd, returncode=next(returncodes), stdout="", stderr=""
+            )
+
+        with (
+            patch("nanvix_zutil.script.shutil.which", return_value="/usr/bin/docker"),
+            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+        ):
+            script._check_docker(image)  # pyright: ignore[reportPrivateUsage]
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0], ["docker", "image", "inspect", image])
+        self.assertEqual(calls[1], ["docker", "pull", image])
+
+    def test_image_missing_pull_fails_exits_fatal(self) -> None:
+        """`image inspect` fails, `docker pull` fails -> fatal EXIT_MISSING_DEP."""
+        from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+
+        script = self._make_script()
+        image = "test/image:tag"
+
+        calls: list[list[str]] = []
+        returncodes = iter([1, 1])  # inspect: miss, pull: fail
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            calls.append(cmd)
+            return sp.CompletedProcess(
+                args=cmd, returncode=next(returncodes), stdout="", stderr=""
+            )
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                patch(
+                    "nanvix_zutil.script.shutil.which",
+                    return_value="/usr/bin/docker",
+                ),
+                patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                script._check_docker(image)  # pyright: ignore[reportPrivateUsage]
+            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+        finally:
+            log_mod.set_json_mode(False)
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0], ["docker", "image", "inspect", image])
+        self.assertEqual(calls[1], ["docker", "pull", image])
+        self.assertIsNone(script.docker)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #95 

This PR auto-pulls missing docker images and implements new tests.
In addition, it removes some excess items and refactors the docker calls in ZScript's main() function.

Verification:
New tests, + this run:
```sh
IMAGE=nanvix/toolchain:latest-minimal
docker image rm $IMAGE
uv run ./examples/bin-hello/.nanvix/z.py setup --with-docker $IMAGE
# []
# Error response from daemon: No such image: nanvix/toolchain:latest-minimal
# latest-minimal: Pulling from nanvix/toolchain
# 612c09d0af5e: Pulling fs layer
# a99c3a4ed424: Pulling fs layer
# 3b847847ab45: Pulling fs layer
# d830834e3740: Pulling fs layer
# 1ce8b652ecae: Pulling fs layer
# 609a3aabb009: Pulling fs layer
# 45a6628200a8: Pulling fs layer
# 2d5eea5120f8: Pulling fs layer
# 08096b624050: Pulling fs layer
# 2ab3f805b162: Pulling fs layer
# 4f4fb700ef54: Pulling fs layer
# e13ff1290ca0: Pulling fs layer
# e322628e1f06: Pulling fs layer
# 98b9229df9eb: Pulling fs layer
# Digest: sha256:77513be32e77dcfe4a20e5b9ee9fd69a3dae8580c4e88d3b4cc99b13f102cf4a
# Status: Downloaded newer image for nanvix/toolchain:latest-minimal
# docker.io/nanvix/toolchain:latest-minimal
```

---

   ## Summary

   Previously, if a user ran `setup --with-docker IMAGE` (or any Docker-backed
   subcommand) and the image wasn't already present locally, the framework would
   exit with a fatal error telling them to `docker pull` it themselves. This PR
   makes the framework do the pull automatically, and folds the Docker
   availability/image-resolution logic into a single hook.

   ## Changes

   - **`src/nanvix_zutil/script.py`**
     - New `ZScript._check_docker(image)` method: verifies `docker` is on PATH,
       runs `docker image inspect`, and on miss attempts `docker pull <image>`.
       Exits with `EXIT_MISSING_DEP` only if the pull fails.
     - Promoted the inline `_DOCKER_COMMANDS` set to a class-level
       `ZScript.DOCKER_COMMANDS` constant.
     - Collapsed the docker-image resolution block in the main dispatch path:
       image is resolved from `--with-docker` or persisted `env.json`, persisted
       on `setup`, then `_check_docker` is called (skipped on Windows, matching
       prior behavior).
   - **`src/nanvix_zutil/docker.py`, `src/nanvix_zutil/__init__.py`**
     - Removed now-dead helpers `docker_available()` and `image_exists()` (logic
       inlined into `_check_docker`).
   - **Tests**
     - Deleted `tests/test_docker.py` (covered the removed helpers).
     - Added coverage in `tests/test_script.py` for the new auto-pull path:
       image present, image missing + pull succeeds, image missing + pull fails,
       docker binary missing, Windows skip.
     - Minor adjustments in `tests/test_integration.py` and `tests/test_script.py`
       to match the new code path.

   ## Behavior diff

   | Scenario | Before | After |
   |---|---|---|
   | Image present locally | OK | OK |
   | Image missing | Fatal, asks user to `docker pull` | Auto `docker pull`, then proceed |
   | Pull fails (e.g. typo, no network) | n/a | Fatal `EXIT_MISSING_DEP` |
   | `docker` not installed | Fatal | Fatal (unchanged) |
   | Windows `setup` | Skips docker checks | Skips docker checks (unchanged) |

   ## Commits

   - `1c8e1b6` [zutils] F: Auto-pull missing docker img
   - `8ede125` [tests] F: Test docker auto-pull

   ## Notes / follow-ups

   - There's a `TODO` left to move the setup-time `env.json` persistence into
     `setup()` itself; out of scope here.
   - Net diff: **+185 / −167** across 6 files; most of the script.py churn is
     deletion of the old inline resolution block.