### PR TITLE
Remove helpers from ZScript

### DIFF
--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -26,6 +26,7 @@ from nanvix_zutil import (
     log,
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
+from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
 
 
 class BinHello(ZScript):
@@ -53,7 +54,7 @@ class BinHello(ZScript):
                 code=EXIT_BUILD_FAILURE,
             )
         host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.translate_path(host) if self.docker else host
+        return self.docker.translate_path(host) if self.docker else host
 
     def _buildroot_path(self) -> PurePosixPath | Path:
         """Return the effective buildroot path (translated for Docker if active)."""
@@ -98,17 +99,19 @@ class BinHello(ZScript):
 
         # Single shell invocation so intermediate .o survives across
         # compile and link steps inside the same Docker container.
-        self.run(
+        run(
             "sh",
             "-c",
             f"{cc} {cflags} -c -o main.o src/main.c"
             f" && {cc} {cflags} {ldflags} -o hello.elf main.o {libs}",
+            cwd=self.repo_root,
+            docker=self.docker,
         )
 
         # For standalone deployment mode, produce an initrd image
         # containing the system daemons and the application binary.
         if self.config.deployment_mode == "standalone":
-            self.make_initrd("hello.elf")
+            make_initrd(self, "hello.elf", InitRdArgs())
 
     def test(self) -> None:
         """Run the test suite (smoke + integration + functional).
@@ -190,12 +193,13 @@ class BinHello(ZScript):
                 f"{nanvixd} not found — run 'nanvix-zutil setup' to download it.",
                 code=EXIT_TEST_FAILURE,
             )
-        self.run(
+        run(
             str(nanvixd),
             "-bin-dir",
             str(sysroot / "bin"),
             "--",
             str(binary),
+            cwd=self.repo_root,
             timeout=60,
         )
         log.success("PASS: bin-hello functional tests")

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -24,6 +24,7 @@ from nanvix_zutil import (
     log,
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
+from nanvix_zutil.helpers import run
 
 
 class LibHello(ZScript):
@@ -51,7 +52,7 @@ class LibHello(ZScript):
                 code=EXIT_BUILD_FAILURE,
             )
         host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.translate_path(host) if self.docker else host
+        return self.docker.translate_path(host) if self.docker else host
 
     # ------------------------------------------------------------------
     # Lifecycle hooks
@@ -66,10 +67,12 @@ class LibHello(ZScript):
 
         # Single shell invocation so intermediate .o survives across
         # compile and archive steps inside the same Docker container.
-        self.run(
+        run(
             "sh",
             "-c",
             f"{cc} {cflags} -c -o hello.o src/hello.c && {ar} rcs libhello.a hello.o",
+            cwd=self.repo_root,
+            docker=self.docker,
         )
 
     def test(self) -> None:

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -35,6 +35,10 @@ Public re-exports:
 - :data:`~nanvix_zutil.release.DEFAULT_FORMATS` — default archive formats
 - :func:`~nanvix_zutil.release.package` — create release archives
 - :func:`~nanvix_zutil.docker.is_windows` — Windows platform detection helper
+- :func:`~nanvix_zutil.helpers.ensure_tool_installed` — verify an external CLI tool is on PATH
+- :func:`~nanvix_zutil.helpers.sync_configs` — sync packaged configs into a Nanvix tree
+- :func:`~nanvix_zutil.helpers.make_initrd` — build an initrd image
+- :func:`~nanvix_zutil.helpers.run` — run a subprocess with standardized logging
 """
 
 from nanvix_zutil.buildroot import (
@@ -77,6 +81,13 @@ from nanvix_zutil.exitcodes import (
     EXIT_TEST_FAILURE,
 )
 from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
+from nanvix_zutil.helpers import (
+    InitRdArgs,
+    ensure_tool_installed,
+    make_initrd,
+    run,
+    sync_configs,
+)
 from nanvix_zutil.info import NanvixInfo, get_nanvix_info
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -130,17 +141,22 @@ __all__ = [
     "Sysroot",
     "ZScript",
     "is_windows",
+    "ensure_tool_installed",
     "extract_nanvix_version",
     "extract_nanvix_version_base",
     "get_nanvix_info",
     "is_stale",
     "load_manifest",
+    "make_initrd",
     "package",
     "parse_semver_tuple",
     "read_lockfile",
     "resolve",
     "resolve_release",
     "resolve_release_with_fallback",
+    "run",
     "suffix_dep",
+    "sync_configs",
     "write_lockfile",
+    "InitRdArgs",
 ]

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -1,0 +1,299 @@
+"""
+Helper utilities for ZScript implementers
+"""
+
+import dataclasses
+import importlib.resources
+import importlib.util
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nanvix_zutil import log
+from nanvix_zutil.config import CFG_SYSROOT
+from nanvix_zutil.docker import DockerConfig, is_windows
+from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
+
+if TYPE_CHECKING:
+    from nanvix_zutil.script import ZScript
+
+
+def check_docker(image: str) -> None:
+    """Ensure the Docker CLI and the requested *image* are available.
+
+    Verifies that the ``docker`` binary is on ``PATH``, then runs
+    ``docker image inspect`` to check whether *image* is present locally.
+    If the image is missing, ``docker pull`` is invoked to fetch it.
+
+    Args:
+        image: Fully qualified Docker image reference to ensure is
+            available locally.
+
+    Raises:
+        SystemExit: Calls :func:`log.fatal` with
+            :data:`EXIT_MISSING_DEP` if the ``docker`` CLI is not on
+            ``PATH`` or if the auto-pull of *image* fails.
+    """
+
+    if shutil.which("docker") is None:
+        log.fatal(
+            "Docker is not available. Install Docker to continue.",
+            code=EXIT_MISSING_DEP,
+        )
+
+    image_exists = subprocess.run(["docker", "image", "inspect", image]).returncode == 0
+
+    if not image_exists:
+        res = subprocess.run(["docker", "pull", image]).returncode
+        if res != 0:
+            log.fatal(
+                f"Docker image '{image}' could not be pulled.",
+                code=EXIT_MISSING_DEP,
+            )
+
+
+def ensure_tool_installed(name: str):
+    if importlib.util.find_spec(name) is None:
+        log.fatal(
+            f"{name} is not installed.",
+            code=EXIT_MISSING_DEP,
+            hint="Run ./z setup before using this command.",
+        )
+
+
+#: Mapping of canonical config filename -> destination relative to .nanvix/.
+_CONFIG_FILES: dict[str, str] = {
+    "pyrightconfig.json": "pyrightconfig.json",
+    ".yamllint.yml": ".yamllint.yml",
+    "black.toml": "black.toml",
+    ".gitignore": ".gitignore",
+}
+
+
+def sync_configs(nanvix_dir: Path) -> None:
+    """Sync canonical tool configuration files into ``.nanvix/``.
+
+    Copies config files shipped inside ``nanvix_zutil.configs`` to the
+    ``.nanvix/`` directory, ensuring all downstream repos use
+    consistent linter/type-checker settings.  Files whose content
+    already matches are skipped.  Configs are confined to ``.nanvix/``
+    so consumer repo roots are never modified.
+    """
+    configs = importlib.resources.files("nanvix_zutil.configs")
+    for src_name, dst_rel in _CONFIG_FILES.items():
+        src = configs / src_name
+        dst = nanvix_dir / dst_rel
+        content = src.read_bytes()
+        if dst.exists() and dst.read_bytes() == content:
+            continue
+        dst.write_bytes(content)
+        log.note(f"Synced .nanvix/{dst_rel}")
+
+
+@dataclass
+class InitRdArgs:
+    """
+    Arguments passed to :func:`make_initrd`
+    """
+
+    app_args: list[str] | None = field(default=None)
+    """ Optional CLI Arguments appended to the app's argv. """
+    app_env: list[str] | None = field(default=None)
+    """ Optional environment variables for the app as ``KEY=VALUE`` strings. """
+    procd_args: list[str] | None = field(default=None)
+    """ Optional CLI Arguments appended to ``procd``'s argv. """
+    procd_env: list[str] | None = field(default=None)
+    """ Optional environment variables for ``procd`` as ``KEY=VALUE`` strings. """
+    memd_args: list[str] | None = field(default=None)
+    """ Optional CLI Arguments appended to ``memd``'s argv. """
+    memd_env: list[str] | None = field(default=None)
+    """ Optional environment variables for ``memd`` as ``KEY=VALUE`` strings. """
+    vfsd_args: list[str] | None = field(default=None)
+    """ Optional CLI Arguments appended to ``vfsd``'s argv. """
+    vfsd_env: list[str] | None = field(default=None)
+    """ Optional environment variables for ``vfsd`` as ``KEY=VALUE`` strings. """
+    kernel_args: list[str] | None = field(default=None)
+    """ Optional arguments passed to the kernel via ``-kernel-args``. """
+    bin_dir: Path | None = field(default=None)
+    """ Directory containing the ELF binaries and ``mkimage``.  Defaults to the sysroot ``bin/`` directory. """
+
+
+def make_initrd(instance: "ZScript", app: str, args: InitRdArgs = InitRdArgs()) -> Path:
+    """Build a standalone initrd image for *app*.
+
+    Invokes ``mkimage`` from the sysroot ``bin/`` directory to produce
+    an image containing the system daemons (``procd``, ``memd``,
+    ``vfsd``) and the application binary.
+
+    Each program entry in the image has the format
+    ``<path>;<argv0> [arg1 arg2 ...][;KEY=VAL ...]``.  An unescaped
+    ``;`` separates CLI arguments from environment variables (see
+    ``run-linux.md`` for the full protocol).
+
+    Args:
+        app: A bare application binary filename (e.g. ``"my-app.elf"``).
+            Must include the extension and must not contain path
+            separators (``/`` or ``\\``).
+        args: Additional arguments controlling the image generation.
+
+    Returns:
+        Path to the generated ``.img`` file.
+
+    Raises:
+        SystemExit: If *app* contains path separators, the sysroot
+            is unavailable, or ``mkimage`` is missing.
+    """
+    # Validate that app is a bare filename — no directory components.
+    if "/" in app or "\\" in app:
+        log.fatal(
+            f"app must be a bare filename without path separators, got: {app!r}",
+            code=EXIT_MISSING_DEP,
+        )
+
+    if args.bin_dir is None:
+        if instance.sysroot is not None:
+            args.bin_dir = instance.sysroot.path / "bin"
+        else:
+            sysroot_str = instance.config.get(CFG_SYSROOT)
+            if sysroot_str:
+                args.bin_dir = Path(sysroot_str) / "bin"
+            else:
+                log.fatal(
+                    "Sysroot not available; run setup first.",
+                    code=EXIT_MISSING_DEP,
+                )
+
+    if is_windows():
+        mkimage = args.bin_dir / "mkimage.exe"
+    else:
+        mkimage = args.bin_dir / "mkimage.elf"
+
+    # Verify mkimage exists before attempting to run it.
+    if not mkimage.exists():
+        log.fatal(
+            f"mkimage not found at {mkimage}; run setup first.",
+            code=EXIT_MISSING_DEP,
+            hint="Ensure the sysroot contains mkimage by running ./z setup.",
+        )
+
+    app_stem = Path(app).stem
+    output = instance.repo_root / f"{app_stem}.img"
+
+    def _escape(arg: str) -> str:
+        return arg.replace(";", "\\;")
+
+    def _entry(
+        elf: str | Path,
+        argv0: str,
+        extra: list[str] | None,
+        env: list[str] | None = None,
+    ) -> str:
+        parts = [_escape(argv0)] + [_escape(a) for a in (extra or [])]
+        argv = " ".join(parts)
+        if env:
+            env_str = " ".join(_escape(e) for e in env)
+            return f"{_escape(str(elf))};{argv};{env_str}"
+        return f"{_escape(str(elf))};{argv}"
+
+    cmd: list[str] = [
+        str(mkimage),
+        "-o",
+        str(output),
+    ]
+
+    if args.kernel_args:
+        escaped = [_escape(a) for a in args.kernel_args]
+        cmd.extend(["-kernel-args", " ".join(escaped)])
+
+    cmd.extend(
+        [
+            _entry(
+                args.bin_dir / "procd.elf", "procd", args.procd_args, args.procd_env
+            ),
+            _entry(args.bin_dir / "memd.elf", "memd", args.memd_args, args.memd_env),
+            _entry(args.bin_dir / "vfsd.elf", "vfsd", args.vfsd_args, args.vfsd_env),
+            _entry(instance.repo_root / app, app, args.app_args, args.app_env),
+        ]
+    )
+
+    run(*cmd)
+
+    return output
+
+
+def run(
+    *args: str,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    docker: DockerConfig | None = None,
+    timeout: int | None = None,
+) -> "subprocess.CompletedProcess[str]":
+    """Run a subprocess, logging the command before execution.
+
+    When Docker mode is active (i.e. ``--with-docker`` was passed
+    during ``setup`` and the current subcommand auto-loads it),
+    the command is transparently wrapped in ``docker run``.
+
+    Args:
+        *args: Command and arguments to execute.
+        cwd: Working directory for the subprocess.  Defaults to
+            :attr:`repo_root`.  Ignored when Docker wrapping is active
+            (the container workdir is controlled by
+            :class:`~nanvix_zutil.DockerConfig`).
+        env: Environment variables for the subprocess.  ``None`` inherits
+            the current process environment.  When Docker mode is active,
+            these variables are forwarded into the container via ``-e``
+            flags rather than being applied to the Docker client process.
+        docker: When ``False``, always runs on the host even if Docker
+            mode is active.  Use this for commands that must run locally
+            (e.g. ``clean``).
+        timeout: Maximum seconds to wait for the process to finish.
+            ``None`` means wait indefinitely.  When the timeout expires
+            the process tree is killed and a fatal error is raised.
+
+    Returns:
+        The completed process result.
+
+    Raises:
+        SystemExit: With exit code ``5`` if the process exits with a
+            non-zero status or the timeout expires.
+    """
+    subprocess_env: dict[str, str] | None = None
+    if docker is not None:
+        if env:
+            merged = {**docker.extra_env, **env}
+            docker = dataclasses.replace(docker, extra_env=merged)
+        if is_windows():
+            cmd = docker.build_windows_run_cmd(*args)
+        else:
+            cmd = docker.build_run_cmd(*args)
+    else:
+        cmd = list(args)
+        if env is not None:
+            subprocess_env = env
+        else:
+            subprocess_env = None
+
+    log.info(f"$ {' '.join(cmd)}")
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=subprocess_env,
+            text=True,
+            check=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        log.fatal(
+            f"Command timed out after {timeout}s: {' '.join(args)}",
+            code=EXIT_BUILD_FAILURE,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.fatal(
+            f"Command failed with exit code {exc.returncode}: {' '.join(args)}",
+            code=EXIT_BUILD_FAILURE,
+        )
+    return result

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -26,14 +26,13 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import importlib.resources
 import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
-from nanvix_zutil import log
+from nanvix_zutil import EXIT_BUILD_FAILURE, log
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
@@ -53,12 +52,12 @@ from nanvix_zutil.docker import (
     is_windows,
 )
 from nanvix_zutil.exitcodes import (
-    EXIT_BUILD_FAILURE,
     EXIT_DEGRADED_SETUP,
     EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
 )
 from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
+from nanvix_zutil.helpers import check_docker, ensure_tool_installed, run, sync_configs
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.resolver import is_stale, resolve
@@ -231,41 +230,6 @@ class ZScript:
     # Docker hooks — override in subclass to customise
     # ------------------------------------------------------------------
 
-    def _check_docker(self, image: str) -> None:
-        """Ensure the Docker CLI and the requested *image* are available.
-
-        Verifies that the ``docker`` binary is on ``PATH``, then runs
-        ``docker image inspect`` to check whether *image* is present locally.
-        If the image is missing, ``docker pull`` is invoked to fetch it.
-
-        Args:
-            image: Fully qualified Docker image reference to ensure is
-                available locally.
-
-        Raises:
-            SystemExit: Calls :func:`log.fatal` with
-                :data:`EXIT_MISSING_DEP` if the ``docker`` CLI is not on
-                ``PATH`` or if the auto-pull of *image* fails.
-        """
-
-        if shutil.which("docker") is None:
-            log.fatal(
-                "Docker is not available. Install Docker to continue.",
-                code=EXIT_MISSING_DEP,
-            )
-
-        image_exists = (
-            subprocess.run(["docker", "image", "inspect", image]).returncode == 0
-        )
-
-        if not image_exists:
-            res = subprocess.run(["docker", "pull", image]).returncode
-            if res != 0:
-                log.fatal(
-                    f"Docker image '{image}' could not be pulled.",
-                    code=EXIT_MISSING_DEP,
-                )
-
     def docker_config(self, image: str) -> DockerConfig:
         """Build the :class:`~nanvix_zutil.DockerConfig` for *image*.
 
@@ -335,6 +299,9 @@ class ZScript:
             Container-side :class:`~pathlib.PurePosixPath` when Docker is active,
             otherwise *host_path*.
         """
+        log.warning(
+            "DEPRECATED: Use self.docker.translate_path instead of self.translate_path."
+        )
         if self.docker is not None:
             return self.docker.translate_path(host_path)
         return host_path
@@ -537,39 +504,8 @@ class ZScript:
                     raise
 
         self.config.save()
-        self._sync_configs()
+        sync_configs(self.nanvix_dir)
         return self._used_fallback
-
-    # ------------------------------------------------------------------
-    # Config synchronisation
-    # ------------------------------------------------------------------
-
-    #: Mapping of canonical config filename -> destination relative to .nanvix/.
-    _CONFIG_FILES: dict[str, str] = {
-        "pyrightconfig.json": "pyrightconfig.json",
-        ".yamllint.yml": ".yamllint.yml",
-        "black.toml": "black.toml",
-        ".gitignore": ".gitignore",
-    }
-
-    def _sync_configs(self) -> None:
-        """Sync canonical tool configuration files into ``.nanvix/``.
-
-        Copies config files shipped inside ``nanvix_zutil.configs`` to the
-        ``.nanvix/`` directory, ensuring all downstream repos use
-        consistent linter/type-checker settings.  Files whose content
-        already matches are skipped.  Configs are confined to ``.nanvix/``
-        so consumer repo roots are never modified.
-        """
-        configs = importlib.resources.files("nanvix_zutil.configs")
-        for src_name, dst_rel in self._CONFIG_FILES.items():
-            src = configs / src_name
-            dst = self.nanvix_dir / dst_rel
-            content = src.read_bytes()
-            if dst.exists() and dst.read_bytes() == content:
-                continue
-            dst.write_bytes(content)
-            log.note(f"Synced .nanvix/{dst_rel}")
 
     def distclean(self) -> None:
         """Remove all transient ``.nanvix/`` artifacts.
@@ -690,17 +626,37 @@ class ZScript:
 
         Runs ``black --check`` followed by ``pyright`` on all Python
         files in the ``.nanvix/`` directory.  Exits with
+        ``EXIT_MISSING_DEP`` if either tool is not installed, or with
         ``EXIT_BUILD_FAILURE`` if either tool reports problems.
         """
+
         py_files = sorted(self.nanvix_dir.glob("*.py"))
         if not py_files:
             log.warning("No .py files found in .nanvix/ — nothing to lint")
             return
+        for tool in ("black", "pyright"):
+            ensure_tool_installed(tool)
+
         str_files = [str(f) for f in py_files]
         black_cfg = str(self.nanvix_dir / "black.toml")
         pyright_cfg = str(self.nanvix_dir / "pyrightconfig.json")
-        self._run_tool("black", "--config", black_cfg, "--check", *str_files)
-        self._run_tool("pyright", "--project", pyright_cfg, *str_files)
+        run(
+            sys.executable,
+            "-m",
+            "black",
+            "--config",
+            black_cfg,
+            "--check",
+            *str_files,
+        )
+        run(
+            sys.executable,
+            "-m",
+            "pyright",
+            "--project",
+            pyright_cfg,
+            *str_files,
+        )
 
     def format(self, *, check: bool = False) -> None:
         """Format ``.nanvix/*.py`` with black.
@@ -708,38 +664,21 @@ class ZScript:
         Args:
             check: When ``True``, run ``black --check`` instead of
                 auto-formatting (exit non-zero on diff).
+
+        Exits with ``EXIT_MISSING_DEP`` if black is not installed.
         """
         py_files = sorted(self.nanvix_dir.glob("*.py"))
         if not py_files:
             log.warning("No .py files found in .nanvix/ — nothing to format")
             return
+        ensure_tool_installed("black")
         str_files = [str(f) for f in py_files]
         black_cfg = str(self.nanvix_dir / "black.toml")
-        cmd = ["black", "--config", black_cfg]
+        cmd = [sys.executable, "-m", "black", "--config", black_cfg]
         if check:
             cmd.append("--check")
         cmd.extend(str_files)
-        self._run_tool(*cmd)
-
-    def _run_tool(self, *args: str) -> None:
-        """Run a host-side tool via ``sys.executable -m``, exiting on failure."""
-        import importlib.util as _imputil
-
-        tool = args[0]
-        if _imputil.find_spec(tool) is None:
-            log.fatal(
-                f"'{tool}' not found — install it with: "
-                f"pip install nanvix-zutil[lint]",
-                code=EXIT_MISSING_DEP,
-            )
-        cmd = [sys.executable, "-m", *args]
-        log.info(f"$ {' '.join(args)}")
-        result = subprocess.run(cmd, cwd=self.repo_root)
-        if result.returncode != 0:
-            log.fatal(
-                f"{tool} failed with exit code {result.returncode}",
-                code=EXIT_BUILD_FAILURE,
-            )
+        run(*cmd)
 
     # ------------------------------------------------------------------
     # Lifecycle hooks — override in subclass
@@ -843,6 +782,7 @@ class ZScript:
             SystemExit: If *app* contains path separators, the sysroot
                 is unavailable, or ``mkimage`` is missing.
         """
+        log.warning("DEPRECATED: Use helpers.make_initrd instead of self.make_initrd.")
         # Validate that app is a bare filename — no directory components.
         if "/" in app or "\\" in app:
             log.fatal(
@@ -960,6 +900,7 @@ class ZScript:
             SystemExit: With exit code ``5`` if the process exits with a
                 non-zero status or the timeout expires.
         """
+        log.warning("DEPRECATED: Use helpers.run instead of self.run.")
         if self.docker is not None and docker:
             cfg = self.docker
             if env:
@@ -1136,7 +1077,7 @@ class ZScript:
 
             if not is_windows():
                 # may exit if Docker is required but not available
-                instance._check_docker(image)
+                check_docker(image)
 
             # Persist Docker image on setup so subsequent commands
             # automatically use the same image.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
 from nanvix_zutil import ZScript
+from nanvix_zutil.helpers import run
 from tests.testutils import write_manifest
 
 # ---------------------------------------------------------------------------
@@ -71,7 +72,7 @@ class TestIntegrationLifecycle(unittest.TestCase):
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
         log_mod.set_json_mode(False)
-        p = patch.object(ZScript, "_check_docker", return_value=None)
+        p = patch("nanvix_zutil.script.check_docker", return_value=None)
         p.start()
         self.addCleanup(p.stop)
 
@@ -284,7 +285,7 @@ class TestIntegrationConfigPersistence(unittest.TestCase):
 
 
 class TestIntegrationRunSubprocess(unittest.TestCase):
-    """ZScript.run() executes subprocesses and propagates errors."""
+    """The ``run`` helper executes subprocesses and propagates errors."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -297,16 +298,21 @@ class TestIntegrationRunSubprocess(unittest.TestCase):
         log_mod.set_json_mode(False)
 
     def test_run_echo_succeeds(self) -> None:
-        script = _MockConsumer(self._repo_root)
-        result = script.run(sys.executable, "-c", "import sys; sys.exit(0)")
+        result = run(
+            sys.executable, "-c", "import sys; sys.exit(0)", cwd=self._repo_root
+        )
         self.assertEqual(result.returncode, 0)
 
     def test_run_exit_nonzero_raises_system_exit_5(self) -> None:
-        script = _MockConsumer(self._repo_root)
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                script.run(sys.executable, "-c", "import sys; sys.exit(2)")
+                run(
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.exit(2)",
+                    cwd=self._repo_root,
+                )
             self.assertEqual(ctx.exception.code, 5)
         finally:
             log_mod.set_json_mode(False)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.log as log_mod
+from nanvix_zutil import helpers
+from nanvix_zutil.helpers import InitRdArgs
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
@@ -22,7 +24,7 @@ from nanvix_zutil.docker import (
     DockerConfig,
     Mount,
 )
-from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
 from nanvix_zutil.script import ZScript
 from tests.testutils import (
     MANIFEST_LATEST_WITH_DEPS,
@@ -553,8 +555,8 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
             self.assertIn(hook, available)
 
 
-class TestZScriptRun(unittest.TestCase):
-    """ZScript.run() executes subprocesses correctly."""
+class TestHelpersRun(unittest.TestCase):
+    """helpers.run() executes subprocesses correctly."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -564,55 +566,59 @@ class TestZScriptRun(unittest.TestCase):
         self._tmpdir.cleanup()
 
     def test_run_success(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
-        result = script.run(sys.executable, "-c", "print('ok')")
+        result = helpers.run(sys.executable, "-c", "print('ok')")
         self.assertEqual(result.returncode, 0)
 
     def test_run_failure_exits(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                script.run(sys.executable, "-c", "raise SystemExit(1)")
-            self.assertEqual(ctx.exception.code, 5)
+                helpers.run(sys.executable, "-c", "raise SystemExit(1)")
+            self.assertEqual(ctx.exception.code, EXIT_BUILD_FAILURE)
         finally:
             log_mod.set_json_mode(False)
 
     def test_run_timeout_exits(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                script.run(
+                helpers.run(
                     sys.executable, "-c", "import time; time.sleep(10)", timeout=1
                 )
-            self.assertEqual(ctx.exception.code, 5)
+            self.assertEqual(ctx.exception.code, EXIT_BUILD_FAILURE)
         finally:
             log_mod.set_json_mode(False)
 
-    @patch("nanvix_zutil.script.is_windows", return_value=True)
-    def test_run_uses_windows_cmd_on_windows(self, _mock: object) -> None:
-        """run() delegates to build_windows_run_cmd on Windows."""
-        script = ZScript(Path(self._tmpdir.name))
-        script.docker = DockerConfig(
+    def test_run_without_docker_uses_args_directly(self) -> None:
+        """Without a docker config, run() executes the command as-is."""
+        result = helpers.run(sys.executable, "-c", "print('ok')")
+        self.assertEqual(result.returncode, 0)
+
+    def _make_docker(self, repo_root: Path) -> DockerConfig:
+        return DockerConfig(
             image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
-                    host_path=script.repo_root,
+                    host_path=repo_root,
                     container_path=WORKSPACE_CONTAINER_PATH,
                 )
             ],
             uid=1000,
             gid=1000,
         )
+
+    @patch("nanvix_zutil.helpers.is_windows", return_value=True)
+    def test_run_uses_windows_cmd_on_windows(self, _mock: object) -> None:
+        """run() delegates to build_windows_run_cmd on Windows."""
+        docker = self._make_docker(Path(self._tmpdir.name))
         captured_cmds: list[list[str]] = []
 
         def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
             captured_cmds.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.run("make", "all")
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.run("make", "all", docker=docker)
 
         self.assertTrue(captured_cmds)
         cmd = captured_cmds[0]
@@ -620,17 +626,16 @@ class TestZScriptRun(unittest.TestCase):
         self.assertIn("sh", cmd)
         self.assertIn("-c", cmd)
 
-    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=True)
     def test_run_dispatch_windows_default_docker(self, _mock: object) -> None:
         """run() uses build_windows_run_cmd on Windows even with default
         (empty) output_files — the dispatch no longer requires
         these fields to be populated."""
-        script = ZScript(Path(self._tmpdir.name))
-        script.docker = DockerConfig(
+        docker = DockerConfig(
             image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
-                    host_path=script.repo_root,
+                    host_path=Path(self._tmpdir.name),
                     container_path=WORKSPACE_CONTAINER_PATH,
                 )
             ],
@@ -644,8 +649,8 @@ class TestZScriptRun(unittest.TestCase):
             captured_cmds.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.run("make", "all")
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.run("make", "all", docker=docker)
 
         self.assertTrue(captured_cmds)
         cmd = captured_cmds[0]
@@ -655,18 +660,76 @@ class TestZScriptRun(unittest.TestCase):
         self.assertIn("-c", cmd)
 
     @patch("nanvix_zutil.docker.is_windows", return_value=False)
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_run_dispatch_linux_uses_build_run_cmd(self, *_mocks: object) -> None:
         """run() uses build_run_cmd on Linux (not the Windows tar-copy path)."""
-        script = ZScript(Path(self._tmpdir.name))
-        script.docker = DockerConfig(
+        docker = self._make_docker(Path(self._tmpdir.name))
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured_cmds.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.run("make", "all", docker=docker)
+
+        self.assertTrue(captured_cmds)
+        cmd = captured_cmds[0]
+        # Standard docker run — should NOT use sh -c wrapping.
+        self.assertEqual(cmd[:3], ["docker", "run", "--rm"])
+        # Inner command is appended directly (not wrapped in sh -c).
+        self.assertEqual(cmd[-2:], ["make", "all"])
+        self.assertNotEqual(cmd[-3:-1], ["sh", "-c"])
+
+    @patch("nanvix_zutil.docker.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
+    def test_run_with_docker_wraps_command(self, *_mocks: object) -> None:
+        """When a docker config is supplied, run() prepends docker run."""
+        docker = self._make_docker(Path(self._tmpdir.name))
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.run("make", "all", docker=docker)
+
+        self.assertTrue(captured)
+        self.assertIn("docker", captured[0])
+        self.assertIn("make", captured[0])
+        self.assertIn("all", captured[0])
+
+    @patch("nanvix_zutil.docker.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
+    def test_run_env_forwarded_into_container(self, *_mocks: object) -> None:
+        """env vars passed to run() are forwarded as -e flags in Docker mode."""
+        docker = DockerConfig(
             image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
-            mounts=[
-                Mount(
-                    host_path=script.repo_root,
-                    container_path=WORKSPACE_CONTAINER_PATH,
-                )
-            ],
+            mounts=[],
+            uid=1000,
+            gid=1000,
+        )
+        captured_kwargs: list[dict[str, object]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured_kwargs.append(dict(kwargs))
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.run("make", "all", docker=docker, env={"MY_VAR": "hello"})
+
+        self.assertTrue(captured_kwargs)
+        # env should NOT be passed to the docker subprocess itself
+        self.assertIsNone(captured_kwargs[0].get("env"))
+
+    @patch("nanvix_zutil.docker.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
+    def test_run_env_forwarded_into_container_as_flags(self, *_mocks: object) -> None:
+        """env vars appear as -e KEY=VAL in the docker run command."""
+        docker = DockerConfig(
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            mounts=[],
             uid=1000,
             gid=1000,
         )
@@ -676,16 +739,14 @@ class TestZScriptRun(unittest.TestCase):
             captured_cmds.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.run("make", "all")
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.run("make", "all", docker=docker, env={"MY_VAR": "hello"})
 
         self.assertTrue(captured_cmds)
         cmd = captured_cmds[0]
-        # Standard docker run — should NOT use sh -c wrapping.
-        self.assertEqual(cmd[:3], ["docker", "run", "--rm"])
-        # Inner command is appended directly (not wrapped in sh -c).
-        self.assertEqual(cmd[-2:], ["make", "all"])
-        self.assertNotEqual(cmd[-3:-1], ["sh", "-c"])
+        # -e MY_VAR=hello must appear in the docker run command
+        self.assertIn("-e", cmd)
+        self.assertIn("MY_VAR=hello", cmd)
 
 
 class TestZScriptSysrootRequiredFiles(unittest.TestCase):
@@ -747,8 +808,8 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
         self.assertNotIn("bin/uservm.elf", files)
 
 
-class TestZScriptDockerIntegration(unittest.TestCase):
-    """Tests for ZScript Docker mode."""
+class TestZScriptDockerConfig(unittest.TestCase):
+    """Tests for ZScript.docker / ZScript.docker_config()."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -805,124 +866,6 @@ class TestZScriptDockerIntegration(unittest.TestCase):
         assert buildroot_mount is not None
         self.assertEqual(buildroot_mount.host_path, buildroot_dir)
         self.assertFalse(buildroot_mount.readonly)
-
-    def test_translate_path_no_docker(self) -> None:
-        """Without Docker, translate_path returns the input unchanged."""
-        script = self._make_script()
-        p = Path("/some/host/path")
-        self.assertEqual(script.translate_path(p), p)
-
-    def test_translate_path_with_docker(self) -> None:
-        """With Docker active, translate_path translates via DockerConfig."""
-        script = self._make_script()
-        script.docker = DockerConfig(
-            image="test-image",
-            mounts=[
-                Mount(
-                    host_path=script.repo_root,
-                    container_path=WORKSPACE_CONTAINER_PATH,
-                )
-            ],
-        )
-        result = script.translate_path(script.repo_root / "src" / "main.c")
-        self.assertEqual(result, WORKSPACE_CONTAINER_PATH / "src" / "main.c")
-
-    def test_run_without_docker_uses_args_directly(self) -> None:
-        """Without Docker, run() executes the command as-is."""
-        script = self._make_script()
-        result = script.run(sys.executable, "-c", "print('ok')")
-        self.assertEqual(result.returncode, 0)
-
-    def test_run_with_docker_false_opt_out(self) -> None:
-        """docker=False bypasses Docker even when _docker is set."""
-        script = self._make_script()
-        script.docker = DockerConfig(
-            image="should-not-be-used",
-            mounts=[],
-        )
-        # This should run on host, not via docker
-        result = script.run(sys.executable, "-c", "print('ok')", docker=False)
-        self.assertEqual(result.returncode, 0)
-
-    @patch("nanvix_zutil.docker.is_windows", return_value=False)
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
-    def test_run_with_docker_wraps_command(self, *_mocks: object) -> None:
-        """When Docker is active, run() prepends docker run to the command."""
-        script = self._make_script()
-        script.docker = DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
-            mounts=[
-                Mount(
-                    host_path=script.repo_root,
-                    container_path=WORKSPACE_CONTAINER_PATH,
-                )
-            ],
-            uid=1000,
-            gid=1000,
-        )
-        captured: list[list[str]] = []
-
-        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
-            captured.append(cmd)
-            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.run("make", "all")
-
-        self.assertTrue(captured)
-        self.assertIn("docker", captured[0])
-        self.assertIn("make", captured[0])
-        self.assertIn("all", captured[0])
-
-    @patch("nanvix_zutil.docker.is_windows", return_value=False)
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
-    def test_run_env_forwarded_into_container(self, *_mocks: object) -> None:
-        """env vars passed to run() are forwarded as -e flags in Docker mode."""
-        script = self._make_script()
-        script.docker = DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
-            mounts=[],
-            uid=1000,
-            gid=1000,
-        )
-        captured_kwargs: list[dict[str, object]] = []
-
-        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
-            captured_kwargs.append(dict(kwargs))
-            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.run("make", "all", env={"MY_VAR": "hello"})
-
-        self.assertTrue(captured_kwargs)
-        # env should NOT be passed to the docker subprocess itself
-        self.assertIsNone(captured_kwargs[0].get("env"))
-
-    @patch("nanvix_zutil.docker.is_windows", return_value=False)
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
-    def test_run_env_forwarded_into_container_as_flags(self, *_mocks: object) -> None:
-        """env vars appear as -e KEY=VAL in the docker run command."""
-        script = self._make_script()
-        script.docker = DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
-            mounts=[],
-            uid=1000,
-            gid=1000,
-        )
-        captured_cmds: list[list[str]] = []
-
-        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
-            captured_cmds.append(cmd)
-            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.run("make", "all", env={"MY_VAR": "hello"})
-
-        self.assertTrue(captured_cmds)
-        cmd = captured_cmds[0]
-        # -e MY_VAR=hello must appear in the docker run command
-        self.assertIn("-e", cmd)
-        self.assertIn("MY_VAR=hello", cmd)
 
 
 class TestZScriptAutoDocker(unittest.TestCase):
@@ -991,8 +934,8 @@ class TestZScriptAutoDocker(unittest.TestCase):
         with (
             patch("sys.argv", ["z.py", "build"]),
             patch("nanvix_zutil.script.is_windows", return_value=False),
-            patch("nanvix_zutil.script.shutil.which", return_value="/usr/bin/docker"),
-            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("nanvix_zutil.helpers.shutil.which", return_value="/usr/bin/docker"),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
             patch.object(BuildScript, "build", _fake_build),
             patch("nanvix_zutil.script.log"),
         ):
@@ -1146,7 +1089,10 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
-        p = patch.object(ZScript, "_check_docker", return_value=None)
+        # script.py calls helpers.check_docker (imported into the script
+        # module namespace). Patch it to a no-op so these tests don't try to
+        # actually pull a Docker image.
+        p = patch("nanvix_zutil.script.check_docker", return_value=None)
         p.start()
         self.addCleanup(p.stop)
 
@@ -1339,7 +1285,7 @@ class TestZScriptLint(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0)
 
         with (
-            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
             patch("importlib.util.find_spec", return_value=True),
         ):
             script.lint()
@@ -1376,12 +1322,14 @@ class TestZScriptLint(unittest.TestCase):
             args: tuple[str, ...], **kwargs: object
         ) -> sp.CompletedProcess[str]:
             cmd = list(args)
-            return sp.CompletedProcess(args=cmd, returncode=1)
+            # helpers.run() passes check=True; emulate the real subprocess.run
+            # behaviour by raising CalledProcessError on non-zero exit.
+            raise sp.CalledProcessError(returncode=1, cmd=cmd)
 
         log_mod.set_json_mode(True)
         try:
             with (
-                patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
                 patch("importlib.util.find_spec", return_value=True),
                 self.assertRaises(SystemExit) as ctx,
             ):
@@ -1403,7 +1351,7 @@ class TestZScriptLint(unittest.TestCase):
                 self.assertRaises(SystemExit) as ctx,
             ):
                 script.lint()
-            self.assertEqual(ctx.exception.code, 3)
+            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
 
@@ -1437,7 +1385,7 @@ class TestZScriptFormat(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0)
 
         with (
-            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
             patch("importlib.util.find_spec", return_value=True),
         ):
             script.format()
@@ -1464,7 +1412,7 @@ class TestZScriptFormat(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0)
 
         with (
-            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
             patch("importlib.util.find_spec", return_value=True),
         ):
             script.format(check=True)
@@ -1497,12 +1445,14 @@ class TestZScriptFormat(unittest.TestCase):
             args: tuple[str, ...], **kwargs: object
         ) -> sp.CompletedProcess[str]:
             cmd = list(args)
-            return sp.CompletedProcess(args=cmd, returncode=1)
+            # helpers.run() passes check=True; emulate subprocess.run by
+            # raising CalledProcessError on non-zero exit.
+            raise sp.CalledProcessError(returncode=1, cmd=cmd)
 
         log_mod.set_json_mode(True)
         try:
             with (
-                patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
                 patch("importlib.util.find_spec", return_value=True),
                 self.assertRaises(SystemExit) as ctx,
             ):
@@ -1678,8 +1628,8 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 3)
 
 
-class TestMakeInitrd(unittest.TestCase):
-    """ZScript.make_initrd() builds the correct mkimage command."""
+class TestHelpersMakeInitrd(unittest.TestCase):
+    """helpers.make_initrd() builds the correct mkimage command."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -1701,7 +1651,7 @@ class TestMakeInitrd(unittest.TestCase):
         script.sysroot = fake_sysroot
         return script
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_basic_invocation_linux(self, _mock: object) -> None:
         """Produces the expected command on Linux."""
         script = self._make_script()
@@ -1711,8 +1661,8 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            result = script.make_initrd("my-app.elf")
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            result = helpers.make_initrd(script, "my-app.elf", InitRdArgs())
 
         self.assertEqual(result, script.repo_root / "my-app.img")
         cmd = captured[0]
@@ -1725,7 +1675,7 @@ class TestMakeInitrd(unittest.TestCase):
         self.assertEqual(cmd[5], f"{bin_dir / 'vfsd.elf'};vfsd")
         self.assertEqual(cmd[6], f"{script.repo_root / 'my-app.elf'};my-app.elf")
 
-    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=True)
     def test_basic_invocation_windows(self, _mock: object) -> None:
         """Uses mkimage.exe on Windows."""
         script = self._make_script()
@@ -1735,13 +1685,13 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf")
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(script, "my-app.elf", InitRdArgs())
 
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
         self.assertEqual(captured[0][0], str(bin_dir / "mkimage.exe"))
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_app_args(self, _mock: object) -> None:
         """App arguments are appended to the app entry."""
         script = self._make_script()
@@ -1751,8 +1701,10 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf", app_args=["--verbose", "--port=8080"])
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script, "my-app.elf", InitRdArgs(app_args=["--verbose", "--port=8080"])
+            )
 
         app_entry = captured[0][6]
         self.assertEqual(
@@ -1760,7 +1712,7 @@ class TestMakeInitrd(unittest.TestCase):
             f"{script.repo_root / 'my-app.elf'};my-app.elf --verbose --port=8080",
         )
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_daemon_args(self, _mock: object) -> None:
         """Daemon arguments are appended to respective entries."""
         script = self._make_script()
@@ -1770,12 +1722,15 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd(
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script,
                 "my-app.elf",
-                procd_args=["--debug"],
-                memd_args=["--heap=64m"],
-                vfsd_args=["--cache=off"],
+                InitRdArgs(
+                    procd_args=["--debug"],
+                    memd_args=["--heap=64m"],
+                    vfsd_args=["--cache=off"],
+                ),
             )
 
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
@@ -1783,7 +1738,7 @@ class TestMakeInitrd(unittest.TestCase):
         self.assertEqual(captured[0][4], f"{bin_dir / 'memd.elf'};memd --heap=64m")
         self.assertEqual(captured[0][5], f"{bin_dir / 'vfsd.elf'};vfsd --cache=off")
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_kernel_args(self, _mock: object) -> None:
         """Kernel arguments are passed via --kernel-args."""
         script = self._make_script()
@@ -1793,15 +1748,17 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf", kernel_args=["console=ttyS0", "debug"])
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script, "my-app.elf", InitRdArgs(kernel_args=["console=ttyS0", "debug"])
+            )
 
         cmd = captured[0]
         # -kernel-args should appear after -o <output>
         ka_idx = cmd.index("-kernel-args")
         self.assertEqual(cmd[ka_idx + 1], "console=ttyS0 debug")
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_semicolons_escaped_in_args(self, _mock: object) -> None:
         """Semicolons in arguments are escaped as \\;."""
         script = self._make_script()
@@ -1811,15 +1768,15 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf", app_args=["--sep=;"])
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(script, "my-app.elf", InitRdArgs(app_args=["--sep=;"]))
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry, f"{script.repo_root / 'my-app.elf'};my-app.elf --sep=\\;"
         )
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_semicolons_escaped_in_kernel_args(self, _mock: object) -> None:
         """Semicolons in kernel arguments are escaped."""
         script = self._make_script()
@@ -1829,14 +1786,14 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf", kernel_args=["a;b"])
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(script, "my-app.elf", InitRdArgs(kernel_args=["a;b"]))
 
         cmd = captured[0]
         ka_idx = cmd.index("-kernel-args")
         self.assertEqual(cmd[ka_idx + 1], "a\\;b")
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_custom_bin_dir(self, _mock: object) -> None:
         """A custom bin_dir is used instead of the sysroot."""
         script = self._make_script()
@@ -1849,25 +1806,25 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf", bin_dir=custom_bin)
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(script, "my-app.elf", InitRdArgs(bin_dir=custom_bin))
 
         self.assertEqual(captured[0][0], str(custom_bin / "mkimage.elf"))
         self.assertIn(str(custom_bin / "procd.elf"), captured[0][3])
 
     def test_no_sysroot_exits(self) -> None:
-        """Exits with EXIT_MISSING_DEP when sysroot is None."""
+        """Exits with EXIT_MISSING_DEP when sysroot is None and config lacks one."""
         script = ZScript(Path(self._tmpdir.name))
         script.sysroot = None
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                script.make_initrd("my-app.elf")
-            self.assertEqual(ctx.exception.code, 3)
+                helpers.make_initrd(script, "my-app.elf", InitRdArgs())
+            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_app_stem_derived_from_filename(self, _mock: object) -> None:
         """The output .img uses the stem; argv0 uses the full filename."""
         script = self._make_script()
@@ -1877,8 +1834,8 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            result = script.make_initrd("hello-world.elf")
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            result = helpers.make_initrd(script, "hello-world.elf", InitRdArgs())
 
         self.assertEqual(result, script.repo_root / "hello-world.img")
         self.assertEqual(
@@ -1891,12 +1848,12 @@ class TestMakeInitrd(unittest.TestCase):
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                script.make_initrd("build/hello.elf")
-            self.assertEqual(ctx.exception.code, 3)
+                helpers.make_initrd(script, "build/hello.elf", InitRdArgs())
+            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_mkimage_not_found_exits(self, _mock: object) -> None:
         """Exits with EXIT_MISSING_DEP when mkimage binary is missing."""
         repo_root = Path(self._tmpdir.name)
@@ -1910,12 +1867,12 @@ class TestMakeInitrd(unittest.TestCase):
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                script.make_initrd("my-app.elf")
-            self.assertEqual(ctx.exception.code, 3)
+                helpers.make_initrd(script, "my-app.elf", InitRdArgs())
+            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_app_env(self, _mock: object) -> None:
         """Environment variables are appended after a semicolon separator."""
         script = self._make_script()
@@ -1925,8 +1882,10 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf", app_env=["VAR1=foo", "VAR2=bar"])
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script, "my-app.elf", InitRdArgs(app_env=["VAR1=foo", "VAR2=bar"])
+            )
 
         app_entry = captured[0][6]
         self.assertEqual(
@@ -1934,7 +1893,7 @@ class TestMakeInitrd(unittest.TestCase):
             f"{script.repo_root / 'my-app.elf'};my-app.elf;VAR1=foo VAR2=bar",
         )
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_app_args_and_env(self, _mock: object) -> None:
         """Both app arguments and environment variables are emitted."""
         script = self._make_script()
@@ -1944,11 +1903,11 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd(
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script,
                 "my-app.elf",
-                app_args=["--verbose"],
-                app_env=["DEBUG=1"],
+                InitRdArgs(app_args=["--verbose"], app_env=["DEBUG=1"]),
             )
 
         app_entry = captured[0][6]
@@ -1957,7 +1916,7 @@ class TestMakeInitrd(unittest.TestCase):
             f"{script.repo_root / 'my-app.elf'};my-app.elf --verbose;DEBUG=1",
         )
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_daemon_env(self, _mock: object) -> None:
         """Daemon environment variables are appended to respective entries."""
         script = self._make_script()
@@ -1967,12 +1926,15 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd(
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script,
                 "my-app.elf",
-                procd_env=["LOG=debug"],
-                memd_env=["HEAP=64m"],
-                vfsd_env=["CACHE=off"],
+                InitRdArgs(
+                    procd_env=["LOG=debug"],
+                    memd_env=["HEAP=64m"],
+                    vfsd_env=["CACHE=off"],
+                ),
             )
 
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
@@ -1980,7 +1942,7 @@ class TestMakeInitrd(unittest.TestCase):
         self.assertEqual(captured[0][4], f"{bin_dir / 'memd.elf'};memd;HEAP=64m")
         self.assertEqual(captured[0][5], f"{bin_dir / 'vfsd.elf'};vfsd;CACHE=off")
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_env_semicolons_escaped(self, _mock: object) -> None:
         """Semicolons in env values are escaped."""
         script = self._make_script()
@@ -1990,8 +1952,10 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd("my-app.elf", app_env=["PATH=/a;/b"])
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script, "my-app.elf", InitRdArgs(app_env=["PATH=/a;/b"])
+            )
 
         app_entry = captured[0][6]
         self.assertEqual(
@@ -1999,7 +1963,7 @@ class TestMakeInitrd(unittest.TestCase):
             f"{script.repo_root / 'my-app.elf'};my-app.elf;PATH=/a\\;/b",
         )
 
-    @patch("nanvix_zutil.script.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_daemon_args_and_env(self, _mock: object) -> None:
         """Daemon entries include both CLI arguments and environment variables."""
         script = self._make_script()
@@ -2009,11 +1973,13 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd(
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script,
                 "my-app.elf",
-                procd_args=["--log-level", "trace"],
-                procd_env=["LOG=debug"],
+                InitRdArgs(
+                    procd_args=["--log-level", "trace"], procd_env=["LOG=debug"]
+                ),
             )
 
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
@@ -2022,7 +1988,7 @@ class TestMakeInitrd(unittest.TestCase):
             f"{bin_dir / 'procd.elf'};procd --log-level trace;LOG=debug",
         )
 
-    @patch("nanvix_zutil.script.is_windows", return_value=True)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=True)
     def test_env_windows(self, _mock: object) -> None:
         """Environment variables work correctly on Windows (mkimage.exe)."""
         script = self._make_script()
@@ -2032,12 +1998,13 @@ class TestMakeInitrd(unittest.TestCase):
             captured.append(cmd)
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
-        with patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run):
-            script.make_initrd(
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.make_initrd(
+                script,
                 "my-app.elf",
-                app_args=["--verbose"],
-                app_env=["DEBUG=1"],
-                procd_env=["LOG=debug"],
+                InitRdArgs(
+                    app_args=["--verbose"], app_env=["DEBUG=1"], procd_env=["LOG=debug"]
+                ),
             )
 
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
@@ -2049,44 +2016,31 @@ class TestMakeInitrd(unittest.TestCase):
         )
 
 
-class TestZScriptCheckDocker(unittest.TestCase):
-    """_check_docker() probes for the image and auto-pulls when missing."""
+class TestHelpersCheckDocker(unittest.TestCase):
+    """helpers.check_docker() probes for the image and auto-pulls when missing."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
-    def _make_script(self) -> ZScript:
-        return ZScript(Path(self._tmpdir.name))
-
     def test_missing_docker_binary_exits_fatal(self) -> None:
         """No `docker` on PATH -> fatal EXIT_MISSING_DEP, no subprocess calls."""
-        from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
-
-        script = self._make_script()
         mock_run = MagicMock()
         log_mod.set_json_mode(True)
         try:
             with (
-                patch("nanvix_zutil.script.shutil.which", return_value=None),
-                patch("nanvix_zutil.script.subprocess.run", mock_run),
+                patch("nanvix_zutil.helpers.shutil.which", return_value=None),
+                patch("nanvix_zutil.helpers.subprocess.run", mock_run),
                 self.assertRaises(SystemExit) as ctx,
             ):
-                script._check_docker("test/image:tag")
+                helpers.check_docker("test/image:tag")
             self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
         mock_run.assert_not_called()
-        self.assertIsNone(script.docker)
 
     def test_image_present_skips_pull(self) -> None:
         """`docker image inspect` returns 0 -> no pull, no fatal."""
-        script = self._make_script()
         image = "test/image:tag"
 
         calls: list[list[str]] = []
@@ -2096,17 +2050,16 @@ class TestZScriptCheckDocker(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with (
-            patch("nanvix_zutil.script.shutil.which", return_value="/usr/bin/docker"),
-            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("nanvix_zutil.helpers.shutil.which", return_value="/usr/bin/docker"),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
         ):
-            script._check_docker(image)  # pyright: ignore[reportPrivateUsage]
+            helpers.check_docker(image)
 
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0], ["docker", "image", "inspect", image])
 
     def test_image_missing_pull_succeeds(self) -> None:
         """`image inspect` fails, `docker pull` succeeds -> no fatal."""
-        script = self._make_script()
         image = "test/image:tag"
 
         calls: list[list[str]] = []
@@ -2119,10 +2072,10 @@ class TestZScriptCheckDocker(unittest.TestCase):
             )
 
         with (
-            patch("nanvix_zutil.script.shutil.which", return_value="/usr/bin/docker"),
-            patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+            patch("nanvix_zutil.helpers.shutil.which", return_value="/usr/bin/docker"),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
         ):
-            script._check_docker(image)  # pyright: ignore[reportPrivateUsage]
+            helpers.check_docker(image)
 
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0], ["docker", "image", "inspect", image])
@@ -2130,9 +2083,6 @@ class TestZScriptCheckDocker(unittest.TestCase):
 
     def test_image_missing_pull_fails_exits_fatal(self) -> None:
         """`image inspect` fails, `docker pull` fails -> fatal EXIT_MISSING_DEP."""
-        from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
-
-        script = self._make_script()
         image = "test/image:tag"
 
         calls: list[list[str]] = []
@@ -2148,13 +2098,13 @@ class TestZScriptCheckDocker(unittest.TestCase):
         try:
             with (
                 patch(
-                    "nanvix_zutil.script.shutil.which",
+                    "nanvix_zutil.helpers.shutil.which",
                     return_value="/usr/bin/docker",
                 ),
-                patch("nanvix_zutil.script.subprocess.run", side_effect=fake_run),
+                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
                 self.assertRaises(SystemExit) as ctx,
             ):
-                script._check_docker(image)  # pyright: ignore[reportPrivateUsage]
+                helpers.check_docker(image)
             self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
@@ -2162,7 +2112,6 @@ class TestZScriptCheckDocker(unittest.TestCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0], ["docker", "image", "inspect", image])
         self.assertEqual(calls[1], ["docker", "pull", image])
-        self.assertIsNone(script.docker)
 
 
 class TestOfflineMode(unittest.TestCase):


### PR DESCRIPTION
This PR moves helper functions out of ZScript. Per #190, the `ZScript` class should _only_ contain overridable lifecycle functions. This doesn't completely close out #190, but it gets us halfway there.

### Changes

This PR deprecates 3 functions and moves internal ZScript helpers to the `helpers` module.

| Function | Status |
| --- | --- |
| run | deprecated, use `helpers.run` instead |
| make_initrd | deprecated, use `helpers.make_initrd` instead |
| translate_path | deprecated, use `self.docker.translate_path` instead |   
| _check_docker | moved |
| _run_tool | removed, replaced with ensure_tool_installed + run |
| _sync_configs | moved |

Deprecated items emit a "DEPRECATED" warning. We are unable to use the `@deprecated` decorator as it forces downstream CI to fail on lint.

`make_initrd` replaces its parameter list with `InitRdArgs` data struct.

Examples are updated to use the new API, as are the tests.

### Verification

On each downstream:

```sh
./z setup   --with-zutils ~/repos/nanvix/zutils/ --with-docker nanvix/toolchain:latest-minimal
./z build   --with-zutils ~/repos/nanvix/zutils/
./z test    --with-zutils ~/repos/nanvix/zutils/
./z release --with-zutils ~/repos/nanvix/zutils/
./z lint    --with-zutils ~/repos/nanvix/zutils
```

DEPRECATION warnings fire appropriately; all stages pass.

### Downstream PRs

https://github.com/nanvix/zlib/pull/210
https://github.com/nanvix/bzip2/pull/240
https://github.com/nanvix/sqlite/pull/220
https://github.com/nanvix/libffi/pull/205
https://github.com/nanvix/openssl/pull/219
https://github.com/nanvix/quickjs/pull/177
https://github.com/nanvix/posix-tests/pull/157
https://github.com/nanvix/nanvix-python/pull/223
https://github.com/nanvix/cpython/pull/665
https://github.com/nanvix/xz/pull/60
https://github.com/nanvix/libxml2/pull/47
https://github.com/nanvix/libxslt/pull/48
https://github.com/nanvix/lxml/pull/45