### PR TITLE
[tests] B: Mock is_windows in auto-docker Windows test

### DIFF
--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -957,6 +957,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
 
         with (
             patch("sys.argv", ["z.py", "build"]),
+            patch("nanvix_zutil.script.is_windows", return_value=True),
             patch.object(BuildScript, "build", _fake_build),
             patch("nanvix_zutil.script.log"),
         ):


### PR DESCRIPTION
`test_build_auto_enables_docker_on_windows` was missing a mock for `is_windows()`, causing `_check_docker()` to execute on Linux CI and fail with `FileNotFoundError` when the `docker` binary is not installed.

**Root cause:** The test simulates a Windows build scenario but never patches `is_windows`. On Linux CI, the guard `if not is_windows()` evaluates to `True`, so `_check_docker()` runs and tries to invoke `docker`.

**Fix:** Add `patch("nanvix_zutil.script.is_windows", return_value=True)` to the test's context managers, matching the pattern already used by the companion `test_build_auto_enables_docker_on_linux` test.

**Validation:** Full test suite passes (577 passed, 2 skipped).