### PR TITLE
Actually read persisted docker image

### DIFF
--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -9,7 +9,7 @@ Demonstrates dependency resolution with ``nanvix.toml``.  Run with
     nanvix-zutil setup                     # download sysroot + lib-hello (Docker auto-enabled)
     nanvix-zutil setup --with-docker IMG   # download sysroot + lib-hello (custom Docker image)
     nanvix-zutil build                     # cross-compile inside Docker container (auto)
-    nanvix-zutil test                      # run tests (smoke + integration + functional)
+    nanvix-zutil test                      # run tests (smoke + integration + functional, host-local)
     nanvix-zutil clean                     # remove build artifacts (host)
 """
 
@@ -35,7 +35,7 @@ class BinHello(ZScript):
     # Docker configuration
     # ------------------------------------------------------------------
 
-    def docker_config(self, image: str) -> DockerConfig:
+    def docker_config(self, image: str | None = None) -> DockerConfig:
         """Add output_files so hello.elf is copied back on Windows."""
         cfg = super().docker_config(image)
         return dataclasses.replace(cfg, output_files=["hello.elf"])
@@ -113,11 +113,10 @@ class BinHello(ZScript):
     def test(self) -> None:
         """Run the test suite (smoke + integration + functional).
 
-        The functional test phase runs under ``nanvixd.elf`` inside a
-        Docker container on Linux, or natively under ``nanvixd.exe`` on
-        Windows.  On Linux, functional tests are skipped when Docker is
-        not configured (the ``test`` subcommand does not enable Docker
-        automatically).
+        All phases run directly on the host — only ``build`` is wrapped
+        in Docker.  The functional phase invokes the sysroot-shipped
+        ``nanvixd`` binary (``nanvixd.exe`` on Windows, ``nanvixd.elf``
+        elsewhere).
         """
         binary = self.repo_root / "hello.elf"
 
@@ -141,42 +140,15 @@ class BinHello(ZScript):
             log.fatal(f"{binary} is not a valid ELF binary.", code=EXIT_TEST_FAILURE)
         log.success(f"OK: {binary.name} is a valid ELF binary")
 
-        # Functional: run under nanvixd on the appropriate platform.
-        #
-        # On Linux the functional test requires Docker (nanvixd.elf
-        # cannot run directly on the CI host).  The ``test`` subcommand
-        # does not enable Docker, so functional tests are skipped unless
-        # Docker was explicitly configured.
-        #
-        # On Windows, nanvixd.exe is a native host binary and runs
-        # without Docker.
-        if sys.platform == "win32":
-            self._test_functional_windows(binary)
-        elif self.docker:
-            self._test_functional_docker(binary)
-        else:
-            log.info("=== skipping functional tests (Docker not configured) ===")
+        # Functional: run nanvixd directly from the sysroot on the host.
+        # The sysroot ships a per-OS nanvixd binary (``nanvixd.exe`` on
+        # Windows, ``nanvixd.elf`` elsewhere) so no Docker wrapping is
+        # needed for ``test`` — only ``build`` runs in Docker.
+        self._test_functional(binary)
 
-    def _test_functional_docker(self, binary: Path) -> None:
-        """Run functional tests inside a Docker container (Linux)."""
-        log.info("=== bin-hello functional tests (Docker) ===")
-        sysroot = self._sysroot()
-        workspace_binary = self.translate_path(binary)
-        self.run(
-            "timeout",
-            "--foreground",
-            "60",
-            f"{sysroot}/bin/nanvixd.elf",
-            "-bin-dir",
-            f"{sysroot}/bin",
-            "--",
-            str(workspace_binary),
-        )
-        log.success("PASS: bin-hello functional tests")
-
-    def _test_functional_windows(self, binary: Path) -> None:
-        """Run functional tests natively on Windows using nanvixd.exe."""
-        log.info("=== bin-hello functional tests (Windows) ===")
+    def _test_functional(self, binary: Path) -> None:
+        """Run nanvixd from the sysroot directly on the host."""
+        log.info("=== bin-hello functional tests ===")
         sysroot_str = self.config.get(CFG_SYSROOT, "")
         if not sysroot_str:
             log.fatal(
@@ -184,7 +156,8 @@ class BinHello(ZScript):
                 code=EXIT_TEST_FAILURE,
             )
         sysroot = Path(sysroot_str)  # type: ignore[arg-type]
-        nanvixd = sysroot / "bin" / "nanvixd.exe"
+        nanvixd_name = "nanvixd.exe" if sys.platform == "win32" else "nanvixd.elf"
+        nanvixd = sysroot / "bin" / nanvixd_name
         if not nanvixd.exists():
             log.fatal(
                 f"{nanvixd} not found — run 'nanvix-zutil setup' to download it.",
@@ -197,6 +170,7 @@ class BinHello(ZScript):
             "--",
             str(binary),
             timeout=60,
+            docker=False,
         )
         log.success("PASS: bin-hello functional tests")
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -96,8 +96,6 @@ class ZScript:
             :meth:`setup`, or ``None`` before setup runs.
         buildroot: The :class:`~nanvix_zutil.Buildroot` populated by
             :meth:`setup`, or ``None`` when there are no dependencies.
-        docker: Active :class:`~nanvix_zutil.DockerConfig`, or ``None``
-            when Docker mode is not in use.
     """
 
     SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
