### PR TITLE
[PATHS 2] Drop Config nanvix_dir parameter

### DIFF
--- a/src/nanvix_zutil/config.py
+++ b/src/nanvix_zutil/config.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 from typing import cast, overload
+
+from nanvix_zutil.paths import nanvix_root
 
 # ---------------------------------------------------------------------------
 # Defaults
@@ -99,15 +100,13 @@ class Config:
             (e.g. ``"256mb"``).
     """
 
-    def __init__(self, nanvix_dir: Path) -> None:
+    def __init__(self) -> None:
         """Initialise configuration from environment and persisted state.
 
-        Args:
-            nanvix_dir: Path to the ``.nanvix/`` directory of the consumer
-                repository.
+        The ``.nanvix/`` directory is resolved lazily via
+        :func:`nanvix_zutil.paths.nanvix_root`.
         """
-        self._nanvix_dir = nanvix_dir
-        self._config_path = nanvix_dir / "env.json"
+        self._config_path = nanvix_root() / "env.json"
         self._data: dict[str, str] = {}
 
         # Seed with defaults.
@@ -205,7 +204,6 @@ class Config:
 
     def save(self) -> None:
         """Persist the current in-memory configuration to ``.nanvix/env.json``."""
-        self._nanvix_dir.mkdir(parents=True, exist_ok=True)
         with self._config_path.open("w", encoding="utf-8") as fh:
             json.dump(self._data, fh, indent=2)
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -195,7 +195,7 @@ class ZScript:
         """
         self.repo_root = repo_root.resolve()
         self.nanvix_dir = self.repo_root / ".nanvix"
-        self.config = Config(self.nanvix_dir)
+        self.config = Config()
         self.log = log
         self.targets: list[str] = []
         self.manifest: Manifest = load_manifest(self.nanvix_dir / "nanvix.toml")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,28 +5,20 @@
 
 import json
 import os
-import tempfile
 import unittest
-from pathlib import Path
 
 from nanvix_zutil.config import Config
+from nanvix_zutil.paths import nanvix_root
 
 
 class TestConfigDefaults(unittest.TestCase):
     """Config initialises with built-in defaults."""
 
-    def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
     def _make_config(self) -> Config:
         # Ensure env vars don't interfere with default tests.
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-        return Config(self._nanvix_dir)
+        return Config()
 
     def test_default_machine(self) -> None:
         cfg = self._make_config()
@@ -44,17 +36,12 @@ class TestConfigDefaults(unittest.TestCase):
 class TestConfigEnvOverride(unittest.TestCase):
     """Environment variables override defaults and persisted values."""
 
-    def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-
     def tearDown(self) -> None:
         os.environ.pop("NANVIX_MACHINE", None)
