### PR TITLE
[ci] B: Fail upload step when integration artifacts are missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
             examples/lib-hello/.nanvix/sysroot/bin/
             examples/lib-hello/.nanvix/sysroot/lib/
           retention-days: 1
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Clean examples
         run: uv run pytest tests/test_examples.py -v -k "Cleanup"


### PR DESCRIPTION
## Summary

Change the `if-no-files-found` policy on the integration test artifact upload step from `warn` to `error`.

## Motivation

When Docker lifecycle tests are skipped on the ubuntu runner (e.g. Docker daemon unavailable), no `.elf`/`.a` build artifacts are produced. The upload step previously used `if-no-files-found: warn`, which silently succeeded without creating an artifact. The dependent Windows integration job then failed with a confusing "Artifact not found" error from `download-artifact`.

## Changes

- **`.github/workflows/ci.yml`**: Changed `if-no-files-found` from `warn` to `error` in the `Upload build artifacts for Windows test` step. This ensures the ubuntu job fails explicitly when no artifacts exist, preventing the Windows job from running with a misleading error message.

Fixes: PR #213 CI failure