### PR TITLE
Make format standalone

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ __init__.py    ←  public library API (re-exports all public symbols)
 
 `script.py` (`ZScript`) is the public-facing orchestrator. Consumers interact almost exclusively with `ZScript`, `Config`, `Buildroot`, `Sysroot`, `Dependency`, `Lockfile`, `DockerConfig`, `NanvixInfo`, and `resolve` — all re-exported from `__init__.py`.
 
-Hooks `setup`, `lock`, `format`, and `help` are auto-implemented in the base class and always available in the CLI. Consumer hooks (`build`, `test`, `benchmark`, `release`, `clean`) only appear when the subclass overrides them. `distclean`, `info`, `lint`, and `resolve` are exposed as **standalone** commands directly under `nanvix-zutil` (no `.nanvix/z.py` required) and are not part of the `ZScript` API.
+Hooks `setup`, `lock`, and `help` are auto-implemented in the base class and always available in the CLI. Consumer hooks (`build`, `test`, `benchmark`, `release`, `clean`) only appear when the subclass overrides them. `distclean`, `info`, `lint`, `format`, and `resolve` are exposed as **standalone** commands directly under `nanvix-zutil` (no `.nanvix/z.py` required) and are not part of the `ZScript` API.
 
 ### Bootstrap Chain
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Then invoke via the bootstrap wrapper or the `nanvix-zutil` CLI:
 ./z test             # run tests
 ./z lint             # black --check + pyright on .nanvix/*.py
 ./z format           # auto-format .nanvix/*.py with black
+./z format --check   # verify formatting without writing (non-zero on diff)
 ./z distclean        # remove all generated artifacts
 ```
 
@@ -43,8 +44,9 @@ nanvix-zutil lock    # resolve dependency graph → nanvix.lock
 nanvix-zutil setup   # download sysroot + install deps
 nanvix-zutil build   # cross-compile
 nanvix-zutil test    # run tests
-nanvix-zutil lint    # lint .nanvix/*.py
-nanvix-zutil format  # format .nanvix/*.py
+nanvix-zutil lint            # lint .nanvix/*.py
+nanvix-zutil format          # format .nanvix/*.py
+nanvix-zutil format --check  # verify formatting (non-zero on diff)
 ```
 
 ## Installation

--- a/docs/design.md
+++ b/docs/design.md
@@ -107,7 +107,7 @@ Zutils has a multi-phase lifecycle similar to other build tools. Most lifecycle 
 | Benchmark | `./z benchmark`                                           | ❌          | ✅           | Runs benchmarks.                                                        |
 | Clean     | `./z clean`                                               | ❌          | ✅           | Cleans up build files.                                                  |
 | Distclean | `./z distclean`                                           | ✅          | ❌           | Removes all transient nanvix artefacts. Also runs clean if available.   |
-| Format    | `./z format`                                              | ✅          | ❌           | Formats python files in `.nanvix` with black.                           |
+| Format    | `./z format [--check]`                                    | ✅          | ❌           | Formats python files in `.nanvix` with black. Pass `--check` to verify without modifying (non-zero on diff). |
 | Lint      | `./z lint`                                                | ✅          | ❌           | Lints python files in `.nanvix` with pyright.                           |
 | Info      | `./z info`                                                | ✅          | ❌           | Standalone command that queries GitHub for the relevant release files.  |
 

--- a/src/nanvix_zutil/__main__.py
+++ b/src/nanvix_zutil/__main__.py
@@ -19,6 +19,7 @@ from nanvix_zutil.exitcodes import (
     EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
 )
+from nanvix_zutil.format_cmd import HELP as _FORMAT_HELP
 from nanvix_zutil.info import HELP as _INFO_HELP
 from nanvix_zutil.lint_cmd import HELP as _LINT_HELP
 from nanvix_zutil.lockfile import get_zutil_version
