### PR TITLE
[PATHS 1] Use consistent path names

### DIFF
--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -24,12 +24,11 @@ from nanvix_zutil.config import (
     DEFAULT_MEMORY_SIZE,
 )
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+from nanvix_zutil.paths import buildroot as _default_buildroot_dir
 
 # ---------------------------------------------------------------------------
 # Default locations
 # ---------------------------------------------------------------------------
-
-_DEFAULT_BUILDROOT_DIR = Path(".nanvix") / "buildroot"
 
 
 # ---------------------------------------------------------------------------
@@ -242,7 +241,7 @@ class Buildroot:
         Returns:
             A :class:`Buildroot` pointing at *dest*.
         """
-        path = dest if dest is not None else _DEFAULT_BUILDROOT_DIR
+        path = dest if dest is not None else _default_buildroot_dir()
         (path / "lib").mkdir(parents=True, exist_ok=True)
         (path / "include").mkdir(parents=True, exist_ok=True)
         log.info(f"Buildroot at {path}")

--- a/src/nanvix_zutil/format_cmd.py
+++ b/src/nanvix_zutil/format_cmd.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_SUCCESS
 from nanvix_zutil.helpers import ensure_tool_installed, run
+from nanvix_zutil.paths import nanvix_root
 
 HELP: str = "Format <nanvix-dir>/*.py with black"
 """One-line description surfaced in ``nanvix-zutil --help``."""
@@ -46,15 +46,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def format(check: bool = False) -> None:
-    nanvix_dir = Path(sys.prefix).parent
-
-    py_files = sorted(nanvix_dir.glob("*.py"))
+    py_files = sorted(nanvix_root().glob("*.py"))
     if not py_files:
-        log.warning(f"No .py files found in {nanvix_dir} — nothing to format")
+        log.warning(f"No .py files found in {nanvix_root()} — nothing to format")
         return
     ensure_tool_installed("black")
     str_files = [str(f) for f in py_files]
-    black_cfg = str(nanvix_dir / "black.toml")
+    black_cfg = str(nanvix_root() / "black.toml")
     cmd = [sys.executable, "-m", "black", "--config", black_cfg]
     if check:
         cmd.append("--check")

--- a/src/nanvix_zutil/lint_cmd.py
+++ b/src/nanvix_zutil/lint_cmd.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_SUCCESS
 from nanvix_zutil.helpers import ensure_tool_installed, run
+from nanvix_zutil.paths import nanvix_root
 
 HELP: str = "Run linters (black --check + pyright) on <nanvix-dir>/*.py"
 """One-line description surfaced in ``nanvix-zutil --help``."""
@@ -42,17 +42,16 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def lint() -> None:
     # venv root is always bootstrapped at .nanvix/venv
-    nanvix_dir = Path(sys.prefix).parent
-    py_files = sorted(nanvix_dir.glob("*.py"))
+    py_files = sorted(nanvix_root().glob("*.py"))
     if not py_files:
-        log.warning(f"No .py files found in {nanvix_dir} — nothing to lint")
+        log.warning(f"No .py files found in {nanvix_root()} — nothing to lint")
         return
     for tool in ("black", "pyright"):
         ensure_tool_installed(tool)
 
     str_files = [str(f) for f in py_files]
-    black_cfg = str(nanvix_dir / "black.toml")
-    pyright_cfg = str(nanvix_dir / "pyrightconfig.json")
+    black_cfg = str(nanvix_root() / "black.toml")
+    pyright_cfg = str(nanvix_root() / "pyrightconfig.json")
     run(
         sys.executable,
         "-m",

--- a/src/nanvix_zutil/paths.py
+++ b/src/nanvix_zutil/paths.py
@@ -1,0 +1,106 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Lazily-resolved path constants for the Nanvix tooling.
+
+All paths are exposed as zero-arg functions so that resolution is
+deferred until first use.  This keeps ``import nanvix_zutil`` safe to
+run from a directory that does not contain a ``.nanvix/`` folder (e.g.
+under pytest collection from the repo root) and lets tests redirect
+every derived path by ``chdir``-ing and calling
+``nanvix_root.cache_clear()`` from a single fixture, instead of
+monkey-patching one symbol per consumer module.
+"""
+
+import functools
+from pathlib import Path
+
+import nanvix_zutil.log as log
+
+
+# -------------------------------
+#   Paths
+# -------------------------------
+@functools.cache
+def nanvix_root() -> Path:
+    """Path to the ``.nanvix`` directory.
+
+    Resolved by walking up the file tree from the current working
+    directory.  Result is cached; call ``nanvix_root.cache_clear()`` to
+    re-resolve (primarily for tests).
+    """
+    for p in (Path.cwd(), *Path.cwd().parents):
+        candidate = p / ".nanvix"
+        if candidate.is_dir():
+            return candidate
+    log.fatal("Could not find .nanvix directory.")
+
+
+def manifest_path() -> Path:
+    """Path to the cross-compilation manifest (``.nanvix/nanvix.toml``)."""
+    return nanvix_root() / "nanvix.toml"
+
+
+def z_py_path() -> Path:
+    """Path to the ZScript implementer module. (``.nanvix/z.py``)"""
+    return nanvix_root() / "z.py"
+
+
+def repo_root() -> Path:
+    """Path to the repository root (parent of ``.nanvix/``)."""
+    return nanvix_root().parent
+
+
+def out_dir() -> Path:
+    """Path to the build output folder (``.nanvix/out``)."""
+    return nanvix_root() / "out"
+
+
+def release_dir() -> Path:
+    """Path to built outputs to be distributed with ``release`` (``.nanvix/out/release``)."""
+    return out_dir() / "release"
+
+
+def dist_dir() -> Path:
+    """Path to the release output folder (``.nanvix/out/dist``)."""
+    return out_dir() / "dist"
+
+
+def lib_out() -> Path:
+    """Path to built library outputs to be bundled into the release
+    lib path. (``.nanvix/out/release/lib``)"""
+    return release_dir() / "lib"
+
+
+def include_out() -> Path:
+    """Path to built header outputs to be bundled into the release
+    include path. (``.nanvix/out/release/include``)"""
+    return release_dir() / "include"
+
+
+def bin_out() -> Path:
+    """Path to built binaries to be bundled into the release bin path.
+    (``.nanvix/out/release/bin``)"""
+    return release_dir() / "bin"
+
+
+def test_out() -> Path:
+    """Path to built test binaries and ramfs images to be bundled for
+    tests. These are _excluded_ from releases. (``.nanvix/out/test``)"""
+    return out_dir() / "test"
+
+
+def buildroot() -> Path:
+    """Path to the build root (``.nanvix/buildroot``).
+
+    Used to store items needed at build time.
+    """
+    return nanvix_root() / "buildroot"
+
+
+def sysroot() -> Path:
+    """Path to the sysroot (``.nanvix/sysroot``).
+
+    Used to store items needed at runtime.
+    """
+    return nanvix_root() / "sysroot"

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -17,15 +17,9 @@ import zipfile
 from pathlib import Path
 
 from nanvix_zutil import github, log