-        self._tmpdir.cleanup()
 
     def test_env_overrides_default(self) -> None:
         os.environ["NANVIX_MACHINE"] = "microvm"
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         self.assertEqual(cfg.machine, "microvm")
 
 
@@ -62,41 +49,32 @@ class TestConfigPersistence(unittest.TestCase):
     """Config.save() / load() round-trip."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
     def test_save_creates_file(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         cfg.save()
-        config_path = self._nanvix_dir / "env.json"
+        config_path = nanvix_root() / "env.json"
         self.assertTrue(config_path.exists())
 
     def test_round_trip(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         cfg.set("NANVIX_SYSROOT", "/some/path")
         cfg.save()
 
-        cfg2 = Config(self._nanvix_dir)
+        cfg2 = Config()
         self.assertEqual(cfg2.get("NANVIX_SYSROOT"), "/some/path")
 
     def test_load_ignores_malformed_json(self) -> None:
-        self._nanvix_dir.mkdir(parents=True, exist_ok=True)
-        (self._nanvix_dir / "env.json").write_text("not json", encoding="utf-8")
+        (nanvix_root() / "env.json").write_text("not json", encoding="utf-8")
         # Should not raise.
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         self.assertEqual(cfg.machine, "microvm")
 
     def test_load_ignores_non_dict_json(self) -> None:
-        self._nanvix_dir.mkdir(parents=True, exist_ok=True)
-        (self._nanvix_dir / "env.json").write_text(
-            json.dumps([1, 2, 3]), encoding="utf-8"
-        )
-        cfg = Config(self._nanvix_dir)
+        (nanvix_root() / "env.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        cfg = Config()
         self.assertEqual(cfg.machine, "microvm")
 
 
@@ -104,48 +82,43 @@ class TestConfigGetSet(unittest.TestCase):
     """Config.get() and Config.set() work correctly."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
     def test_get_missing_key_returns_default(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         self.assertIsNone(cfg.get("NONEXISTENT_KEY"))
         self.assertEqual(cfg.get("NONEXISTENT_KEY", "fallback"), "fallback")
 
     def test_get_with_str_default_returns_str(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         # When a str default is given, the return value must be str (not None).
         result = cfg.get("NONEXISTENT_KEY", "/opt/nanvix")
         self.assertIsInstance(result, str)
         self.assertEqual(result, "/opt/nanvix")
 
     def test_set_then_get(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         cfg.set("MY_KEY", "my_value")
         self.assertEqual(cfg.get("MY_KEY"), "my_value")
 
     def test_delete_removes_key(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         cfg.set("MY_KEY", "my_value")
         cfg.delete("MY_KEY")
         self.assertIsNone(cfg.get("MY_KEY"))
 
     def test_delete_missing_key_is_noop(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         cfg.delete("NONEXISTENT_KEY")  # should not raise
 
     def test_delete_persists_after_save(self) -> None:
-        cfg = Config(self._nanvix_dir)
+        cfg = Config()
         cfg.set("MY_KEY", "my_value")
         cfg.save()
         cfg.delete("MY_KEY")
         cfg.save()
-        cfg2 = Config(self._nanvix_dir)
+        cfg2 = Config()
         self.assertIsNone(cfg2.get("MY_KEY"))
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,6 +65,13 @@ class TestIntegrationLifecycle(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self._repo_root = Path(self._tmpdir.name)
         write_manifest(self._repo_root)
+        # Config and other path-based helpers resolve .nanvix/ from cwd.
+        # Override the autouse fixture's tmp_path so they find this test's repo.
+        self._orig_cwd = os.getcwd()
+        os.chdir(self._repo_root)
+        from nanvix_zutil.paths import nanvix_root
+
+        nanvix_root.cache_clear()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
         log_mod.set_json_mode(False)
@@ -73,6 +80,8 @@ class TestIntegrationLifecycle(unittest.TestCase):
         self.addCleanup(p.stop)
 
     def tearDown(self) -> None:
+        # Restore cwd before tmpdir cleanup so Windows can delete it.
+        os.chdir(self._orig_cwd)
         self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -99,10 +99,18 @@ class TestZScriptAutoSetup(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         write_manifest(Path(self._tmpdir.name))
+        # Config resolves .nanvix/ from cwd; override the autouse fixture.
+        self._orig_cwd = os.getcwd()
+        os.chdir(self._tmpdir.name)
+        from nanvix_zutil.paths import nanvix_root
+
+        nanvix_root.cache_clear()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def tearDown(self) -> None:
+        # Restore cwd before tmpdir cleanup so Windows can delete it.
+        os.chdir(self._orig_cwd)
         self._tmpdir.cleanup()
 
     def test_setup_downloads_sysroot(self) -> None:

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
-from nanvix_zutil.config import Config, DEFAULT_TARGET
+from nanvix_zutil.config import DEFAULT_TARGET, Config
 from nanvix_zutil.sysroot import WINDOWS_HOST_BINARIES, Sysroot
 
 
@@ -62,12 +62,10 @@ class TestSysrootDownloadSkipsIfExists(unittest.TestCase):
         log_mod.set_json_mode(False)
 
     def test_skips_download_when_dest_exists(self) -> None:
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        nanvix_dir.mkdir()
         dest = Path(self._tmpdir.name) / "sysroot"
         dest.mkdir()
 
-        config = Config(nanvix_dir)
+        config = Config()
         config.set("sysroot_tag", "v1.0.0")
         config.save()
 
@@ -105,14 +103,12 @@ class TestSysrootDownloadStaleDetection(unittest.TestCase):
 
     def test_redownloads_when_tag_mismatches(self) -> None:
         """If sysroot exists but cached tag != requested tag, re-download."""
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        nanvix_dir.mkdir()
         dest = Path(self._tmpdir.name) / "sysroot"
         dest.mkdir()
         (dest / "lib").mkdir()
         (dest / "lib" / "old.a").write_bytes(b"old")
 
-        config = Config(nanvix_dir)
+        config = Config()
         config.set("sysroot_tag", "v1.0.0")
         config.save()
 
@@ -145,12 +141,10 @@ class TestSysrootDownloadStaleDetection(unittest.TestCase):
 
     def test_skips_download_when_tag_matches(self) -> None:
         """If sysroot exists and cached tag == requested tag, skip download."""
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        nanvix_dir.mkdir()
         dest = Path(self._tmpdir.name) / "sysroot"
         dest.mkdir()
 
-        config = Config(nanvix_dir)
+        config = Config()
         config.set("sysroot_tag", "v1.0.0")
         config.save()
 
@@ -175,12 +169,10 @@ class TestSysrootDownloadStaleDetection(unittest.TestCase):
 
     def test_skips_when_bare_semver_resolves_to_cached_v_tag(self) -> None:
         """Requesting '1.0.0' that resolves to 'v1.0.0' should cache-hit."""
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        nanvix_dir.mkdir()
         dest = Path(self._tmpdir.name) / "sysroot"
         dest.mkdir()
 
-        config = Config(nanvix_dir)
+        config = Config()
         config.set("sysroot_tag", "v1.0.0")
         config.save()
 
@@ -205,12 +197,10 @@ class TestSysrootDownloadStaleDetection(unittest.TestCase):
 
     def test_skips_when_latest_resolves_to_cached_tag(self) -> None:
         """Requesting 'latest' that resolves to the cached tag should cache-hit."""
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        nanvix_dir.mkdir()
         dest = Path(self._tmpdir.name) / "sysroot"
         dest.mkdir()
 
-        config = Config(nanvix_dir)
+        config = Config()
         config.set("sysroot_tag", "v0.12.410")
         config.save()
 
@@ -249,15 +239,13 @@ class TestWindowsBinariesStaleDetection(unittest.TestCase):
         """If Windows binaries exist but persisted tag differs, re-download."""
         import zipfile
 
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        nanvix_dir.mkdir()
         sysroot_dir = Path(self._tmpdir.name) / "sysroot"
         bin_dir = sysroot_dir / "bin"
         bin_dir.mkdir(parents=True)
         for b in WINDOWS_HOST_BINARIES:
             (bin_dir / b).write_bytes(b"old-binary")
 
-        config = Config(nanvix_dir)
+        config = Config()
         config.set("windows_binaries_tag", "v1.0.0")
         config.save()
 


### PR DESCRIPTION
**Stacked on #240**

Step 2 for #239 

`Config.__init__` now takes no arguments, instead resolving based on `nanvix_root()`.

test_config and test_sysroot are updated to construct Config()
no-args under the autouse conftest fixture's isolated .nanvix/.

TestZScriptAutoSetup (test_script.py) and TestIntegrationLifecycle
(test_integration.py) construct ZScript(other_tmpdir) at a path that
differs from the conftest fixture's cwd; they now chdir into the
script's tmpdir and clear the nanvix_root cache in setUp so Config
resolves to the test's .nanvix/.  These workarounds disappear once
ZScript stops carrying repo_root/nanvix_dir itself.