### PR TITLE
Strip host-only env vars before forwarding to container

### DIFF
--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -20,6 +20,49 @@ if TYPE_CHECKING:
     from nanvix_zutil.script import ZScript
 
 
+# Env vars that must never leak from the host into the Docker container.
+#
+# Forwarding ``PATH`` is the catastrophic case on Windows: the host value is a
+# semicolon-separated list of ``C:\...`` paths with no ``/bin`` or ``/usr/bin``,
+# which overrides the image's Linux ``PATH`` and makes runc fail to resolve the
+# container's entrypoint (``exec: "sh": executable file not found in $PATH``).
+# ``HOME`` is always set explicitly by ``DockerConfig`` (currently to ``/tmp``);
+# ``USER`` is set explicitly on the standard (non-Windows) path.  In both cases
+# the caller must not override them.  ``LD_LIBRARY_PATH`` and ``PYTHONPATH``
+# similarly refer to host filesystem locations that do not exist inside the
+# container.
+_CONTAINER_ENV_BLOCKLIST: frozenset[str] = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "USER",
+        "USERNAME",
+        "PWD",
+        "OLDPWD",
+        "SHELL",
+        "TERM",
+        "LD_LIBRARY_PATH",
+        "DYLD_LIBRARY_PATH",
+        "PYTHONPATH",
+        "PYTHONHOME",
+    }
+)
+
+
+def filter_container_env(env: dict[str, str]) -> dict[str, str]:
+    """Strip host-only / shell-managed keys before forwarding into the container.
+
+    The match is case-insensitive so that mixed-case variants (e.g. Windows'
+    ``Path``) are also rejected.
+    """
+    return {
+        k: v
+        for k, v in env.items()
+        if k not in _CONTAINER_ENV_BLOCKLIST
+        and k.upper() not in _CONTAINER_ENV_BLOCKLIST
+    }
+
+
 def check_docker(image: str) -> None:
     """Ensure the Docker CLI and the requested *image* are available.
 
@@ -263,7 +306,15 @@ def run(
     subprocess_env: dict[str, str] | None = None
     if docker is not None:
         if env:
-            merged = {**docker.extra_env, **env}
+            # When the caller hands us ``dict(os.environ)`` (a common pattern
+            # for autotools wrappers), the host's environment leaks into the
+            # container via ``-e KEY=VALUE`` flags.  On Windows that includes
+            # ``PATH`` (full of ``C:\...`` paths with no ``/bin`` or
+            # ``/usr/bin``), which overrides the image's Linux ``PATH`` and
+            # makes runc fail to resolve the container's entrypoint (e.g.
+            # ``sh``) with ``exec: "sh": executable file not found in $PATH``.
+            # Strip host-only / shell-managed keys before forwarding.
+            merged = {**docker.extra_env, **filter_container_env(env)}
             docker = dataclasses.replace(docker, extra_env=merged)
         if is_windows():
             cmd = docker.build_windows_run_cmd(*args)

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -57,7 +57,13 @@ from nanvix_zutil.exitcodes import (
     EXIT_MISSING_DEP,
 )
 from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
-from nanvix_zutil.helpers import check_docker, ensure_tool_installed, run, sync_configs
+from nanvix_zutil.helpers import (
+    check_docker,
+    ensure_tool_installed,
+    filter_container_env,
+    run,
+    sync_configs,
+)
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.resolver import is_stale, resolve
@@ -904,7 +910,10 @@ class ZScript:
         if self.docker is not None and docker:
             cfg = self.docker
             if env:
-                merged = {**cfg.extra_env, **env}
+                # Strip host-only / shell-managed keys (e.g. Windows' ``PATH``)
+                # before forwarding into the container.  See
+                # :func:`helpers.filter_container_env` for the rationale.
+                merged = {**cfg.extra_env, **filter_container_env(env)}
                 cfg = dataclasses.replace(cfg, extra_env=merged)
             if is_windows():
                 cmd = cfg.build_windows_run_cmd(*args)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -748,6 +748,102 @@ class TestHelpersRun(unittest.TestCase):
         self.assertIn("-e", cmd)
         self.assertIn("MY_VAR=hello", cmd)
 
+    @patch.dict(
+        os.environ,
+        {"USER": "test-runner-user", "USERNAME": "test-runner-user"},
+        clear=False,
+    )
+    @patch("nanvix_zutil.docker.is_windows", return_value=False)
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
+    def test_run_strips_blocklisted_env_vars(self, *_mocks: object) -> None:
+        """helpers.run() must not forward host-only env vars
+        (PATH/HOME/USER/...) into the container, including mixed-case
+        variants.  Non-blocklisted keys still pass through."""
+        docker = DockerConfig(
+            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            mounts=[],
+            uid=1000,
+            gid=1000,
+        )
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured_cmds.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        env = {
+            # Blocklisted (uppercase canonical).
+            "PATH": "C:\\Windows\\System32",
+            "HOME": "/home/host",
+            "USER": "host-user",
+            "USERNAME": "host-user",
+            "PWD": "/some/host/path",
+            "OLDPWD": "/other/host/path",
+            "SHELL": "/bin/bash",
+            "TERM": "xterm",
+            "LD_LIBRARY_PATH": "/host/lib",
+            "DYLD_LIBRARY_PATH": "/host/dyld",
+            "PYTHONPATH": "/host/py",
+            "PYTHONHOME": "/host/pyhome",
+            # Blocklisted (mixed case).
+            "Path": "C:\\mixed",
+            "home": "/home/lower",
+            # Non-blocklisted — must pass through.
+            "CC": "gcc",
+            "CFLAGS": "-O2",
+            "PKG_CONFIG_PATH": "/usr/local/lib/pkgconfig",
+        }
+
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            helpers.run("make", "all", docker=docker, env=env)
+
+        self.assertTrue(captured_cmds)
+        cmd = captured_cmds[0]
+        # Collect every "KEY=VALUE" token that follows a "-e" flag.
+        forwarded: list[tuple[str, str]] = []
+        for i, tok in enumerate(cmd):
+            if tok == "-e" and i + 1 < len(cmd):
+                key, _, val = cmd[i + 1].partition("=")
+                forwarded.append((key, val))
+
+        # The caller's host-only values must never reach the container.
+        # ``DockerConfig`` legitimately sets ``HOME``/``USER`` itself, so we
+        # check VALUES rather than keys for those cases.
+        host_values = {
+            "PATH": "C:\\Windows\\System32",
+            "HOME": "/home/host",
+            "USER": "host-user",
+            "USERNAME": "host-user",
+            "PWD": "/some/host/path",
+            "OLDPWD": "/other/host/path",
+            "SHELL": "/bin/bash",
+            "TERM": "xterm",
+            "LD_LIBRARY_PATH": "/host/lib",
+            "DYLD_LIBRARY_PATH": "/host/dyld",
+            "PYTHONPATH": "/host/py",
+            "PYTHONHOME": "/host/pyhome",
+            "Path": "C:\\mixed",
+            "home": "/home/lower",
+        }
+        for key, host_val in host_values.items():
+            self.assertNotIn(
+                (key, host_val),
+                forwarded,
+                f"blocklisted env var {key!r}={host_val!r} leaked into docker run",
+            )
+
+        # Non-blocklisted keys must still pass through with their values.
+        for allowed_key, allowed_val in (
+            ("CC", "gcc"),
+            ("CFLAGS", "-O2"),
+            ("PKG_CONFIG_PATH", "/usr/local/lib/pkgconfig"),
+        ):
+            self.assertIn(
+                (allowed_key, allowed_val),
+                forwarded,
+                f"non-blocklisted env var {allowed_key!r} missing from docker run",
+            )
+
 
 class TestZScriptSysrootRequiredFiles(unittest.TestCase):
     """sysroot_required_files() varies by deployment mode."""


### PR DESCRIPTION
## Summary

`ZScript.run` previously forwarded the caller's `env` mapping verbatim into `docker run` via `-e KEY=VALUE` flags. Callers commonly pass `dict(os.environ)` (a natural pattern for autotools / `configure` wrappers), which leaks the host environment into the container.

On Windows this is catastrophic: the host `PATH` is a semicolon-separated list of `C:\...` directories with no `/bin` or `/usr/bin` entries. Forwarding it overrides the image's Linux `PATH` and makes `runc` fail to resolve the container entrypoint, surfacing as:

```
exec: "sh": executable file not found in $PATH
```

Other host-only or shell-managed keys (`HOME`, `USER`, `PWD`, `LD_LIBRARY_PATH`, `PYTHONPATH`, …) are similarly meaningless or actively harmful inside the container — `HOME` is always set explicitly by `DockerConfig` (and `USER` on the non-Windows path), and must not be overridden by the caller.

## Change

Introduce `_CONTAINER_ENV_BLOCKLIST` and filter the incoming `env` mapping (case-insensitive) before merging it with `cfg.extra_env`. Values the caller sets intentionally (`CC`, `CFLAGS`, `PKG_CONFIG_*`, target-specific flags, …) still pass through unchanged.

Blocklisted keys:

- `PATH`
- `HOME`, `USER`, `USERNAME`
- `PWD`, `OLDPWD`, `SHELL`, `TERM`
- `LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH`
- `PYTHONPATH`, `PYTHONHOME`

## Impact

- **Windows**: unblocks every consumer build that hands `os.environ` to `ZScript.run` (cpython, libffi, openssl, sqlite, libxml2, libxslt, lxml, …).
- **Linux**: no behaviour change for callers that already pass a minimal env; affected callers now get a clean container environment regardless of what `os.environ` happens to contain.
