### PR TITLE
Drop CFG_TOOLCHAIN

### DIFF
--- a/examples/bin-hello/.nanvix/.gitignore
+++ b/examples/bin-hello/.nanvix/.gitignore
@@ -1,6 +1,6 @@
 venv/
 cache/
-sysroot/
+sysroot
 buildroot/
 env.json
 nanvix.lock

--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -20,7 +20,7 @@ from pathlib import Path, PurePosixPath
 from nanvix_zutil import (
     BUILDROOT_CONTAINER_PATH,
     CFG_SYSROOT,
-    CFG_TOOLCHAIN,
+    TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
     log,
@@ -43,11 +43,6 @@ class BinHello(ZScript):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-
-    def _toolchain(self) -> PurePosixPath | Path:
-        """Return the toolchain root, translated for Docker if active."""
-        host = Path(self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix")
-        return self.translate_path(host) if self.docker else host
 
     def _sysroot(self) -> PurePosixPath | Path:
         """Return the sysroot path, translated for Docker if active."""
@@ -86,7 +81,7 @@ class BinHello(ZScript):
 
     def build(self) -> None:
         """Cross-compile main.c into hello.elf for Nanvix."""
-        tc = self._toolchain()
+        tc = TOOLCHAIN_CONTAINER_PATH
         sysroot = self._sysroot()
         buildroot = self._buildroot_path()
         cc = str(tc / "bin" / "i686-nanvix-gcc")

--- a/examples/lib-hello/.nanvix/.gitignore
+++ b/examples/lib-hello/.nanvix/.gitignore
@@ -1,7 +1,9 @@
+__pycache__/
 venv/
 cache/
 sysroot/
 buildroot/
+.yamllint.yml
+black.toml
 env.json
-nanvix.lock
-__pycache__/
+pyrightconfig.json

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -18,7 +18,7 @@ from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import (
     CFG_SYSROOT,
-    CFG_TOOLCHAIN,
+    TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
     log,
@@ -42,11 +42,6 @@ class LibHello(ZScript):
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _toolchain(self) -> PurePosixPath | Path:
-        """Return the toolchain root, translated for Docker if active."""
-        host = Path(self.config.get(CFG_TOOLCHAIN, "/opt/nanvix") or "/opt/nanvix")
-        return self.translate_path(host) if self.docker else host
-
     def _sysroot(self) -> PurePosixPath | Path:
         """Return the sysroot path, translated for Docker if active."""
         sysroot_str = self.config.get(CFG_SYSROOT, "")
@@ -64,7 +59,7 @@ class LibHello(ZScript):
 
     def build(self) -> None:
         """Cross-compile hello.c into libhello.a for Nanvix."""
-        tc = self._toolchain()
+        tc = TOOLCHAIN_CONTAINER_PATH
         cc = str(tc / "bin" / "i686-nanvix-gcc")
         ar = str(tc / "bin" / "i686-nanvix-ar")
         cflags = "-O2 -Wall -msse2 -mfpmath=sse"

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -51,12 +51,11 @@ from nanvix_zutil.config import (
     CFG_DOCKER_IMAGE,
     CFG_GH_TOKEN,
     CFG_SYSROOT,
-    CFG_TOOLCHAIN,
-    Config,
     DEFAULT_DEPLOYMENT_MODE,
     DEFAULT_MACHINE,
     DEFAULT_MEMORY_SIZE,
     DEFAULT_TARGET,
+    Config,
 )
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
@@ -100,7 +99,6 @@ __all__ = [
     "CFG_DOCKER_IMAGE",
     "CFG_GH_TOKEN",
     "CFG_SYSROOT",
-    "CFG_TOOLCHAIN",
     "Config",
     "DEFAULT_DEPLOYMENT_MODE",
     "DEFAULT_FORMATS",

--- a/src/nanvix_zutil/config.py
+++ b/src/nanvix_zutil/config.py
@@ -48,9 +48,6 @@ DEFAULT_MEMORY_SIZE: str = _DEFAULTS["NANVIX_MEMORY_SIZE"]
 CFG_SYSROOT: str = "NANVIX_SYSROOT"
 """Path to the downloaded Nanvix sysroot directory."""
 
-CFG_TOOLCHAIN: str = "NANVIX_TOOLCHAIN"
-"""Path to the Nanvix cross-compilation toolchain."""
-
 CFG_GH_TOKEN: str = "GH_TOKEN"
 """GitHub token for authenticated API requests (rate limits)."""
 
@@ -67,7 +64,6 @@ ENV_VARS: dict[str, str] = {
     "NANVIX_DEPLOYMENT_MODE": f"Deployment mode (default: {DEFAULT_DEPLOYMENT_MODE})",
     "NANVIX_MEMORY_SIZE": f"Memory size for artifact naming (default: {DEFAULT_MEMORY_SIZE})",
     "NANVIX_SYSROOT": "Path to runtime sysroot (set by setup)",
-    "NANVIX_TOOLCHAIN": "Path to cross-compilation toolchain",
     "NANVIX_DOCKER_IMAGE": "Docker image override (set by setup --with-docker)",
     "GH_TOKEN": "GitHub token for API rate limits",
 }

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -139,7 +139,6 @@ def _write_env_json(nanvix_dir: Path, sysroot: Path) -> None:
         "NANVIX_DEPLOYMENT_MODE": "standalone",
         "NANVIX_MEMORY_SIZE": "256mb",
         "NANVIX_SYSROOT": str(sysroot),
-        "NANVIX_TOOLCHAIN": "/opt/nanvix",
         "NANVIX_DOCKER_IMAGE": _DOCKER_IMAGE,
     }
     nanvix_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Drop non-configurable toolchain path. Downstreams should replace calls to `CFG_TOOLCHAIN` with `TOOLCHAIN_CONTAINER_PATH`

Also updates example .gitignores to remove dangling files after test.