@@ -266,7 +264,7 @@ class ZScript:
                     code=EXIT_MISSING_DEP,
                 )
 
-    def docker_config(self, image: str) -> DockerConfig:
+    def docker_config(self, image: str | None = None) -> DockerConfig:
         """Build the :class:`~nanvix_zutil.DockerConfig` for *image*.
 
         Constructs a standard configuration that mounts:
@@ -312,6 +310,14 @@ class ZScript:
                     readonly=True,
                 )
             )
+
+        if image is None:
+            image = self.config.get(CFG_DOCKER_IMAGE)
+            if image is None:
+                log.fatal(
+                    "No Docker image configured. Run 'setup --with-docker IMAGE' first.",
+                    code=EXIT_INVALID_ARGS,
+                )
 
         return DockerConfig(
             image=image,
@@ -1109,8 +1115,8 @@ class ZScript:
         # to .nanvix/env.json so that subsequent commands can use it,
         # but we do not require Docker to be installed or the image to
         # exist locally.
+        image: str | None = getattr(args, "with_docker", None)
         if args.subcommand in ZScript.DOCKER_COMMANDS:
-            image: str | None = getattr(args, "with_docker", None)
             persisted_image = instance.config.get(CFG_DOCKER_IMAGE)
 
             if image is None:
@@ -1137,9 +1143,9 @@ class ZScript:
                 # may exit if Docker is required but not available
                 instance._check_docker(image)
 
-            # Persist Docker image on setup so subsequent commands
-            # automatically use the same image.
-            instance.docker = instance.docker_config(image)
+        # Persist Docker image on setup so subsequent commands
+        # automatically use the same image.
+        instance.docker = instance.docker_config(image)
 
         # ------------------------------------------------------------------
         # Dispatch to lifecycle hook

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,9 +95,10 @@ class TestIntegrationLifecycle(unittest.TestCase):
         if subcommand == "setup" and "--with-docker" not in argv:
             argv += ["--with-docker", "test/image:tag"]
 
-        # build/release/clean need a persisted Docker image.
-        _DOCKER_COMMANDS = {"build", "release", "clean"}
-        if subcommand in _DOCKER_COMMANDS:
+        # docker_config() is now called unconditionally for every
+        # subcommand, so any command other than `setup` (which provides
+        # the image via --with-docker) needs a persisted Docker image.
+        if subcommand != "setup":
             nanvix_dir = self._repo_root / ".nanvix"
             env_json = nanvix_dir / "env.json"
             if not env_json.exists():


### PR DESCRIPTION
Bug fix. Persisted docker image (`NANVIX_DOCKER_IMAGE` in `env.json`) was persisted but not always made available. Additionally, this fixes a longstanding bug in examples/ where `hello-bin` was not properly running tests. It tried to run tests in Docker and failed.