### PR TITLE
Add --with-zutils bootstrap override

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ Consumer repos typically don't install manually — the bootstrap wrappers
 (`z`, `z.sh`, `z.ps1`) auto-create a virtualenv and install the pinned
 version into `.nanvix/venv/`.
 
+To iterate on `nanvix-zutil` itself against a downstream consumer, point the
+bootstrapper at a local source checkout (a directory containing
+`pyproject.toml`).  An editable install is materialised in `.nanvix/venv/`
+and the pinned-version check is bypassed:
+
+```bash
+WITH_ZUTIL=~/src/zutils ./z.sh build      # Linux/macOS
+$env:WITH_ZUTIL = 'C:\src\zutils'; .\z.ps1 build   # Windows
+```
+
+The override is re-applied when the recorded source path changes or when
+the venv is missing, so repeated invocations stay fast.  `./z distclean`
+removes the venv, so the override must be set again on the next bootstrap.
+
 ## Documentation
 
 | Document | Description |

--- a/README.md
+++ b/README.md
@@ -69,24 +69,24 @@ version into `.nanvix/venv/`.
 
 To iterate on `nanvix-zutil` itself against a downstream consumer, point the
 bootstrapper at a local source checkout (a directory containing
-`pyproject.toml`).  An editable install is materialised in `.nanvix/venv/`
-and the pinned-version check is bypassed:
+`pyproject.toml`) via the `--with-zutils` flag.  An editable install is
+materialised in `.nanvix/venv/` and the pinned-version check is bypassed:
 
 Linux/macOS:
 
 ```bash
-WITH_ZUTIL=~/src/zutils ./z.sh build
+./z.sh --with-zutils ~/src/zutils build
 ```
 
 Windows:
 
 ```powershell
-$env:WITH_ZUTIL = 'C:\src\zutils'; .\z.ps1 build
+.\z.ps1 --with-zutils C:\src\zutils build
 ```
 
 The override is re-applied when the recorded source path changes or when
 the venv is missing, so repeated invocations stay fast.  `./z distclean`
-removes the venv, so the override must be set again on the next bootstrap.
+removes the venv, so the flag must be passed again on the next bootstrap.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,16 @@ bootstrapper at a local source checkout (a directory containing
 `pyproject.toml`).  An editable install is materialised in `.nanvix/venv/`
 and the pinned-version check is bypassed:
 
+Linux/macOS:
+
 ```bash
-WITH_ZUTIL=~/src/zutils ./z.sh build      # Linux/macOS
-$env:WITH_ZUTIL = 'C:\src\zutils'; .\z.ps1 build   # Windows
+WITH_ZUTIL=~/src/zutils ./z.sh build
+```
+
+Windows:
+
+```powershell
+$env:WITH_ZUTIL = 'C:\src\zutils'; .\z.ps1 build
 ```
 
 The override is re-applied when the recorded source path changes or when

--- a/examples/bin-hello/z.ps1
+++ b/examples/bin-hello/z.ps1
@@ -19,32 +19,6 @@ else {
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
-# Optional override: install nanvix-zutil from a local source tree (editable)
-# instead of fetching the pinned wheel from GitHub Releases.  Useful when
-# iterating on zutils itself against a downstream consumer repo.
-#
-#   $env:WITH_ZUTIL = "C:\src\zutils"; .\z.ps1 build
-#
-# The path must point at a nanvix-zutil source checkout (a directory
-# containing pyproject.toml).  The venv version-match check is bypassed; the
-# editable install is rebuilt only when the recorded source path changes.
-$withZutil = if ($env:WITH_ZUTIL) {
-    $resolved = Resolve-Path -LiteralPath $env:WITH_ZUTIL -ErrorAction SilentlyContinue
-    if (-not $resolved) {
-        throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
-    }
-    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
-        throw "ERROR: WITH_ZUTIL is not a directory: $($resolved.Path)"
-    }
-    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
-        throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
-    }
-    $resolved.Path
-}
-else {
-    $null
-}
-
 # z.ps1 lives at the repository root, so use its directory directly
 # instead of relying on git to discover the top-level checkout directory.
 $repoRoot = $PSScriptRoot