-from nanvix_zutil.config import Config
-from nanvix_zutil.config import DEFAULT_TARGET
+from nanvix_zutil.config import DEFAULT_TARGET, Config
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
-
-# ---------------------------------------------------------------------------
-# Default location
-# ---------------------------------------------------------------------------
-
-_DEFAULT_SYSROOT_DIR = Path(".nanvix") / "sysroot"
+from nanvix_zutil.paths import sysroot as _default_sysroot_dir
 
 # ---------------------------------------------------------------------------
 # Sysroot repository / tag constants
@@ -129,7 +123,7 @@ class Sysroot:
         Returns:
             A :class:`Sysroot` pointing at the extracted directory.
         """
-        sysroot_dir = dest if dest is not None else _DEFAULT_SYSROOT_DIR
+        sysroot_dir = dest if dest is not None else _default_sysroot_dir()
 
         # Fail early if the path exists but is not a directory.
         if sysroot_dir.exists() and not sysroot_dir.is_dir():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Pytest bootstrap for the nanvix_zutil test suite.
+
+The ``nanvix_zutil.paths`` module resolves ``.nanvix/`` by walking
+up from the current working directory and aborts the process when no
+such directory is found.  Since the test suite runs from the repo
+root (which has no ``.nanvix/``), every test would crash at collection
+time without an isolated working directory.
+
+This file installs a single autouse fixture that:
+
+* ``chdir``s into a fresh ``tmp_path`` containing an empty ``.nanvix/``,
+* clears ``nanvix_root``'s cache before and after the test so that the
+  next test (or any test that recreates ``.nanvix/`` content) gets a
+  fresh resolution,
+* leaves the original working directory restored by ``monkeypatch``.
+
+Tests that need a manifest or other artifacts under ``.nanvix/`` should
+write them into ``tmp_path / ".nanvix"`` themselves (or use the helpers
+in ``tests.testutils``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from nanvix_zutil.paths import nanvix_root
+
+
+@pytest.fixture(autouse=True)
+def _isolated_nanvix_root(  # pyright: ignore[reportUnusedFunction]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[Path, None, None]:
+    """Give every test a private ``.nanvix/`` directory in a fresh CWD."""
+    (tmp_path / ".nanvix").mkdir()
+    monkeypatch.chdir(tmp_path)
+    nanvix_root.cache_clear()
+    try:
+        yield tmp_path
+    finally:
+        nanvix_root.cache_clear()

--- a/tests/test_format_cmd.py
+++ b/tests/test_format_cmd.py
@@ -4,37 +4,21 @@
 """Tests for nanvix_zutil.format_cmd."""
 
 import subprocess as sp
-import tempfile
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
+from nanvix_zutil import paths
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 from nanvix_zutil.format_cmd import format, main
-
-
-def _patch_prefix(nanvix_dir: Path):
-    """Patch ``sys.prefix`` so ``format()`` resolves *nanvix_dir*.
-
-    ``format()`` computes ``nanvix_dir = Path(sys.prefix).parent`` on the
-    assumption that the active venv lives at ``<nanvix-dir>/venv``.  Tests
-    fake this by pointing ``sys.prefix`` at ``<nanvix-dir>/venv`` (the
-    path need not exist on disk).
-    """
-    return patch("nanvix_zutil.format_cmd.sys.prefix", str(nanvix_dir / "venv"))
 
 
 class TestFormatCmd(unittest.TestCase):
     """Behaviour of the standalone ``nanvix-zutil format`` command."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self.nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        self.nanvix_dir.mkdir()
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        # Autouse fixture provides a fresh CWD with .nanvix/.
+        self.nanvix_dir = paths.nanvix_root()
 
     def test_runs_black(self) -> None:
         """``format`` invokes black (without --check) on .nanvix/*.py."""