@@ -28,6 +29,7 @@ from nanvix_zutil.script import ZScript
 # Standalone command help text, keyed by subcommand name.
 _STANDALONE_HELP: dict[str, str] = {
     "distclean": _DISTCLEAN_HELP,
+    "format": _FORMAT_HELP,
     "info": _INFO_HELP,
     "lint": _LINT_HELP,
     "resolve": _RESOLVE_HELP,
@@ -157,6 +159,12 @@ def main() -> None:
 
         sys.argv = ["nanvix-zutil lint", *remaining]
         lint_main()
+
+    if subcmd == "format":
+        from nanvix_zutil.format_cmd import main as format_main
+
+        sys.argv = ["nanvix-zutil format", *remaining]
+        format_main()
         return
 
     if subcmd == "help":

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -17,11 +17,6 @@ from pathlib import Path
 from nanvix_zutil.lockfile import get_zutil_version
 
 # ---------------------------------------------------------------------------
-# Version helper
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
 # Parser factory
 # ---------------------------------------------------------------------------
 
@@ -34,7 +29,6 @@ SUBCOMMANDS: tuple[str, ...] = (
     "release",
     "clean",
     "lock",
-    "format",
     "install",
     "help",
 )
@@ -55,7 +49,6 @@ SUBCOMMAND_HELP: dict[str, str] = {
     "release": "Package a release",
     "clean": "Remove build artifacts",
     "lock": "Resolve dependencies and write nanvix.lock",
-    "format": "Format .nanvix/*.py with black",
     "install": "Export build artifacts to a target directory",
     "help": "Show help message",
 }
@@ -137,13 +130,6 @@ def build_parser(
                 action="store_true",
                 default=False,
                 help="Resolve only direct dependencies (skip transitive discovery)",
-            )
-        if name == "format":
-            sub.add_argument(
-                "--check",
-                action="store_true",
-                default=False,
-                help="Check formatting without modifying files (exit non-zero on diff)",
             )
         if name in DOCKER_SUBCOMMANDS:
             sub.add_argument(

--- a/src/nanvix_zutil/format_cmd.py
+++ b/src/nanvix_zutil/format_cmd.py
@@ -1,0 +1,72 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""``nanvix-zutil format`` — format ``.nanvix/*.py`` with black.
+
+Standalone command (per issue #189): does not require a ``ZScript``
+subclass.  Runs ``black`` on all Python files in the target ``.nanvix/``
+directory, using the ``black.toml`` configuration alongside them.
+With ``--check``, runs ``black --check`` instead (exits non-zero on diff).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from nanvix_zutil import log
+from nanvix_zutil.exitcodes import EXIT_SUCCESS
+from nanvix_zutil.helpers import ensure_tool_installed, run
+
+HELP: str = "Format <nanvix-dir>/*.py with black"
+"""One-line description surfaced in ``nanvix-zutil --help``."""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the argument parser for ``nanvix-zutil format``.
+
+    Returns:
+        Configured :class:`argparse.ArgumentParser`.
+    """
+    parser = argparse.ArgumentParser(
+        prog="nanvix-zutil format",
+        description=(
+            "Format every *.py file in the nanvix directory with black,"
+            " using the black configuration file shipped alongside them."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        default=False,
+        help="Check formatting without modifying files (exit non-zero on diff)",
+    )
+    return parser
+
+
+def format(check: bool = False) -> None:
+    nanvix_dir = Path(sys.prefix).parent
+
+    py_files = sorted(nanvix_dir.glob("*.py"))
+    if not py_files:
+        log.warning(f"No .py files found in {nanvix_dir} — nothing to format")
+        return
+    ensure_tool_installed("black")
+    str_files = [str(f) for f in py_files]
+    black_cfg = str(nanvix_dir / "black.toml")
+    cmd = [sys.executable, "-m", "black", "--config", black_cfg]
+    if check:
+        cmd.append("--check")
+    cmd.extend(str_files)
+    run(*cmd)
+
+
+def main() -> None:
+    """Entry point for ``nanvix-zutil format``."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    format(check=args.check)
+
+    sys.exit(EXIT_SUCCESS)

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -59,9 +59,7 @@ from nanvix_zutil.exitcodes import (
 from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
 from nanvix_zutil.helpers import (
     check_docker,
-    ensure_tool_installed,
     filter_container_env,
-    run,
     sync_configs,
 )
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
@@ -145,7 +143,6 @@ class ZScript:
     AUTO_HOOKS: tuple[str, ...] = (
         "setup",
         "lock",
-        "format",
         "install",
         "help",
     )
@@ -588,32 +585,6 @@ class ZScript:
             )
 
     # ------------------------------------------------------------------
-    # Format hook — auto-implemented
-    # ------------------------------------------------------------------
-
-    def format(self, *, check: bool = False) -> None:
-        """Format ``.nanvix/*.py`` with black.
-
-        Args:
-            check: When ``True``, run ``black --check`` instead of
-                auto-formatting (exit non-zero on diff).
-
-        Exits with ``EXIT_MISSING_DEP`` if black is not installed.
-        """
-        py_files = sorted(self.nanvix_dir.glob("*.py"))
-        if not py_files:
-            log.warning("No .py files found in .nanvix/ — nothing to format")
-            return
-        ensure_tool_installed("black")
-        str_files = [str(f) for f in py_files]
-        black_cfg = str(self.nanvix_dir / "black.toml")
-        cmd = [sys.executable, "-m", "black", "--config", black_cfg]
-        if check:
-            cmd.append("--check")
-        cmd.extend(str_files)
-        run(*cmd)
-
-    # ------------------------------------------------------------------
     # Lifecycle hooks — override in subclass
     # ------------------------------------------------------------------
 
@@ -1031,12 +1002,6 @@ class ZScript:
                 log.success("Lockfile is up-to-date")
             else:
                 instance.lock(shallow=args.shallow)
-            return
-
-        # Special handling for format subcommand (--check flag).
-        if subcommand == "format":
-            instance.format(check=args.check)
-            log.success("Format complete")
             return
 
         # Special handling for install subcommand (--output flag).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,43 +141,6 @@ class TestDockerFlags(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
-class TestLintFormatSubcommands(unittest.TestCase):
-    """Tests for the format subcommand (lint is standalone, see test_lint_cmd)."""
-
-    def test_format_registered(self) -> None:
-        parser = build_parser()
-        args = parser.parse_args(["format"])
-        self.assertEqual(args.subcommand, "format")
-
-    def test_format_check_flag(self) -> None:
-        parser = build_parser()
-        args = parser.parse_args(["format", "--check"])
-        self.assertTrue(args.check)
-
-    def test_format_check_default_false(self) -> None:
-        parser = build_parser()
-        args = parser.parse_args(["format"])
-        self.assertFalse(args.check)
-
-    def test_lint_not_in_subcommands(self) -> None:
-        """lint has moved to a standalone command and is no longer a consumer subcommand."""
-        self.assertNotIn("lint", SUBCOMMANDS)
-
-    def test_format_in_subcommands(self) -> None:
-        self.assertIn("format", SUBCOMMANDS)
-
-    def test_lint_unknown_in_available(self) -> None:
-        """lint is rejected when passed in the available set."""
-        with self.assertRaises(ValueError):
-            build_parser(available=("lint", "help"))
-
-    def test_format_available_restricted(self) -> None:
-        """format is accepted when in the available set."""
-        parser = build_parser(available=("format", "help"))
-        args = parser.parse_args(["format"])
-        self.assertEqual(args.subcommand, "format")
-
-
 class TestOfflineFlag(unittest.TestCase):
     """Tests for the --offline flag on the setup subcommand."""
 

--- a/tests/test_format_cmd.py
+++ b/tests/test_format_cmd.py
@@ -1,0 +1,204 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Tests for nanvix_zutil.format_cmd."""
+
+import subprocess as sp
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import nanvix_zutil.log as log_mod
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+from nanvix_zutil.format_cmd import format, main
+
+
+def _patch_prefix(nanvix_dir: Path):
+    """Patch ``sys.prefix`` so ``format()`` resolves *nanvix_dir*.
+
+    ``format()`` computes ``nanvix_dir = Path(sys.prefix).parent`` on the
+    assumption that the active venv lives at ``<nanvix-dir>/venv``.  Tests
+    fake this by pointing ``sys.prefix`` at ``<nanvix-dir>/venv`` (the
+    path need not exist on disk).
+    """
+    return patch("nanvix_zutil.format_cmd.sys.prefix", str(nanvix_dir / "venv"))
+
+
+class TestFormatCmd(unittest.TestCase):
+    """Behaviour of the standalone ``nanvix-zutil format`` command."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        self.nanvix_dir.mkdir()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_runs_black(self) -> None:
+        """``format`` invokes black (without --check) on .nanvix/*.py."""
+        (self.nanvix_dir / "z.py").write_text("x = 1\n")
+
+        calls: list[list[str]] = []
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            calls.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0)
+
+        with (
+            _patch_prefix(self.nanvix_dir),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+        ):
+            format()
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("-m", calls[0])
+        self.assertIn("black", calls[0])
+        self.assertIn("--config", calls[0])
+        self.assertNotIn("--check", calls[0])
+
+    def test_check_mode(self) -> None:
+        """``format(check=True)`` runs black --check."""
+        (self.nanvix_dir / "z.py").write_text("x = 1\n")
+
+        calls: list[list[str]] = []
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            calls.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0)
+
+        with (
+            _patch_prefix(self.nanvix_dir),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+        ):
+            format(check=True)
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("-m", calls[0])
+        self.assertIn("black", calls[0])
+        self.assertIn("--config", calls[0])
+        self.assertIn("--check", calls[0])
+
+    def test_no_py_files_warns(self) -> None:
+        """Warns and returns when no .py files exist."""
+        with (
+            _patch_prefix(self.nanvix_dir),
+            patch("nanvix_zutil.format_cmd.log") as mock_log,
+        ):
+            format()
+
+        mock_log.warning.assert_called_once()
+        self.assertIn("nothing to format", mock_log.warning.call_args[0][0].lower())
+
+    def test_exits_on_failure(self) -> None:
+        """Exits with EXIT_BUILD_FAILURE when black fails."""
+        (self.nanvix_dir / "z.py").write_text("x = 1\n")
+
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            raise sp.CalledProcessError(returncode=1, cmd=cmd)
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                _patch_prefix(self.nanvix_dir),
+                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+                patch("importlib.util.find_spec", return_value=True),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                format()
+            self.assertEqual(ctx.exception.code, 5)
+        finally:
+            log_mod.set_json_mode(False)
+
+    def test_exits_when_tool_missing(self) -> None:
+        """Exits with EXIT_MISSING_DEP when black is not installed."""
+        (self.nanvix_dir / "z.py").write_text("x = 1\n")
+
+        log_mod.set_json_mode(True)
+        try:
+            with (
+                _patch_prefix(self.nanvix_dir),
+                patch("importlib.util.find_spec", return_value=None),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                format()
+            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+        finally:
+            log_mod.set_json_mode(False)
+
+
+class TestFormatCmdMain(unittest.TestCase):
+    """``main()`` parses args and exits with EXIT_SUCCESS."""
+
+    def test_main_no_py_files_exits_zero(self) -> None:
+        """``main()`` exits 0 when the resolved nanvix dir has no .py files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nanvix_dir = Path(tmpdir) / ".nanvix"
+            nanvix_dir.mkdir()
+            with (
+                _patch_prefix(nanvix_dir),
+                patch("sys.argv", ["nanvix-zutil format"]),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                main()
+            self.assertEqual(ctx.exception.code, 0)
+
+    def test_main_rejects_unknown_args(self) -> None:
+        """The parser no longer accepts ``--nanvix-dir`` (resolved via sys.prefix)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nanvix_dir = Path(tmpdir) / "custom-dir"
+            nanvix_dir.mkdir()
+            with (
+                _patch_prefix(nanvix_dir),
+                patch(
+                    "sys.argv",
+                    ["nanvix-zutil format", "--nanvix-dir", str(nanvix_dir)],
+                ),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                main()
+            # argparse exits 2 on unrecognised args
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_main_check_flag(self) -> None:
+        """``--check`` is propagated to format()."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nanvix_dir = Path(tmpdir) / ".nanvix"
+            nanvix_dir.mkdir()
+            (nanvix_dir / "z.py").write_text("x = 1\n")
+
+            calls: list[list[str]] = []
+
+            def fake_run(
+                args: tuple[str, ...], **kwargs: object
+            ) -> sp.CompletedProcess[str]:
+                cmd = list(args)
+                calls.append(cmd)
+                return sp.CompletedProcess(args=cmd, returncode=0)
+
+            with (
+                _patch_prefix(nanvix_dir),
+                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+                patch("importlib.util.find_spec", return_value=True),
+                patch("sys.argv", ["nanvix-zutil format", "--check"]),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                main()
+            self.assertEqual(ctx.exception.code, 0)
+            self.assertIn("--check", calls[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.log as log_mod
 from nanvix_zutil import helpers
-from nanvix_zutil.helpers import InitRdArgs
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
@@ -25,6 +24,7 @@ from nanvix_zutil.docker import (
     Mount,
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
+from nanvix_zutil.helpers import InitRdArgs
 from nanvix_zutil.script import ZScript
 from tests.testutils import (
     MANIFEST_LATEST_WITH_DEPS,
@@ -1232,137 +1232,6 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         # The dependency was satisfied locally so GitHub resolve should not
         # have been called.
         mock_resolve.assert_not_called()
-
-
-class TestZScriptFormat(unittest.TestCase):
-    """Tests for ZScript.format() default implementation."""
-
-    def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
-    def _make_script(self) -> ZScript:
-        return ZScript(Path(self._tmpdir.name))
-
-    def test_format_runs_black(self) -> None:
-        """format() runs black on .nanvix/*.py files."""
-        script = self._make_script()
-        py_file = script.nanvix_dir / "z.py"
-        py_file.write_text("x = 1\n")
-
-        calls: list[list[str]] = []
-
-        def fake_run(
-            args: tuple[str, ...], **kwargs: object
-        ) -> sp.CompletedProcess[str]:
-            cmd = list(args)
-            calls.append(cmd)
-            return sp.CompletedProcess(args=cmd, returncode=0)
-
-        with (
-            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
-            patch("importlib.util.find_spec", return_value=True),
-        ):
-            script.format()
-
-        self.assertEqual(len(calls), 1)
-        self.assertIn("-m", calls[0])
-        self.assertIn("black", calls[0])
-        self.assertIn("--config", calls[0])
-        self.assertNotIn("--check", calls[0])
-
-    def test_format_check_mode(self) -> None:
-        """format(check=True) runs black --check."""
-        script = self._make_script()
-        py_file = script.nanvix_dir / "z.py"
-        py_file.write_text("x = 1\n")
-
-        calls: list[list[str]] = []
-
-        def fake_run(
-            args: tuple[str, ...], **kwargs: object
-        ) -> sp.CompletedProcess[str]:
-            cmd = list(args)
-            calls.append(cmd)
-            return sp.CompletedProcess(args=cmd, returncode=0)
-
-        with (
-            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
-            patch("importlib.util.find_spec", return_value=True),
-        ):
-            script.format(check=True)
-
-        self.assertEqual(len(calls), 1)
-        self.assertIn("-m", calls[0])
-        self.assertIn("black", calls[0])
-        self.assertIn("--config", calls[0])
-        self.assertIn("--check", calls[0])
-
-    def test_format_no_py_files_warns(self) -> None:
-        """format() warns and returns when no .py files exist."""
-        script = self._make_script()
-        for f in script.nanvix_dir.glob("*.py"):
-            f.unlink()
-
-        with patch("nanvix_zutil.script.log") as mock_log:
-            script.format()
-
-        mock_log.warning.assert_called_once()
-        self.assertIn("nothing to format", mock_log.warning.call_args[0][0].lower())
-
-    def test_format_exits_on_failure(self) -> None:
-        """format() exits with EXIT_BUILD_FAILURE when black fails."""
-        script = self._make_script()
-        py_file = script.nanvix_dir / "z.py"
-        py_file.write_text("x = 1\n")
-
-        def fake_run(
-            args: tuple[str, ...], **kwargs: object
-        ) -> sp.CompletedProcess[str]:
-            cmd = list(args)
-            # helpers.run() passes check=True; emulate subprocess.run by
-            # raising CalledProcessError on non-zero exit.
-            raise sp.CalledProcessError(returncode=1, cmd=cmd)
-
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
-                patch("importlib.util.find_spec", return_value=True),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                script.format()
-            self.assertEqual(ctx.exception.code, 5)
-        finally:
-            log_mod.set_json_mode(False)
-
-
-class TestZScriptLintInAutoHooks(unittest.TestCase):
-    """format appears in AUTO_HOOKS and available_subcommands; lint is standalone."""
-
-    def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
-    def test_lint_not_in_auto_hooks(self) -> None:
-        self.assertNotIn("lint", ZScript.AUTO_HOOKS)
-
-    def test_format_in_auto_hooks(self) -> None:
-        self.assertIn("format", ZScript.AUTO_HOOKS)
-
-    def test_lint_not_available(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
-        self.assertNotIn("lint", script.available_subcommands())
-
-    def test_format_always_available(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
-        self.assertIn("format", script.available_subcommands())
 
 
 class TestZScriptSetupLocalSysroot(unittest.TestCase):


### PR DESCRIPTION
Per issue #193 and the CLI verb parity table in #189, format is now a standalone command and is no longer overridable on ZScript.

- New module src/nanvix_zutil/format_cmd.py: HELP, _build_parser(), format(), main().  Accepts --nanvix-dir PATH (default ".nanvix") and --check.
- Removed ZScript.format, removed "format" from AUTO_HOOKS, the format special-case in ZScript.main, cli.SUBCOMMANDS, cli.SUBCOMMAND_HELP, and the --check subparser argument.
- Wired into __main__.py alongside info/lint/resolve dispatch and updated the top-level parser description.
- Tests: deleted TestZScriptFormat, refactored TestZScriptLintInAutoHooks and TestLintFormatSubcommands to assert that format is no longer a consumer subcommand; added tests/test_format_cmd.py covering the previous behaviours plus --nanvix-dir / --check wiring.
- Docs: README and copilot-instructions no longer list format as a ZScript hook.

Closes #193