@@ -65,6 +39,73 @@ $zutilGlobalVersion = try {
 }
 catch {
     $null
+}
+
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   .\z.ps1 --with-zutils C:\src\zutils build
+#   .\z.ps1 --with-zutils=C:\src\zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+$withZutils = $null
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-zutils') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-zutils requires a path argument"
+        }
+        $withZutils = $ZArgs[$i + 1]
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-zutils=(.+)$') {
+        $withZutils = $Matches[1]
+        $i++
+    }
+    elseif ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+if ($withZutils) {
+    $resolved = Resolve-Path -LiteralPath $withZutils -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "ERROR: --with-zutils path does not exist: $withZutils"
+    }
+    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+        throw "ERROR: --with-zutils is not a directory: $($resolved.Path)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
+        throw "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): $($resolved.Path)"
+    }
+    $withZutils = $resolved.Path
 }
 
 function NewZutilVenv {
@@ -107,25 +148,25 @@ function Bootstrap {
 }
 
 function BootstrapLocal {
-    # Install nanvix-zutil from $withZutil as an editable install.
-    Write-Information "nanvix-zutil -- installing editable from ${withZutil}..." -InformationAction Continue
+    # Install nanvix-zutil from $withZutils as an editable install.
+    Write-Information "nanvix-zutil -- installing editable from ${withZutils}..." -InformationAction Continue
     NewZutilVenv
-    & $venvPython -m pip install --quiet -e "$($withZutil)[lint]"
+    & $venvPython -m pip install --quiet -e "$($withZutils)[lint]"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install (editable) failed (exit code $LASTEXITCODE)"
     }
-    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutil') -Value $withZutil -NoNewline
+    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutils') -Value $withZutils -NoNewline
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
-if ($withZutil) {
-    $zutilMarker = Join-Path $venvDir '.with-zutil'
-    $recordedZutil = if (Test-Path -LiteralPath $zutilMarker) {
-        (Get-Content -LiteralPath $zutilMarker -Raw).Trim()
+if ($withZutils) {
+    $zutilsMarker = Join-Path $venvDir '.with-zutils'
+    $recordedZutils = if (Test-Path -LiteralPath $zutilsMarker) {
+        (Get-Content -LiteralPath $zutilsMarker -Raw).Trim()
     }
     else { $null }
-    if ((-not (Test-Path $venvZutil)) -or ($recordedZutil -ne $withZutil)) {
+    if ((-not (Test-Path $venvZutil)) -or ($recordedZutils -ne $withZutils)) {
         BootstrapLocal
     }
     if (-not (Test-Path $venvZutil)) {
@@ -175,35 +216,6 @@ else {
             throw "Bootstrap completed but $venvZutil not found."
         }
         $bin = $venvZutil
-    }
-}
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-$filteredArgs = [System.Collections.Generic.List[string]]::new()
-$i = 0
-while ($i -lt $ZArgs.Count) {
-    if ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i += 2
-    }
-    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
-        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i++
-    }
-    else {
-        $filteredArgs.Add($ZArgs[$i])
-        $i++
     }
 }
 

--- a/examples/bin-hello/z.ps1
+++ b/examples/bin-hello/z.ps1
@@ -19,6 +19,29 @@ else {
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
+# Optional override: install nanvix-zutil from a local source tree (editable)
+# instead of fetching the pinned wheel from GitHub Releases.  Useful when
+# iterating on zutils itself against a downstream consumer repo.
+#
+#   $env:WITH_ZUTIL = "C:\src\zutils"; .\z.ps1 build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+$withZutil = if ($env:WITH_ZUTIL) {
+    $resolved = Resolve-Path -LiteralPath $env:WITH_ZUTIL -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
+        throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
+    }
+    $resolved.Path
+}
+else {
+    $null
+}
+
 # z.ps1 lives at the repository root, so use its directory directly
 # instead of relying on git to discover the top-level checkout directory.
 $repoRoot = $PSScriptRoot
@@ -41,15 +64,8 @@ catch {
     $null
 }
 
-function Bootstrap {
-    param([string]$Reason = "not found")
-    # Pin nanvix-zutil version for reproducible bootstrapping.
-    # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
-
-    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
-
-    # Discover a Python 3 interpreter.
+function NewZutilVenv {
+    # Discover a Python 3 interpreter and (re)create the venv.
     $venvArgs = @("-m", "venv")
     if (Test-Path $venvDir) {
         $venvArgs += "--clear"
@@ -71,15 +87,50 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
+}
+
+function Bootstrap {
+    param([string]$Reason = "not found")
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+
+    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+    NewZutilVenv
     & $venvPython -m pip install --quiet "nanvix-zutil[lint] @ $($wheelUrl)"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }
 }
 
+function BootstrapLocal {
+    # Install nanvix-zutil from $withZutil as an editable install.
+    Write-Information "nanvix-zutil -- installing editable from ${withZutil}..." -InformationAction Continue
+    NewZutilVenv
+    & $venvPython -m pip install --quiet -e "$($withZutil)[lint]"
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "pip install (editable) failed (exit code $LASTEXITCODE)"
+    }
+    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutil') -Value $withZutil -NoNewline
+}
+
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
-if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
+if ($withZutil) {
+    $zutilMarker = Join-Path $venvDir '.with-zutil'
+    $recordedZutil = if (Test-Path -LiteralPath $zutilMarker) {
+        (Get-Content -LiteralPath $zutilMarker -Raw).Trim()
+    }
+    else { $null }
+    if ((-not (Test-Path $venvZutil)) -or ($recordedZutil -ne $withZutil)) {
+        BootstrapLocal
+    }
+    if (-not (Test-Path $venvZutil)) {
+        throw "BootstrapLocal completed but $venvZutil not found."
+    }
+    $bin = $venvZutil
+}
+elseif ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     Bootstrap
     if (-not (Test-Path $venvZutil)) {
         throw "Bootstrap completed but $venvZutil not found."

--- a/examples/bin-hello/z.ps1
+++ b/examples/bin-hello/z.ps1
@@ -33,6 +33,9 @@ $withZutil = if ($env:WITH_ZUTIL) {
     if (-not $resolved) {
         throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
     }
+    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+        throw "ERROR: WITH_ZUTIL is not a directory: $($resolved.Path)"
+    }
     if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
         throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
     }

--- a/examples/bin-hello/z.sh
+++ b/examples/bin-hello/z.sh
@@ -13,6 +13,37 @@ ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
+# Optional override: install nanvix-zutil from a local source tree (editable)
+# instead of fetching the pinned wheel from GitHub Releases.  Useful when
+# iterating on zutils itself against a downstream consumer repo.
+#
+#   WITH_ZUTIL=~/src/zutils ./z.sh build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+WITH_ZUTIL="${WITH_ZUTIL:-}"
+if [ -n "$WITH_ZUTIL" ]; then
+    _zutil_raw="$WITH_ZUTIL"
+    if [ ! -e "$_zutil_raw" ]; then
+        echo "ERROR: WITH_ZUTIL path does not exist: ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if [ ! -d "$_zutil_raw" ]; then
+        echo "ERROR: WITH_ZUTIL is not a directory: ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if ! WITH_ZUTIL="$(cd -- "$_zutil_raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: WITH_ZUTIL is not accessible (cd failed): ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if [ ! -f "$WITH_ZUTIL/pyproject.toml" ]; then
+        echo "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): ${WITH_ZUTIL}" >&2
+        exit 1
+    fi
+    unset _zutil_raw
+fi
+
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
 # Can be called before venv creation to initialize default paths; call it
 # again after venv creation to pick up the actual layout.
@@ -27,6 +58,23 @@ function _resolve_venv_paths() {
 }
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
+
+function bootstrap_local() {
+    # Install nanvix-zutil from $WITH_ZUTIL as an editable install.
+    echo "nanvix-zutil -- installing editable from ${WITH_ZUTIL}..." >&2
+    if ! command -v python3 &>/dev/null; then
+        echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+        exit 1
+    fi
+    if [ -d "$VENV" ]; then
+        python3 -m venv --clear "$VENV"
+    else
+        python3 -m venv "$VENV"
+    fi
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTIL}[lint]"
+    printf '%s\n' "$WITH_ZUTIL" >"$VENV/.with-zutil"
+}
 
 function bootstrap() {
     # Pin nanvix-zutil version for reproducible bootstrapping.
@@ -52,7 +100,16 @@ function bootstrap() {
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
-if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
+if [ -n "$WITH_ZUTIL" ]; then
+    RECORDED_ZUTIL=""
+    if [ -f "$VENV/.with-zutil" ]; then
+        RECORDED_ZUTIL="$(cat "$VENV/.with-zutil")"
+    fi
+    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTIL" != "$WITH_ZUTIL" ]; then
+        bootstrap_local
+    fi
+    BIN="$VENV_BIN"
+elif [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
     bootstrap
     BIN="$VENV_BIN"
 elif [ -x "$VENV_BIN" ]; then

--- a/examples/bin-hello/z.sh
+++ b/examples/bin-hello/z.sh
@@ -13,37 +13,6 @@ ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
-# Optional override: install nanvix-zutil from a local source tree (editable)
-# instead of fetching the pinned wheel from GitHub Releases.  Useful when
-# iterating on zutils itself against a downstream consumer repo.
-#
-#   WITH_ZUTIL=~/src/zutils ./z.sh build
-#
-# The path must point at a nanvix-zutil source checkout (a directory
-# containing pyproject.toml).  The venv version-match check is bypassed; the
-# editable install is rebuilt only when the recorded source path changes.
-WITH_ZUTIL="${WITH_ZUTIL:-}"
-if [ -n "$WITH_ZUTIL" ]; then
-    _zutil_raw="$WITH_ZUTIL"
-    if [ ! -e "$_zutil_raw" ]; then
-        echo "ERROR: WITH_ZUTIL path does not exist: ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if [ ! -d "$_zutil_raw" ]; then
-        echo "ERROR: WITH_ZUTIL is not a directory: ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if ! WITH_ZUTIL="$(cd -- "$_zutil_raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: WITH_ZUTIL is not accessible (cd failed): ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if [ ! -f "$WITH_ZUTIL/pyproject.toml" ]; then
-        echo "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): ${WITH_ZUTIL}" >&2
-        exit 1
-    fi
-    unset _zutil_raw
-fi
-
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
 # Can be called before venv creation to initialize default paths; call it
 # again after venv creation to pick up the actual layout.
@@ -59,9 +28,89 @@ function _resolve_venv_paths() {
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.  The nanvix-zutil CLI inspects positional args to find the
+# subcommand; either flag's PATH argument would be mistaken for a subcommand.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   ./z.sh --with-zutils ~/src/zutils build
+#   ./z.sh --with-zutils=~/src/zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+#
+# --with-nanvix PATH is forwarded to z.py via the WITH_NANVIX env var.
+WITH_ZUTILS=""
+_resolve_zutils_path() {
+    local raw="$1"
+    if [ ! -e "$raw" ]; then
+        echo "ERROR: --with-zutils path does not exist: ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -d "$raw" ]; then
+        echo "ERROR: --with-zutils is not a directory: ${raw}" >&2
+        exit 1
+    fi
+    if ! WITH_ZUTILS="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-zutils is not accessible (cd failed): ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -f "$WITH_ZUTILS/pyproject.toml" ]; then
+        echo "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): ${WITH_ZUTILS}" >&2
+        exit 1
+    fi
+}
+
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-zutils=*)
+            _resolve_zutils_path "${1#--with-zutils=}"
+            shift
+            ;;
+        --with-zutils)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-zutils requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_zutils_path "$2"
+            shift 2
+            ;;
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
 function bootstrap_local() {
-    # Install nanvix-zutil from $WITH_ZUTIL as an editable install.
-    echo "nanvix-zutil -- installing editable from ${WITH_ZUTIL}..." >&2
+    # Install nanvix-zutil from $WITH_ZUTILS as an editable install.
+    echo "nanvix-zutil -- installing editable from ${WITH_ZUTILS}..." >&2
     if ! command -v python3 &>/dev/null; then
         echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
         exit 1
@@ -72,8 +121,8 @@ function bootstrap_local() {
         python3 -m venv "$VENV"
     fi
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTIL}[lint]"
-    printf '%s\n' "$WITH_ZUTIL" >"$VENV/.with-zutil"
+    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTILS}[lint]"
+    printf '%s\n' "$WITH_ZUTILS" >"$VENV/.with-zutils"
 }
 
 function bootstrap() {
@@ -100,12 +149,12 @@ function bootstrap() {
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
-if [ -n "$WITH_ZUTIL" ]; then
-    RECORDED_ZUTIL=""
-    if [ -f "$VENV/.with-zutil" ]; then
-        RECORDED_ZUTIL="$(cat "$VENV/.with-zutil")"
+if [ -n "$WITH_ZUTILS" ]; then
+    RECORDED_ZUTILS=""
+    if [ -f "$VENV/.with-zutils" ]; then
+        RECORDED_ZUTILS="$(cat "$VENV/.with-zutils")"
     fi
-    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTIL" != "$WITH_ZUTIL" ]; then
+    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTILS" != "$WITH_ZUTILS" ]; then
         bootstrap_local
     fi
     BIN="$VENV_BIN"
@@ -131,41 +180,6 @@ else
         BIN="$VENV_BIN"
     fi
 fi
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-# The nanvix-zutil CLI inspects positional args to find the subcommand;
-# --with-nanvix's PATH argument would be mistaken for a subcommand.
-# Pass the value via env var so z.py can pick it up.
-_resolve_nanvix_path() {
-    local raw="$1"
-    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
-        exit 1
-    fi
-    export WITH_NANVIX
-}
-
-ARGS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --with-nanvix=*)
-            _resolve_nanvix_path "${1#--with-nanvix=}"
-            shift
-            ;;
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            _resolve_nanvix_path "$2"
-            shift 2
-            ;;
-        *)
-            ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
 
 # On Windows (Git Bash / MSYS2) the venv's python.exe is locked while it runs,
 # so the Python distclean command cannot delete it.  Run without exec so the

--- a/examples/lib-hello/z.ps1
+++ b/examples/lib-hello/z.ps1
@@ -19,32 +19,6 @@ else {
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
-# Optional override: install nanvix-zutil from a local source tree (editable)
-# instead of fetching the pinned wheel from GitHub Releases.  Useful when
-# iterating on zutils itself against a downstream consumer repo.
-#
-#   $env:WITH_ZUTIL = "C:\src\zutils"; .\z.ps1 build
-#
-# The path must point at a nanvix-zutil source checkout (a directory
-# containing pyproject.toml).  The venv version-match check is bypassed; the
-# editable install is rebuilt only when the recorded source path changes.
-$withZutil = if ($env:WITH_ZUTIL) {
-    $resolved = Resolve-Path -LiteralPath $env:WITH_ZUTIL -ErrorAction SilentlyContinue
-    if (-not $resolved) {
-        throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
-    }
-    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
-        throw "ERROR: WITH_ZUTIL is not a directory: $($resolved.Path)"
-    }
-    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
-        throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
-    }
-    $resolved.Path
-}
-else {
-    $null
-}
-
 # z.ps1 lives at the repository root, so use its directory directly
 # instead of relying on git to discover the top-level checkout directory.
 $repoRoot = $PSScriptRoot
@@ -65,6 +39,73 @@ $zutilGlobalVersion = try {
 }
 catch {
     $null
+}
+
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   .\z.ps1 --with-zutils C:\src\zutils build
+#   .\z.ps1 --with-zutils=C:\src\zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+$withZutils = $null
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-zutils') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-zutils requires a path argument"
+        }
+        $withZutils = $ZArgs[$i + 1]
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-zutils=(.+)$') {
+        $withZutils = $Matches[1]
+        $i++
+    }
+    elseif ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+if ($withZutils) {
+    $resolved = Resolve-Path -LiteralPath $withZutils -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "ERROR: --with-zutils path does not exist: $withZutils"
+    }
+    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+        throw "ERROR: --with-zutils is not a directory: $($resolved.Path)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
+        throw "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): $($resolved.Path)"
+    }
+    $withZutils = $resolved.Path
 }
 
 function NewZutilVenv {
@@ -107,25 +148,25 @@ function Bootstrap {
 }
 
 function BootstrapLocal {
-    # Install nanvix-zutil from $withZutil as an editable install.
-    Write-Information "nanvix-zutil -- installing editable from ${withZutil}..." -InformationAction Continue
+    # Install nanvix-zutil from $withZutils as an editable install.
+    Write-Information "nanvix-zutil -- installing editable from ${withZutils}..." -InformationAction Continue
     NewZutilVenv
-    & $venvPython -m pip install --quiet -e "$($withZutil)[lint]"
+    & $venvPython -m pip install --quiet -e "$($withZutils)[lint]"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install (editable) failed (exit code $LASTEXITCODE)"
     }
-    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutil') -Value $withZutil -NoNewline
+    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutils') -Value $withZutils -NoNewline
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
-if ($withZutil) {
-    $zutilMarker = Join-Path $venvDir '.with-zutil'
-    $recordedZutil = if (Test-Path -LiteralPath $zutilMarker) {
-        (Get-Content -LiteralPath $zutilMarker -Raw).Trim()
+if ($withZutils) {
+    $zutilsMarker = Join-Path $venvDir '.with-zutils'
+    $recordedZutils = if (Test-Path -LiteralPath $zutilsMarker) {
+        (Get-Content -LiteralPath $zutilsMarker -Raw).Trim()
     }
     else { $null }
-    if ((-not (Test-Path $venvZutil)) -or ($recordedZutil -ne $withZutil)) {
+    if ((-not (Test-Path $venvZutil)) -or ($recordedZutils -ne $withZutils)) {
         BootstrapLocal
     }
     if (-not (Test-Path $venvZutil)) {
@@ -175,35 +216,6 @@ else {
             throw "Bootstrap completed but $venvZutil not found."
         }
         $bin = $venvZutil
-    }
-}
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-$filteredArgs = [System.Collections.Generic.List[string]]::new()
-$i = 0
-while ($i -lt $ZArgs.Count) {
-    if ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i += 2
-    }
-    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
-        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i++
-    }
-    else {
-        $filteredArgs.Add($ZArgs[$i])
-        $i++
     }
 }
 

--- a/examples/lib-hello/z.ps1
+++ b/examples/lib-hello/z.ps1
@@ -19,6 +19,29 @@ else {
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
+# Optional override: install nanvix-zutil from a local source tree (editable)
+# instead of fetching the pinned wheel from GitHub Releases.  Useful when
+# iterating on zutils itself against a downstream consumer repo.
+#
+#   $env:WITH_ZUTIL = "C:\src\zutils"; .\z.ps1 build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+$withZutil = if ($env:WITH_ZUTIL) {
+    $resolved = Resolve-Path -LiteralPath $env:WITH_ZUTIL -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
+        throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
+    }
+    $resolved.Path
+}
+else {
+    $null
+}
+
 # z.ps1 lives at the repository root, so use its directory directly
 # instead of relying on git to discover the top-level checkout directory.
 $repoRoot = $PSScriptRoot
@@ -41,15 +64,8 @@ catch {
     $null
 }
 
-function Bootstrap {
-    param([string]$Reason = "not found")
-    # Pin nanvix-zutil version for reproducible bootstrapping.
-    # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
-
-    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
-
-    # Discover a Python 3 interpreter.
+function NewZutilVenv {
+    # Discover a Python 3 interpreter and (re)create the venv.
     $venvArgs = @("-m", "venv")
     if (Test-Path $venvDir) {
         $venvArgs += "--clear"
@@ -71,15 +87,50 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
+}
+
+function Bootstrap {
+    param([string]$Reason = "not found")
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+
+    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+    NewZutilVenv
     & $venvPython -m pip install --quiet "nanvix-zutil[lint] @ $($wheelUrl)"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }
 }
 
+function BootstrapLocal {
+    # Install nanvix-zutil from $withZutil as an editable install.
+    Write-Information "nanvix-zutil -- installing editable from ${withZutil}..." -InformationAction Continue
+    NewZutilVenv
+    & $venvPython -m pip install --quiet -e "$($withZutil)[lint]"
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "pip install (editable) failed (exit code $LASTEXITCODE)"
+    }
+    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutil') -Value $withZutil -NoNewline
+}
+
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
-if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
+if ($withZutil) {
+    $zutilMarker = Join-Path $venvDir '.with-zutil'
+    $recordedZutil = if (Test-Path -LiteralPath $zutilMarker) {
+        (Get-Content -LiteralPath $zutilMarker -Raw).Trim()
+    }
+    else { $null }
+    if ((-not (Test-Path $venvZutil)) -or ($recordedZutil -ne $withZutil)) {
+        BootstrapLocal
+    }
+    if (-not (Test-Path $venvZutil)) {
+        throw "BootstrapLocal completed but $venvZutil not found."
+    }
+    $bin = $venvZutil
+}
+elseif ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     Bootstrap
     if (-not (Test-Path $venvZutil)) {
         throw "Bootstrap completed but $venvZutil not found."

--- a/examples/lib-hello/z.ps1
+++ b/examples/lib-hello/z.ps1
@@ -33,6 +33,9 @@ $withZutil = if ($env:WITH_ZUTIL) {
     if (-not $resolved) {
         throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
     }
+    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+        throw "ERROR: WITH_ZUTIL is not a directory: $($resolved.Path)"
+    }
     if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
         throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
     }

--- a/examples/lib-hello/z.sh
+++ b/examples/lib-hello/z.sh
@@ -13,6 +13,37 @@ ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
+# Optional override: install nanvix-zutil from a local source tree (editable)
+# instead of fetching the pinned wheel from GitHub Releases.  Useful when
+# iterating on zutils itself against a downstream consumer repo.
+#
+#   WITH_ZUTIL=~/src/zutils ./z.sh build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+WITH_ZUTIL="${WITH_ZUTIL:-}"
+if [ -n "$WITH_ZUTIL" ]; then
+    _zutil_raw="$WITH_ZUTIL"
+    if [ ! -e "$_zutil_raw" ]; then
+        echo "ERROR: WITH_ZUTIL path does not exist: ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if [ ! -d "$_zutil_raw" ]; then
+        echo "ERROR: WITH_ZUTIL is not a directory: ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if ! WITH_ZUTIL="$(cd -- "$_zutil_raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: WITH_ZUTIL is not accessible (cd failed): ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if [ ! -f "$WITH_ZUTIL/pyproject.toml" ]; then
+        echo "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): ${WITH_ZUTIL}" >&2
+        exit 1
+    fi
+    unset _zutil_raw
+fi
+
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
 # Can be called before venv creation to initialize default paths; call it
 # again after venv creation to pick up the actual layout.
@@ -27,6 +58,23 @@ function _resolve_venv_paths() {
 }
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
+
+function bootstrap_local() {
+    # Install nanvix-zutil from $WITH_ZUTIL as an editable install.
+    echo "nanvix-zutil -- installing editable from ${WITH_ZUTIL}..." >&2
+    if ! command -v python3 &>/dev/null; then
+        echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+        exit 1
+    fi
+    if [ -d "$VENV" ]; then
+        python3 -m venv --clear "$VENV"
+    else
+        python3 -m venv "$VENV"
+    fi
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTIL}[lint]"
+    printf '%s\n' "$WITH_ZUTIL" >"$VENV/.with-zutil"
+}
 
 function bootstrap() {
     # Pin nanvix-zutil version for reproducible bootstrapping.
@@ -52,7 +100,16 @@ function bootstrap() {
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
-if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
+if [ -n "$WITH_ZUTIL" ]; then
+    RECORDED_ZUTIL=""
+    if [ -f "$VENV/.with-zutil" ]; then
+        RECORDED_ZUTIL="$(cat "$VENV/.with-zutil")"
+    fi
+    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTIL" != "$WITH_ZUTIL" ]; then
+        bootstrap_local
+    fi
+    BIN="$VENV_BIN"
+elif [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
     bootstrap
     BIN="$VENV_BIN"
 elif [ -x "$VENV_BIN" ]; then

--- a/examples/lib-hello/z.sh
+++ b/examples/lib-hello/z.sh
@@ -13,37 +13,6 @@ ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
-# Optional override: install nanvix-zutil from a local source tree (editable)
-# instead of fetching the pinned wheel from GitHub Releases.  Useful when
-# iterating on zutils itself against a downstream consumer repo.
-#
-#   WITH_ZUTIL=~/src/zutils ./z.sh build
-#
-# The path must point at a nanvix-zutil source checkout (a directory
-# containing pyproject.toml).  The venv version-match check is bypassed; the
-# editable install is rebuilt only when the recorded source path changes.
-WITH_ZUTIL="${WITH_ZUTIL:-}"
-if [ -n "$WITH_ZUTIL" ]; then
-    _zutil_raw="$WITH_ZUTIL"
-    if [ ! -e "$_zutil_raw" ]; then
-        echo "ERROR: WITH_ZUTIL path does not exist: ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if [ ! -d "$_zutil_raw" ]; then
-        echo "ERROR: WITH_ZUTIL is not a directory: ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if ! WITH_ZUTIL="$(cd -- "$_zutil_raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: WITH_ZUTIL is not accessible (cd failed): ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if [ ! -f "$WITH_ZUTIL/pyproject.toml" ]; then
-        echo "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): ${WITH_ZUTIL}" >&2
-        exit 1
-    fi
-    unset _zutil_raw
-fi
-
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
 # Can be called before venv creation to initialize default paths; call it
 # again after venv creation to pick up the actual layout.
@@ -59,9 +28,89 @@ function _resolve_venv_paths() {
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.  The nanvix-zutil CLI inspects positional args to find the
+# subcommand; either flag's PATH argument would be mistaken for a subcommand.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   ./z.sh --with-zutils ~/src/zutils build
+#   ./z.sh --with-zutils=~/src/zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+#
+# --with-nanvix PATH is forwarded to z.py via the WITH_NANVIX env var.
+WITH_ZUTILS=""
+_resolve_zutils_path() {
+    local raw="$1"
+    if [ ! -e "$raw" ]; then
+        echo "ERROR: --with-zutils path does not exist: ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -d "$raw" ]; then
+        echo "ERROR: --with-zutils is not a directory: ${raw}" >&2
+        exit 1
+    fi
+    if ! WITH_ZUTILS="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-zutils is not accessible (cd failed): ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -f "$WITH_ZUTILS/pyproject.toml" ]; then
+        echo "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): ${WITH_ZUTILS}" >&2
+        exit 1
+    fi
+}
+
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-zutils=*)
+            _resolve_zutils_path "${1#--with-zutils=}"
+            shift
+            ;;
+        --with-zutils)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-zutils requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_zutils_path "$2"
+            shift 2
+            ;;
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
 function bootstrap_local() {
-    # Install nanvix-zutil from $WITH_ZUTIL as an editable install.
-    echo "nanvix-zutil -- installing editable from ${WITH_ZUTIL}..." >&2
+    # Install nanvix-zutil from $WITH_ZUTILS as an editable install.
+    echo "nanvix-zutil -- installing editable from ${WITH_ZUTILS}..." >&2
     if ! command -v python3 &>/dev/null; then
         echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
         exit 1
@@ -72,8 +121,8 @@ function bootstrap_local() {
         python3 -m venv "$VENV"
     fi
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTIL}[lint]"
-    printf '%s\n' "$WITH_ZUTIL" >"$VENV/.with-zutil"
+    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTILS}[lint]"
+    printf '%s\n' "$WITH_ZUTILS" >"$VENV/.with-zutils"
 }
 
 function bootstrap() {
@@ -100,12 +149,12 @@ function bootstrap() {
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
-if [ -n "$WITH_ZUTIL" ]; then
-    RECORDED_ZUTIL=""
-    if [ -f "$VENV/.with-zutil" ]; then
-        RECORDED_ZUTIL="$(cat "$VENV/.with-zutil")"
+if [ -n "$WITH_ZUTILS" ]; then
+    RECORDED_ZUTILS=""
+    if [ -f "$VENV/.with-zutils" ]; then
+        RECORDED_ZUTILS="$(cat "$VENV/.with-zutils")"
     fi
-    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTIL" != "$WITH_ZUTIL" ]; then
+    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTILS" != "$WITH_ZUTILS" ]; then
         bootstrap_local
     fi
     BIN="$VENV_BIN"
@@ -131,41 +180,6 @@ else
         BIN="$VENV_BIN"
     fi
 fi
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-# The nanvix-zutil CLI inspects positional args to find the subcommand;
-# --with-nanvix's PATH argument would be mistaken for a subcommand.
-# Pass the value via env var so z.py can pick it up.
-_resolve_nanvix_path() {
-    local raw="$1"
-    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
-        exit 1
-    fi
-    export WITH_NANVIX
-}
-
-ARGS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --with-nanvix=*)
-            _resolve_nanvix_path "${1#--with-nanvix=}"
-            shift
-            ;;
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            _resolve_nanvix_path "$2"
-            shift 2
-            ;;
-        *)
-            ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
 
 # On Windows (Git Bash / MSYS2) the venv's python.exe is locked while it runs,
 # so the Python distclean command cannot delete it.  Run without exec so the

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -19,32 +19,6 @@ else {
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
-# Optional override: install nanvix-zutil from a local source tree (editable)
-# instead of fetching the pinned wheel from GitHub Releases.  Useful when
-# iterating on zutils itself against a downstream consumer repo.
-#
-#   $env:WITH_ZUTIL = "C:\src\zutils"; .\z.ps1 build
-#
-# The path must point at a nanvix-zutil source checkout (a directory
-# containing pyproject.toml).  The venv version-match check is bypassed; the
-# editable install is rebuilt only when the recorded source path changes.
-$withZutil = if ($env:WITH_ZUTIL) {
-    $resolved = Resolve-Path -LiteralPath $env:WITH_ZUTIL -ErrorAction SilentlyContinue
-    if (-not $resolved) {
-        throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
-    }
-    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
-        throw "ERROR: WITH_ZUTIL is not a directory: $($resolved.Path)"
-    }
-    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
-        throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
-    }
-    $resolved.Path
-}
-else {
-    $null
-}
-
 # z.ps1 lives at the repository root, so use its directory directly
 # instead of relying on git to discover the top-level checkout directory.
 $repoRoot = $PSScriptRoot
@@ -65,6 +39,73 @@ $zutilGlobalVersion = try {
 }
 catch {
     $null
+}
+
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   .\z.ps1 --with-zutils C:\src\zutils build
+#   .\z.ps1 --with-zutils=C:\src\zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+$withZutils = $null
+$filteredArgs = [System.Collections.Generic.List[string]]::new()
+$i = 0
+while ($i -lt $ZArgs.Count) {
+    if ($ZArgs[$i] -eq '--with-zutils') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-zutils requires a path argument"
+        }
+        $withZutils = $ZArgs[$i + 1]
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-zutils=(.+)$') {
+        $withZutils = $Matches[1]
+        $i++
+    }
+    elseif ($ZArgs[$i] -eq '--with-nanvix') {
+        if ($i + 1 -ge $ZArgs.Count) {
+            throw "ERROR: --with-nanvix requires a path argument"
+        }
+        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i += 2
+    }
+    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
+        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
+        if (-not $item.PSIsContainer) {
+            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
+        }
+        $env:WITH_NANVIX = $item.FullName
+        $i++
+    }
+    else {
+        $filteredArgs.Add($ZArgs[$i])
+        $i++
+    }
+}
+
+if ($withZutils) {
+    $resolved = Resolve-Path -LiteralPath $withZutils -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "ERROR: --with-zutils path does not exist: $withZutils"
+    }
+    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+        throw "ERROR: --with-zutils is not a directory: $($resolved.Path)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
+        throw "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): $($resolved.Path)"
+    }
+    $withZutils = $resolved.Path
 }
 
 function NewZutilVenv {
@@ -107,25 +148,25 @@ function Bootstrap {
 }
 
 function BootstrapLocal {
-    # Install nanvix-zutil from $withZutil as an editable install.
-    Write-Information "nanvix-zutil -- installing editable from ${withZutil}..." -InformationAction Continue
+    # Install nanvix-zutil from $withZutils as an editable install.
+    Write-Information "nanvix-zutil -- installing editable from ${withZutils}..." -InformationAction Continue
     NewZutilVenv
-    & $venvPython -m pip install --quiet -e "$($withZutil)[lint]"
+    & $venvPython -m pip install --quiet -e "$($withZutils)[lint]"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install (editable) failed (exit code $LASTEXITCODE)"
     }
-    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutil') -Value $withZutil -NoNewline
+    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutils') -Value $withZutils -NoNewline
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
-if ($withZutil) {
-    $zutilMarker = Join-Path $venvDir '.with-zutil'
-    $recordedZutil = if (Test-Path -LiteralPath $zutilMarker) {
-        (Get-Content -LiteralPath $zutilMarker -Raw).Trim()
+if ($withZutils) {
+    $zutilsMarker = Join-Path $venvDir '.with-zutils'
+    $recordedZutils = if (Test-Path -LiteralPath $zutilsMarker) {
+        (Get-Content -LiteralPath $zutilsMarker -Raw).Trim()
     }
     else { $null }
-    if ((-not (Test-Path $venvZutil)) -or ($recordedZutil -ne $withZutil)) {
+    if ((-not (Test-Path $venvZutil)) -or ($recordedZutils -ne $withZutils)) {
         BootstrapLocal
     }
     if (-not (Test-Path $venvZutil)) {
@@ -175,35 +216,6 @@ else {
             throw "Bootstrap completed but $venvZutil not found."
         }
         $bin = $venvZutil
-    }
-}
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-$filteredArgs = [System.Collections.Generic.List[string]]::new()
-$i = 0
-while ($i -lt $ZArgs.Count) {
-    if ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i += 2
-    }
-    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
-        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i++
-    }
-    else {
-        $filteredArgs.Add($ZArgs[$i])
-        $i++
     }
 }
 

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -19,6 +19,29 @@ else {
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
+# Optional override: install nanvix-zutil from a local source tree (editable)
+# instead of fetching the pinned wheel from GitHub Releases.  Useful when
+# iterating on zutils itself against a downstream consumer repo.
+#
+#   $env:WITH_ZUTIL = "C:\src\zutils"; .\z.ps1 build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+$withZutil = if ($env:WITH_ZUTIL) {
+    $resolved = Resolve-Path -LiteralPath $env:WITH_ZUTIL -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
+        throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
+    }
+    $resolved.Path
+}
+else {
+    $null
+}
+
 # z.ps1 lives at the repository root, so use its directory directly
 # instead of relying on git to discover the top-level checkout directory.
 $repoRoot = $PSScriptRoot
@@ -41,15 +64,8 @@ catch {
     $null
 }
 
-function Bootstrap {
-    param([string]$Reason = "not found")
-    # Pin nanvix-zutil version for reproducible bootstrapping.
-    # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
-
-    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
-
-    # Discover a Python 3 interpreter.
+function NewZutilVenv {
+    # Discover a Python 3 interpreter and (re)create the venv.
     $venvArgs = @("-m", "venv")
     if (Test-Path $venvDir) {
         $venvArgs += "--clear"
@@ -71,15 +87,50 @@ function Bootstrap {
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "venv creation failed (exit code $LASTEXITCODE)"
     }
+}
+
+function Bootstrap {
+    param([string]$Reason = "not found")
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+
+    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+    NewZutilVenv
     & $venvPython -m pip install --quiet "nanvix-zutil[lint] @ $($wheelUrl)"
     if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
         throw "pip install failed (exit code $LASTEXITCODE)"
     }
 }
 
+function BootstrapLocal {
+    # Install nanvix-zutil from $withZutil as an editable install.
+    Write-Information "nanvix-zutil -- installing editable from ${withZutil}..." -InformationAction Continue
+    NewZutilVenv
+    & $venvPython -m pip install --quiet -e "$($withZutil)[lint]"
+    if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+        throw "pip install (editable) failed (exit code $LASTEXITCODE)"
+    }
+    Set-Content -LiteralPath (Join-Path $venvDir '.with-zutil') -Value $withZutil -NoNewline
+}
+
 # Prefer the venv copy if it exists; otherwise use the global install.
 $bin = $null
-if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
+if ($withZutil) {
+    $zutilMarker = Join-Path $venvDir '.with-zutil'
+    $recordedZutil = if (Test-Path -LiteralPath $zutilMarker) {
+        (Get-Content -LiteralPath $zutilMarker -Raw).Trim()
+    }
+    else { $null }
+    if ((-not (Test-Path $venvZutil)) -or ($recordedZutil -ne $withZutil)) {
+        BootstrapLocal
+    }
+    if (-not (Test-Path $venvZutil)) {
+        throw "BootstrapLocal completed but $venvZutil not found."
+    }
+    $bin = $venvZutil
+}
+elseif ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     Bootstrap
     if (-not (Test-Path $venvZutil)) {
         throw "Bootstrap completed but $venvZutil not found."

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -33,6 +33,9 @@ $withZutil = if ($env:WITH_ZUTIL) {
     if (-not $resolved) {
         throw "ERROR: WITH_ZUTIL path does not exist: $($env:WITH_ZUTIL)"
     }
+    if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+        throw "ERROR: WITH_ZUTIL is not a directory: $($resolved.Path)"
+    }
     if (-not (Test-Path -LiteralPath (Join-Path $resolved.Path 'pyproject.toml'))) {
         throw "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): $($resolved.Path)"
     }

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -13,6 +13,37 @@ ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
+# Optional override: install nanvix-zutil from a local source tree (editable)
+# instead of fetching the pinned wheel from GitHub Releases.  Useful when
+# iterating on zutils itself against a downstream consumer repo.
+#
+#   WITH_ZUTIL=~/src/zutils ./z.sh build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+WITH_ZUTIL="${WITH_ZUTIL:-}"
+if [ -n "$WITH_ZUTIL" ]; then
+    _zutil_raw="$WITH_ZUTIL"
+    if [ ! -e "$_zutil_raw" ]; then
+        echo "ERROR: WITH_ZUTIL path does not exist: ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if [ ! -d "$_zutil_raw" ]; then
+        echo "ERROR: WITH_ZUTIL is not a directory: ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if ! WITH_ZUTIL="$(cd -- "$_zutil_raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: WITH_ZUTIL is not accessible (cd failed): ${_zutil_raw}" >&2
+        exit 1
+    fi
+    if [ ! -f "$WITH_ZUTIL/pyproject.toml" ]; then
+        echo "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): ${WITH_ZUTIL}" >&2
+        exit 1
+    fi
+    unset _zutil_raw
+fi
+
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
 # Can be called before venv creation to initialize default paths; call it
 # again after venv creation to pick up the actual layout.
@@ -27,6 +58,23 @@ function _resolve_venv_paths() {
 }
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
+
+function bootstrap_local() {
+    # Install nanvix-zutil from $WITH_ZUTIL as an editable install.
+    echo "nanvix-zutil -- installing editable from ${WITH_ZUTIL}..." >&2
+    if ! command -v python3 &>/dev/null; then
+        echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+        exit 1
+    fi
+    if [ -d "$VENV" ]; then
+        python3 -m venv --clear "$VENV"
+    else
+        python3 -m venv "$VENV"
+    fi
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTIL}[lint]"
+    printf '%s\n' "$WITH_ZUTIL" >"$VENV/.with-zutil"
+}
 
 function bootstrap() {
     # Pin nanvix-zutil version for reproducible bootstrapping.
@@ -52,7 +100,16 @@ function bootstrap() {
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
-if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
+if [ -n "$WITH_ZUTIL" ]; then
+    RECORDED_ZUTIL=""
+    if [ -f "$VENV/.with-zutil" ]; then
+        RECORDED_ZUTIL="$(cat "$VENV/.with-zutil")"
+    fi
+    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTIL" != "$WITH_ZUTIL" ]; then
+        bootstrap_local
+    fi
+    BIN="$VENV_BIN"
+elif [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
     bootstrap
     BIN="$VENV_BIN"
 elif [ -x "$VENV_BIN" ]; then

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -13,37 +13,6 @@ ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
-# Optional override: install nanvix-zutil from a local source tree (editable)
-# instead of fetching the pinned wheel from GitHub Releases.  Useful when
-# iterating on zutils itself against a downstream consumer repo.
-#
-#   WITH_ZUTIL=~/src/zutils ./z.sh build
-#
-# The path must point at a nanvix-zutil source checkout (a directory
-# containing pyproject.toml).  The venv version-match check is bypassed; the
-# editable install is rebuilt only when the recorded source path changes.
-WITH_ZUTIL="${WITH_ZUTIL:-}"
-if [ -n "$WITH_ZUTIL" ]; then
-    _zutil_raw="$WITH_ZUTIL"
-    if [ ! -e "$_zutil_raw" ]; then
-        echo "ERROR: WITH_ZUTIL path does not exist: ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if [ ! -d "$_zutil_raw" ]; then
-        echo "ERROR: WITH_ZUTIL is not a directory: ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if ! WITH_ZUTIL="$(cd -- "$_zutil_raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: WITH_ZUTIL is not accessible (cd failed): ${_zutil_raw}" >&2
-        exit 1
-    fi
-    if [ ! -f "$WITH_ZUTIL/pyproject.toml" ]; then
-        echo "ERROR: WITH_ZUTIL is not a Python source tree (no pyproject.toml): ${WITH_ZUTIL}" >&2
-        exit 1
-    fi
-    unset _zutil_raw
-fi
-
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
 # Can be called before venv creation to initialize default paths; call it
 # again after venv creation to pick up the actual layout.
@@ -59,9 +28,89 @@ function _resolve_venv_paths() {
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
+# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
+# nanvix-zutil.  The nanvix-zutil CLI inspects positional args to find the
+# subcommand; either flag's PATH argument would be mistaken for a subcommand.
+#
+# --with-zutils PATH (optional): install nanvix-zutil from a local source
+# tree (editable) instead of fetching the pinned wheel from GitHub Releases.
+# Useful when iterating on zutils itself against a downstream consumer repo.
+#
+#   ./z.sh --with-zutils ~/src/zutils build
+#   ./z.sh --with-zutils=~/src/zutils build
+#
+# The path must point at a nanvix-zutil source checkout (a directory
+# containing pyproject.toml).  The venv version-match check is bypassed; the
+# editable install is rebuilt only when the recorded source path changes.
+#
+# --with-nanvix PATH is forwarded to z.py via the WITH_NANVIX env var.
+WITH_ZUTILS=""
+_resolve_zutils_path() {
+    local raw="$1"
+    if [ ! -e "$raw" ]; then
+        echo "ERROR: --with-zutils path does not exist: ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -d "$raw" ]; then
+        echo "ERROR: --with-zutils is not a directory: ${raw}" >&2
+        exit 1
+    fi
+    if ! WITH_ZUTILS="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-zutils is not accessible (cd failed): ${raw}" >&2
+        exit 1
+    fi
+    if [ ! -f "$WITH_ZUTILS/pyproject.toml" ]; then
+        echo "ERROR: --with-zutils is not a Python source tree (no pyproject.toml): ${WITH_ZUTILS}" >&2
+        exit 1
+    fi
+}
+
+_resolve_nanvix_path() {
+    local raw="$1"
+    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
+        exit 1
+    fi
+    export WITH_NANVIX
+}
+
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-zutils=*)
+            _resolve_zutils_path "${1#--with-zutils=}"
+            shift
+            ;;
+        --with-zutils)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-zutils requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_zutils_path "$2"
+            shift 2
+            ;;
+        --with-nanvix=*)
+            _resolve_nanvix_path "${1#--with-nanvix=}"
+            shift
+            ;;
+        --with-nanvix)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --with-nanvix requires a path argument" >&2
+                exit 1
+            fi
+            _resolve_nanvix_path "$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
 function bootstrap_local() {
-    # Install nanvix-zutil from $WITH_ZUTIL as an editable install.
-    echo "nanvix-zutil -- installing editable from ${WITH_ZUTIL}..." >&2
+    # Install nanvix-zutil from $WITH_ZUTILS as an editable install.
+    echo "nanvix-zutil -- installing editable from ${WITH_ZUTILS}..." >&2
     if ! command -v python3 &>/dev/null; then
         echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
         exit 1
@@ -72,8 +121,8 @@ function bootstrap_local() {
         python3 -m venv "$VENV"
     fi
     _resolve_venv_paths
-    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTIL}[lint]"
-    printf '%s\n' "$WITH_ZUTIL" >"$VENV/.with-zutil"
+    "$VENV_PYTHON" -m pip install --quiet -e "${WITH_ZUTILS}[lint]"
+    printf '%s\n' "$WITH_ZUTILS" >"$VENV/.with-zutils"
 }
 
 function bootstrap() {
@@ -100,12 +149,12 @@ function bootstrap() {
 
 # Prefer the venv copy if it exists; otherwise use the global install.
 BIN=""
-if [ -n "$WITH_ZUTIL" ]; then
-    RECORDED_ZUTIL=""
-    if [ -f "$VENV/.with-zutil" ]; then
-        RECORDED_ZUTIL="$(cat "$VENV/.with-zutil")"
+if [ -n "$WITH_ZUTILS" ]; then
+    RECORDED_ZUTILS=""
+    if [ -f "$VENV/.with-zutils" ]; then
+        RECORDED_ZUTILS="$(cat "$VENV/.with-zutils")"
     fi
-    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTIL" != "$WITH_ZUTIL" ]; then
+    if [ ! -x "$VENV_BIN" ] || [ "$RECORDED_ZUTILS" != "$WITH_ZUTILS" ]; then
         bootstrap_local
     fi
     BIN="$VENV_BIN"
@@ -131,41 +180,6 @@ else
         BIN="$VENV_BIN"
     fi
 fi
-
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-# The nanvix-zutil CLI inspects positional args to find the subcommand;
-# --with-nanvix's PATH argument would be mistaken for a subcommand.
-# Pass the value via env var so z.py can pick it up.
-_resolve_nanvix_path() {
-    local raw="$1"
-    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
-        exit 1
-    fi
-    export WITH_NANVIX
-}
-
-ARGS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --with-nanvix=*)
-            _resolve_nanvix_path "${1#--with-nanvix=}"
-            shift
-            ;;
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            _resolve_nanvix_path "$2"
-            shift 2
-            ;;
-        *)
-            ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
 
 # On Windows (Git Bash / MSYS2) the venv's python.exe is locked while it runs,
 # so the Python distclean command cannot delete it.  Run without exec so the

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,7 +5,7 @@
 
 These tests exercise both examples end-to-end **through the bootstrap
 wrapper** (``z.sh`` / ``z.ps1``), the same way a real user would.  The
-wrapper is pointed at the in-tree source via ``WITH_ZUTIL=<repo root>``,
+wrapper is pointed at the in-tree source via ``--with-zutils <repo root>``,
 which performs an editable install into ``examples/<name>/.nanvix/venv/``
 and bypasses the pinned-wheel version check.  This means the bootstrap
 logic itself is covered by these tests, not just the underlying CLI.
@@ -97,24 +97,24 @@ def _run_z(
     """Invoke the bootstrap wrapper in *cwd* and return the completed process.
 
     Calls ``z.sh`` (Linux/macOS) or ``z.ps1`` via ``pwsh`` (Windows) with
-    ``WITH_ZUTIL`` set to the repo root, so the wrapper materialises an
-    editable install of ``nanvix-zutil`` into ``cwd/.nanvix/venv/`` and
+    ``--with-zutils <repo root>`` prepended, so the wrapper materialises
+    an editable install of ``nanvix-zutil`` into ``cwd/.nanvix/venv/`` and
     dispatches the subcommand through that venv.  The first call per
     example dir pays the editable-install cost (~5-30s); subsequent calls
     hit the recorded-path fast path.
     """
     env = os.environ.copy()
-    env["WITH_ZUTIL"] = str(_REPO_ROOT)
     # An outer venv must not bleed into the wrapper's `python -m venv`
     # invocation (`pip install -e` would otherwise target the outer venv
     # when the wrapper's resolved python happens to be `sys.executable`).
     env.pop("VIRTUAL_ENV", None)
     if extra_env:
         env.update(extra_env)
+    z_args = ("--with-zutils", str(_REPO_ROOT), *args)
     if sys.platform == "win32":
-        cmd = ["pwsh", "-NoProfile", "-File", str(cwd / "z.ps1"), *args]
+        cmd = ["pwsh", "-NoProfile", "-File", str(cwd / "z.ps1"), *z_args]
     else:
-        cmd = [str(cwd / "z.sh"), *args]
+        cmd = [str(cwd / "z.sh"), *z_args]
     return subprocess.run(
         cmd,
         cwd=str(cwd),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,14 +3,19 @@
 
 """Integration tests for the example projects (lib-hello and bin-hello).
 
-These tests exercise both examples end-to-end via ``nanvix-zutil``,
-the same way a real user would.
+These tests exercise both examples end-to-end **through the bootstrap
+wrapper** (``z.sh`` / ``z.ps1``), the same way a real user would.  The
+wrapper is pointed at the in-tree source via ``WITH_ZUTIL=<repo root>``,
+which performs an editable install into ``examples/<name>/.nanvix/venv/``
+and bypasses the pinned-wheel version check.  This means the bootstrap
+logic itself is covered by these tests, not just the underlying CLI.
 
 **CI Linux** (Docker available):
     Full lifecycle — ``setup → build → test`` — for both examples.
 
 **CI Windows** (pre-built artifacts downloaded from Linux job):
-    Test-only — ``nanvix-zutil test`` — for both examples.
+    Test-only — ``nanvix-zutil test`` — for both examples.  Requires
+    ``pwsh`` on PATH.
 
 **Local** (no Docker):
     CLI smoke tests only (``--help``, ``--json``).
@@ -89,16 +94,29 @@ def _run_z(
     timeout: int = _TIMEOUT,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Invoke ``nanvix-zutil`` in *cwd* and return the completed process."""
+    """Invoke the bootstrap wrapper in *cwd* and return the completed process.
+
+    Calls ``z.sh`` (Linux/macOS) or ``z.ps1`` via ``pwsh`` (Windows) with
+    ``WITH_ZUTIL`` set to the repo root, so the wrapper materialises an
+    editable install of ``nanvix-zutil`` into ``cwd/.nanvix/venv/`` and
+    dispatches the subcommand through that venv.  The first call per
+    example dir pays the editable-install cost (~5-30s); subsequent calls
+    hit the recorded-path fast path.
+    """
     env = os.environ.copy()
-    # Ensure the source tree is importable regardless of subprocess cwd.
-    src_dir = str(_REPO_ROOT / "src")
-    existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = f"{src_dir}{os.pathsep}{existing}" if existing else src_dir
+    env["WITH_ZUTIL"] = str(_REPO_ROOT)
+    # An outer venv must not bleed into the wrapper's `python -m venv`
+    # invocation (`pip install -e` would otherwise target the outer venv
+    # when the wrapper's resolved python happens to be `sys.executable`).
+    env.pop("VIRTUAL_ENV", None)
     if extra_env:
         env.update(extra_env)
+    if sys.platform == "win32":
+        cmd = ["pwsh", "-NoProfile", "-File", str(cwd / "z.ps1"), *args]
+    else:
+        cmd = [str(cwd / "z.sh"), *args]
     return subprocess.run(
-        [sys.executable, "-m", "nanvix_zutil", *args],
+        cmd,
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -196,7 +214,12 @@ class TestLibHelloCLI(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
 
     def test_json_mode(self) -> None:
-        """``--json`` produces parseable JSON on stderr."""
+        """``--json`` produces parseable JSON on stderr.
+
+        ``distclean`` is benign but triggers the wrapper's post-distclean
+        ``rm -rf .nanvix/venv``, so the next ``_run_z`` invocation in this
+        dir re-bootstraps (~5s).  Acceptable as a per-example one-off.
+        """
         r = _run_z(_LIB_HELLO, "--json", "distclean")
         self.assertEqual(r.returncode, 0, r.stderr)
         json_lines = [ln for ln in r.stderr.splitlines() if ln.startswith("{")]
@@ -218,7 +241,7 @@ class TestBinHelloCLI(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
 
     def test_json_mode(self) -> None:
-        """``--json`` produces parseable JSON on stderr."""
+        """``--json`` produces parseable JSON on stderr.  See lib-hello sibling."""
         r = _run_z(_BIN_HELLO, "--json", "distclean")
         self.assertEqual(r.returncode, 0, r.stderr)
         json_lines = [ln for ln in r.stderr.splitlines() if ln.startswith("{")]


### PR DESCRIPTION
   ## Add `--with-zutils` bootstrap override

   Adds `--with-zutils`, a bootstrap-time escape hatch mirroring `--with-nanvix`.
This is useful for testing changes on downstream consumers locally, without cutting a relase.

### Implementation

   When set to a directory containing a `nanvix-zutil` source checkout, the
   `z.sh` / `z.ps1` wrappers do an editable install into `.nanvix/venv/`
   instead of fetching the pinned wheel from GitHub Releases:

   ```bash
   ./z.sh --with-zutils=some_path
   ```

   - Path validated in three tiers (exists → is a dir → has `pyproject.toml`).
   - Resolved path recorded in `.nanvix/venv/.with-zutil`; subsequent calls
     skip re-bootstrap unless the path changes or the venv is missing.
   - Pinned-version mismatch check is bypassed while `WITH_ZUTIL` is set.
   - Reverting (unset) is safe: normal version-mismatch path runs and
     `venv --clear` wipes the marker before the pinned bootstrap takes over.
   - `./z distclean` removes the venv and marker.

### Test updates

   Downstream: `tests/test_examples.py` now drives both examples through
   `./z.sh` (or `./z.ps1` via `pwsh`) with `--with-zutils=<repo root>`, replacing
   the `python -m nanvix_zutil` + `PYTHONPATH=src/` shortcut. The lifecycle
   and CLI smoke tests now exercise the wrapper end-to-end.

   Templates and example mirrors kept byte-identical per `tasks.py`
   `_bump_version` invariant.

   Local: `pytest tests/test_examples.py` → 8 passed, 2 skipped (Windows-only
   test-only paths) in ~20s.

   ### Known limitations

   - **No dedicated bootstrap unit tests in this PR** — coverage is via
     `test_examples.py` end-to-end. A follow-up will add `test_bootstrap.py`
     with fast validation-path tests + opt-in slow round-trip tests.
   - **Paths containing `[` or `]` in `WITH_ZUTIL`** will be misparsed by pip
     as extras syntax. Undocumented; can add an explicit reject if preferred.
   - **Windows CI needs `pwsh` on PATH** for the routed example tests.
   - **CLI smoke tests use `--json distclean`**, which forces one re-bootstrap
     per example (~5s × 2). `lint` would avoid it but bin-hello is missing
     `black.toml`/`pyrightconfig.json`; aligning the two examples is a
     separate cleanup.