@@ -50,7 +34,6 @@ class TestFormatCmd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0)
 
         with (
-            _patch_prefix(self.nanvix_dir),
             patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
             patch("importlib.util.find_spec", return_value=True),
         ):
@@ -76,7 +59,6 @@ class TestFormatCmd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0)
 
         with (
-            _patch_prefix(self.nanvix_dir),
             patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
             patch("importlib.util.find_spec", return_value=True),
         ):
@@ -90,10 +72,7 @@ class TestFormatCmd(unittest.TestCase):
 
     def test_no_py_files_warns(self) -> None:
         """Warns and returns when no .py files exist."""
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("nanvix_zutil.format_cmd.log") as mock_log,
-        ):
+        with patch("nanvix_zutil.format_cmd.log") as mock_log:
             format()
 
         mock_log.warning.assert_called_once()
@@ -112,7 +91,6 @@ class TestFormatCmd(unittest.TestCase):
         log_mod.set_json_mode(True)
         try:
             with (
-                _patch_prefix(self.nanvix_dir),
                 patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
                 patch("importlib.util.find_spec", return_value=True),
                 self.assertRaises(SystemExit) as ctx,
@@ -129,7 +107,6 @@ class TestFormatCmd(unittest.TestCase):
         log_mod.set_json_mode(True)
         try:
             with (
-                _patch_prefix(self.nanvix_dir),
                 patch("importlib.util.find_spec", return_value=None),
                 self.assertRaises(SystemExit) as ctx,
             ):
@@ -144,60 +121,49 @@ class TestFormatCmdMain(unittest.TestCase):
 
     def test_main_no_py_files_exits_zero(self) -> None:
         """``main()`` exits 0 when the resolved nanvix dir has no .py files."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / ".nanvix"
-            nanvix_dir.mkdir()
-            with (
-                _patch_prefix(nanvix_dir),
-                patch("sys.argv", ["nanvix-zutil format"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            self.assertEqual(ctx.exception.code, 0)
+        with (
+            patch("sys.argv", ["nanvix-zutil format"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 0)
 
     def test_main_rejects_unknown_args(self) -> None:
-        """The parser no longer accepts ``--nanvix-dir`` (resolved via sys.prefix)."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / "custom-dir"
-            nanvix_dir.mkdir()
-            with (
-                _patch_prefix(nanvix_dir),
-                patch(
-                    "sys.argv",
-                    ["nanvix-zutil format", "--nanvix-dir", str(nanvix_dir)],
-                ),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            # argparse exits 2 on unrecognised args
-            self.assertEqual(ctx.exception.code, 2)
+        """The parser no longer accepts ``--nanvix-dir`` (resolved from CWD)."""
+        with (
+            patch(
+                "sys.argv",
+                ["nanvix-zutil format", "--nanvix-dir", "/tmp"],
+            ),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        # argparse exits 2 on unrecognised args
+        self.assertEqual(ctx.exception.code, 2)
 
     def test_main_check_flag(self) -> None:
         """``--check`` is propagated to format()."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / ".nanvix"
-            nanvix_dir.mkdir()
-            (nanvix_dir / "z.py").write_text("x = 1\n")
+        nanvix_dir = paths.nanvix_root()
+        (nanvix_dir / "z.py").write_text("x = 1\n")
 
-            calls: list[list[str]] = []
+        calls: list[list[str]] = []
 
-            def fake_run(
-                args: tuple[str, ...], **kwargs: object
-            ) -> sp.CompletedProcess[str]:
-                cmd = list(args)
-                calls.append(cmd)
-                return sp.CompletedProcess(args=cmd, returncode=0)
+        def fake_run(
+            args: tuple[str, ...], **kwargs: object
+        ) -> sp.CompletedProcess[str]:
+            cmd = list(args)
+            calls.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0)
 
-            with (
-                _patch_prefix(nanvix_dir),
-                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
-                patch("importlib.util.find_spec", return_value=True),
-                patch("sys.argv", ["nanvix-zutil format", "--check"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            self.assertEqual(ctx.exception.code, 0)
-            self.assertIn("--check", calls[0])
+        with (
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+            patch("sys.argv", ["nanvix-zutil format", "--check"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("--check", calls[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_lint_cmd.py
+++ b/tests/test_lint_cmd.py
@@ -4,37 +4,20 @@
 """Tests for nanvix_zutil.lint_cmd."""
 
 import subprocess as sp
-import tempfile
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
+from nanvix_zutil import paths
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 from nanvix_zutil.lint_cmd import lint, main
-
-
-def _patch_prefix(nanvix_dir: Path):
-    """Patch ``sys.prefix`` so ``lint()`` resolves *nanvix_dir*.
-
-    ``lint()`` computes ``nanvix_dir = Path(sys.prefix).parent`` on the
-    assumption that the active venv lives at ``<nanvix-dir>/venv``.  Tests
-    fake this by pointing ``sys.prefix`` at ``<nanvix-dir>/venv`` (the
-    path need not exist on disk).
-    """
-    return patch("nanvix_zutil.lint_cmd.sys.prefix", str(nanvix_dir / "venv"))
 
 
 class TestLintCmd(unittest.TestCase):
     """Behaviour of the standalone ``nanvix-zutil lint`` command."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self.nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        self.nanvix_dir.mkdir()
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        self.nanvix_dir = paths.nanvix_root()
 
     def test_runs_black_and_pyright(self) -> None:
         """``lint`` invokes black --check then pyright on .nanvix/*.py."""
@@ -50,7 +33,6 @@ class TestLintCmd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0)
 
         with (
-            _patch_prefix(self.nanvix_dir),
             patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
             patch("importlib.util.find_spec", return_value=True),
         ):
@@ -67,10 +49,7 @@ class TestLintCmd(unittest.TestCase):
 
     def test_no_py_files_warns(self) -> None:
         """Warns and returns when no .py files exist."""
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("nanvix_zutil.lint_cmd.log") as mock_log,
-        ):
+        with patch("nanvix_zutil.lint_cmd.log") as mock_log:
             lint()
 
         mock_log.warning.assert_called_once()
@@ -89,7 +68,6 @@ class TestLintCmd(unittest.TestCase):
         log_mod.set_json_mode(True)
         try:
             with (
-                _patch_prefix(self.nanvix_dir),
                 patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
                 patch("importlib.util.find_spec", return_value=True),
                 self.assertRaises(SystemExit) as ctx,
@@ -106,7 +84,6 @@ class TestLintCmd(unittest.TestCase):
         log_mod.set_json_mode(True)
         try:
             with (
-                _patch_prefix(self.nanvix_dir),
                 patch("importlib.util.find_spec", return_value=None),
                 self.assertRaises(SystemExit) as ctx,
             ):
@@ -121,32 +98,22 @@ class TestLintCmdMain(unittest.TestCase):
 
     def test_main_no_py_files_exits_zero(self) -> None:
         """``main()`` exits 0 when the resolved nanvix dir has no .py files."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / ".nanvix"
-            nanvix_dir.mkdir()
-            with (
-                _patch_prefix(nanvix_dir),
-                patch("sys.argv", ["nanvix-zutil lint"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            self.assertEqual(ctx.exception.code, 0)
+        with (
+            patch("sys.argv", ["nanvix-zutil lint"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 0)
 
     def test_main_rejects_unknown_args(self) -> None:
-        """The parser no longer accepts ``--nanvix-dir`` (resolved via sys.prefix)."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / "custom-dir"
-            nanvix_dir.mkdir()
-            with (
-                _patch_prefix(nanvix_dir),
-                patch(
-                    "sys.argv", ["nanvix-zutil lint", "--nanvix-dir", str(nanvix_dir)]
-                ),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            # argparse exits 2 on unrecognised args
-            self.assertEqual(ctx.exception.code, 2)
+        """The parser no longer accepts ``--nanvix-dir`` (resolved from CWD)."""
+        with (
+            patch("sys.argv", ["nanvix-zutil lint", "--nanvix-dir", "/tmp"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        # argparse exits 2 on unrecognised args
+        self.assertEqual(ctx.exception.code, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
First PR in a series to use path names consistently across the library. Ref: https://github.com/nanvix/zutils/issues/239

No breaking changes are introduced in this PR.

Adds `paths.py` to correctly resolve expected items across the library.