### PR TITLE
[PATHS 3] Manifest paths + remove --manifest flag

### DIFF
--- a/examples/lib-hello/.nanvix/.gitignore
+++ b/examples/lib-hello/.nanvix/.gitignore
@@ -1,7 +1,9 @@
+__pycache__/
 venv/
 cache/
 sysroot/
 buildroot/
+.yamllint.yml
+black.toml
 env.json
-nanvix.lock
-__pycache__/
+pyrightconfig.json

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -27,13 +27,13 @@ import os
 import re
 import tomllib
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import cast
 
 from nanvix_zutil import log
-from nanvix_zutil.utils import SEMVER_RE
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_MISSING_DEP
+from nanvix_zutil.paths import manifest_path
+from nanvix_zutil.utils import SEMVER_RE
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -91,7 +91,7 @@ def is_local_path(value: str) -> bool:
     return _LOCAL_PATH_RE.match(value) is not None
 
 
-def _validate_version_string(raw: str, context: str, path: Path) -> str:
+def _validate_version_string(raw: str, context: str) -> str:
     """Validate a plain version string.
 
     The string must be non-empty and contain no whitespace.  The value
@@ -100,14 +100,13 @@ def _validate_version_string(raw: str, context: str, path: Path) -> str:
     Args:
         raw: Raw version string.
         context: Human-readable label for error messages.
-        path: Manifest file path (for error messages).
 
     Returns:
         The validated version string (unchanged).
     """
     if not raw or any(ch.isspace() for ch in raw):
         log.fatal(
-            f"{path}: invalid version for '{context}': '{raw}'",
+            f"{manifest_path()}: invalid version for '{context}': '{raw}'",
             code=EXIT_INVALID_ARGS,
             hint=f"Version for {context} must be a non-empty string"
             " without whitespace.",
@@ -115,33 +114,32 @@ def _validate_version_string(raw: str, context: str, path: Path) -> str:
 
     if any(ch in _URL_UNSAFE for ch in raw):
         log.fatal(
-            f"{path}: version for '{context}' contains URL-unsafe characters: '{raw}'",
+            f"{manifest_path()}: version for '{context}' contains URL-unsafe characters: '{raw}'",
             code=EXIT_INVALID_ARGS,
             hint="Version strings must not contain '/', '\\\\', '#', '?', or '%'.",
         )
 
     if raw == "latest":
         log.warning(
-            f"{path}: '{context}' is set to 'latest' — this is"
+            f"{manifest_path()}: '{context}' is set to 'latest' — this is"
             " unlikely to match an actual release"
         )
 
     return raw
 
 
-def _parse_nanvix_version(raw: object, path: Path) -> Ref:
+def _parse_nanvix_version(raw: object) -> Ref:
     """Parse ``nanvix-version``: semver ``X.Y.Z`` or ``"latest"``.
 
     Args:
         raw: The raw TOML value for ``nanvix-version``.
-        path: Manifest file path (for error messages).
 
     Returns:
         A :class:`Ref` with kind :attr:`RefKind.TAG`.
     """
     if not isinstance(raw, str):
         log.fatal(
-            f"{path}: 'nanvix-version' must be a plain string"
+            f"{manifest_path()}: 'nanvix-version' must be a plain string"
             f" (got {type(raw).__name__})",
             code=EXIT_INVALID_ARGS,
             hint="Use 'nanvix-version = \"X.Y.Z\"' (semver) or"
@@ -152,7 +150,7 @@ def _parse_nanvix_version(raw: object, path: Path) -> Ref:
         return Ref(kind=RefKind.TAG, value="latest")
     if not SEMVER_RE.match(raw):
         log.fatal(
-            f"{path}: 'nanvix-version' must be semver X.Y.Z or 'latest' (got '{raw}')",
+            f"{manifest_path()}: 'nanvix-version' must be semver X.Y.Z or 'latest' (got '{raw}')",
             code=EXIT_INVALID_ARGS,
             hint="Use a version like 'nanvix-version = \"0.12.257\"'"
             " or 'nanvix-version = \"latest\"'.",
@@ -160,7 +158,7 @@ def _parse_nanvix_version(raw: object, path: Path) -> Ref:
     return Ref(kind=RefKind.TAG, value=raw)
 
 
-def _parse_version_field(raw: object, context: str, path: Path) -> Ref:
+def _parse_version_field(raw: object, context: str) -> Ref:
     """Parse a dependency version field.
 
     Accepts:
@@ -175,7 +173,7 @@ def _parse_version_field(raw: object, context: str, path: Path) -> Ref:
         A :class:`Ref` with the appropriate :class:`RefKind`.
     """
     if isinstance(raw, str):
-        value = _validate_version_string(raw, context, path)
+        value = _validate_version_string(raw, context)
         return Ref(kind=RefKind.VERSION, value=value)
 
     if isinstance(raw, dict):
@@ -184,7 +182,7 @@ def _parse_version_field(raw: object, context: str, path: Path) -> Ref:
         found = _SPECIFIER_KEYS & raw_dict.keys()
         if len(found) > 1:
             log.fatal(
-                f"{path}: table for '{context}' has conflicting keys:"
+                f"{manifest_path()}: table for '{context}' has conflicting keys:"
                 f" {', '.join(sorted(found))}",
                 code=EXIT_INVALID_ARGS,
                 hint="Use exactly one of 'version', 'tag', 'commitish', or 'id'.",
@@ -194,43 +192,43 @@ def _parse_version_field(raw: object, context: str, path: Path) -> Ref:
             ver_val: object = raw_dict["version"]
             if not isinstance(ver_val, str):
                 log.fatal(
-                    f"{path}: 'version' value for '{context}' must be a string",
+                    f"{manifest_path()}: 'version' value for '{context}' must be a string",
                     code=EXIT_INVALID_ARGS,
                 )
-            value = _validate_version_string(ver_val, f"{context}.version", path)
+            value = _validate_version_string(ver_val, f"{context}.version")
             return Ref(kind=RefKind.VERSION, value=value)
 
         if "tag" in raw_dict:
             tag_val: object = raw_dict["tag"]
             if not isinstance(tag_val, str):
                 log.fatal(
-                    f"{path}: 'tag' value for '{context}' must be a string",
+                    f"{manifest_path()}: 'tag' value for '{context}' must be a string",
                     code=EXIT_INVALID_ARGS,
                 )
-            value = _validate_version_string(tag_val, f"{context}.tag", path)
+            value = _validate_version_string(tag_val, f"{context}.tag")
             return Ref(kind=RefKind.TAG, value=value)
 
         if "commitish" in raw_dict:
             com_val: object = raw_dict["commitish"]
             if not isinstance(com_val, str):
                 log.fatal(
-                    f"{path}: 'commitish' value for '{context}' must be a string",
+                    f"{manifest_path()}: 'commitish' value for '{context}' must be a string",
                     code=EXIT_INVALID_ARGS,
                 )
-            value = _validate_version_string(com_val, f"{context}.commitish", path)
+            value = _validate_version_string(com_val, f"{context}.commitish")
             return Ref(kind=RefKind.COMMITISH, value=value)
 
         if "id" in raw_dict:
             id_val: object = raw_dict["id"]
             if not isinstance(id_val, int):
                 log.fatal(
-                    f"{path}: 'id' value for '{context}' must be an integer",
+                    f"{manifest_path()}: 'id' value for '{context}' must be an integer",
                     code=EXIT_INVALID_ARGS,
                 )
             return Ref(kind=RefKind.ID, value=id_val)
 
         log.fatal(
-            f"{path}: table for '{context}' must contain one of"
+            f"{manifest_path()}: table for '{context}' must contain one of"
             " 'version', 'tag', 'commitish', or 'id'",
             code=EXIT_INVALID_ARGS,
             hint=f"Use '{context} = {{ version = \"1.2.3\" }}',"
@@ -240,7 +238,7 @@ def _parse_version_field(raw: object, context: str, path: Path) -> Ref:
         )
 
     log.fatal(
-        f"{path}: value for '{context}' must be a string or a table",
+        f"{manifest_path()}: value for '{context}' must be a string or a table",
         code=EXIT_INVALID_ARGS,
         hint=f"Use '{context} = \"1.2.3\"' or '{context} = {{ version = \"1.2.3\" }}'.",
     )
@@ -248,7 +246,6 @@ def _parse_version_field(raw: object, context: str, path: Path) -> Ref:
 
 def _parse_dependencies(
     section: dict[str, object],
-    path: Path,
     section_name: str,
 ) -> list[Dependency]:
     """Parse a ``[dependencies]`` or ``[system-dependencies]`` table.
@@ -258,7 +255,7 @@ def _parse_dependencies(
     """
     deps: list[Dependency] = []
     for name, raw_value in section.items():
-        ref = _parse_version_field(raw_value, f"{section_name}.{name}", path)
+        ref = _parse_version_field(raw_value, f"{section_name}.{name}")
 
         # Manifest values must not include the nanvix suffix — it is
         # derived automatically from nanvix-version.
@@ -268,7 +265,7 @@ def _parse_dependencies(
             and "-nanvix-" in ref.value
         ):
             log.fatal(
-                f"{path}: dependency '{name}' must not include the nanvix"
+                f"{manifest_path()}: dependency '{name}' must not include the nanvix"
                 f" version in its ref (got '{ref.value}')",
                 code=EXIT_INVALID_ARGS,
                 hint=f"Use '{name} = \"{ref.value.split('-nanvix-')[0]}\"'"
@@ -295,7 +292,7 @@ def _parse_dependencies(
 # ---------------------------------------------------------------------------
 
 
-def load_manifest(path: Path) -> Manifest:
+def load_manifest() -> Manifest:
     """Parse a ``nanvix.toml`` manifest file.
 
     Reads the TOML file, validates required keys, enforces semver for
@@ -306,9 +303,6 @@ def load_manifest(path: Path) -> Manifest:
     Environment variables ``NANVIX_VERSION`` (sysroot) and
     ``NANVIX_VERSION_<NAME>`` (per dependency) override manifest values.
 
-    Args:
-        path: Path to the ``nanvix.toml`` file.
-
     Returns:
         A :class:`Manifest` instance.
 
@@ -316,19 +310,19 @@ def load_manifest(path: Path) -> Manifest:
         SystemExit: With exit code ``3`` if the file does not exist, or
             exit code ``2`` if the manifest is malformed.
     """
-    if not path.is_file():
+    if not manifest_path().is_file():
         log.fatal(
-            f"Required file not found: {path}",
+            f"Required file not found: {manifest_path()}",
             code=EXIT_MISSING_DEP,
             hint="Create a nanvix.toml in the .nanvix/ directory.",
         )
 
-    raw_bytes = path.read_bytes()
+    raw_bytes = manifest_path().read_bytes()
     try:
         data: dict[str, object] = tomllib.loads(raw_bytes.decode("utf-8"))
     except tomllib.TOMLDecodeError as exc:
         log.fatal(
-            f"{path}: invalid TOML syntax: {exc}",
+            f"{manifest_path()}: invalid TOML syntax: {exc}",
             code=EXIT_INVALID_ARGS,
         )
 
@@ -336,7 +330,7 @@ def load_manifest(path: Path) -> Manifest:
     package: object = data.get("package")
     if not isinstance(package, dict):
         log.fatal(
-            f"{path}: missing required [package] section",
+            f"{manifest_path()}: missing required [package] section",
             code=EXIT_INVALID_ARGS,
             hint="Add a [package] section with 'name', 'version',"
             " and 'nanvix-version'.",
@@ -347,7 +341,7 @@ def load_manifest(path: Path) -> Manifest:
     pkg_name: object = pkg.get("name")
     if not isinstance(pkg_name, str) or not pkg_name:
         log.fatal(
-            f"{path}: missing or invalid [package] key 'name'",
+            f"{manifest_path()}: missing or invalid [package] key 'name'",
             code=EXIT_INVALID_ARGS,
             hint="Add 'name = \"...\"' under [package].",
         )
@@ -355,7 +349,7 @@ def load_manifest(path: Path) -> Manifest:
     pkg_version: object = pkg.get("version")
     if not isinstance(pkg_version, str) or not pkg_version:
         log.fatal(
-            f"{path}: missing or invalid [package] key 'version'",
+            f"{manifest_path()}: missing or invalid [package] key 'version'",
             code=EXIT_INVALID_ARGS,
             hint="Add 'version = \"...\"' under [package].",
         )
@@ -363,12 +357,12 @@ def load_manifest(path: Path) -> Manifest:
     raw_nanvix_version: object = pkg.get("nanvix-version")
     if raw_nanvix_version is None:
         log.fatal(
-            f"{path}: missing or invalid [package] key 'nanvix-version'",
+            f"{manifest_path()}: missing or invalid [package] key 'nanvix-version'",
             code=EXIT_INVALID_ARGS,
             hint="Add 'nanvix-version = \"...\"' under [package].",
         )
 
-    sysroot_ref = _parse_nanvix_version(raw_nanvix_version, path)
+    sysroot_ref = _parse_nanvix_version(raw_nanvix_version)
     env_sysroot = os.environ.get("NANVIX_VERSION")
     if env_sysroot is not None:
         # NOTE: NANVIX_VERSION intentionally bypasses semver validation.
@@ -383,22 +377,22 @@ def load_manifest(path: Path) -> Manifest:
     deps_raw: object = data.get("dependencies", {})
     if not isinstance(deps_raw, dict):
         log.fatal(
-            f"{path}: [dependencies] must be a TOML table",
+            f"{manifest_path()}: [dependencies] must be a TOML table",
             code=EXIT_INVALID_ARGS,
         )
     dependencies = _parse_dependencies(
-        cast("dict[str, object]", deps_raw), path, "dependencies"
+        cast("dict[str, object]", deps_raw), "dependencies"
     )
 
     # --- [system-dependencies] (optional) ---
     sys_deps_raw: object = data.get("system-dependencies", {})
     if not isinstance(sys_deps_raw, dict):
         log.fatal(
-            f"{path}: [system-dependencies] must be a TOML table",
+            f"{manifest_path()}: [system-dependencies] must be a TOML table",
             code=EXIT_INVALID_ARGS,
         )
     system_dependencies = _parse_dependencies(
-        cast("dict[str, object]", sys_deps_raw), path, "system-dependencies"
+        cast("dict[str, object]", sys_deps_raw), "system-dependencies"
     )
 
     # Auto-suffix VERSION refs with the nanvix sysroot version.

--- a/src/nanvix_zutil/paths.py
+++ b/src/nanvix_zutil/paths.py
@@ -16,6 +16,7 @@ import functools
 from pathlib import Path
 
 import nanvix_zutil.log as log
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 
 
 # -------------------------------
@@ -33,7 +34,11 @@ def nanvix_root() -> Path:
         candidate = p / ".nanvix"
         if candidate.is_dir():
             return candidate
-    log.fatal("Could not find .nanvix directory.")
+    log.fatal(
+        "Could not find .nanvix directory.",
+        code=EXIT_MISSING_DEP,
+        hint="Run this command from a Nanvix consumer repo root.",
+    )
 
 
 def manifest_path() -> Path:

--- a/src/nanvix_zutil/resolve_cmd.py
+++ b/src/nanvix_zutil/resolve_cmd.py
@@ -9,11 +9,11 @@ import argparse
 import json
 import os
 import sys
-from pathlib import Path
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP, EXIT_SUCCESS
 from nanvix_zutil.manifest import load_manifest
+from nanvix_zutil.paths import manifest_path
 from nanvix_zutil.resolver import resolve
 
 HELP: str = "Resolve manifest and emit CI-ready metadata"
@@ -33,12 +33,6 @@ def _build_parser() -> argparse.ArgumentParser:
             "metadata as key=value lines (suitable for $GITHUB_OUTPUT) "
             "or JSON."
         ),
-    )
-    parser.add_argument(
-        "--manifest",
-        default=".nanvix/nanvix.toml",
-        metavar="PATH",
-        help="Path to the nanvix.toml manifest (default: .nanvix/nanvix.toml)",
     )
     parser.add_argument(
         "--json",
@@ -67,12 +61,11 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    manifest_path = Path(args.manifest)
-    if not manifest_path.exists():
+    if not manifest_path().exists():
         log.fatal(
-            f"Manifest not found: {manifest_path}",
+            f"Manifest not found: {manifest_path()}",
             code=EXIT_MISSING_DEP,
-            hint="Run from a Nanvix consumer repo root, or pass --manifest.",
+            hint="Run from a Nanvix consumer repo root.",
         )
 
     gh_token: str | None = args.gh_token or os.environ.get("GH_TOKEN")
@@ -80,12 +73,11 @@ def main() -> None:
     if args.json:
         log.set_json_mode(True)
 
-    manifest = load_manifest(manifest_path)
+    manifest = load_manifest()
     lockfile = resolve(
         manifest,
         gh_token=gh_token,
         shallow=args.shallow,
-        manifest_path=manifest_path,
     )
 
     sysroot = next(

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 import shutil
 import tempfile
 from collections import deque
-from dataclasses import dataclass, replace as _dc_replace
+from dataclasses import dataclass
+from dataclasses import replace as _dc_replace
 from pathlib import Path
 from typing import cast
 
@@ -39,6 +40,7 @@ from nanvix_zutil.lockfile import (
     get_zutil_version,
 )
 from nanvix_zutil.manifest import Manifest
+from nanvix_zutil.paths import manifest_path
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -203,7 +205,6 @@ def resolve(
     cache_dir: Path | None = None,
     *,
     shallow: bool = False,
-    manifest_path: Path | None = None,
 ) -> Lockfile:
     """Resolve a manifest into a fully pinned lockfile.
 
@@ -226,8 +227,6 @@ def resolve(
             to a ``tempfile.mkdtemp()``; cleaned up on completion.
         shallow: When ``True``, skip transitive dependency discovery.
             Resolves only the sysroot and direct dependencies.
-        manifest_path: Path to the ``nanvix.toml`` file for hash
-            computation.  Defaults to ``.nanvix/nanvix.toml``.
 
     Returns:
         The fully resolved :class:`Lockfile`.
@@ -238,10 +237,9 @@ def resolve(
     """
     tmp_dir = Path(cache_dir) if cache_dir else Path(tempfile.mkdtemp())
     owns_tmp = cache_dir is None
-    m_path = manifest_path or Path(".nanvix") / "nanvix.toml"
 
     try:
-        return _resolve_inner(manifest, gh_token, tmp_dir, m_path, shallow=shallow)
+        return _resolve_inner(manifest, gh_token, tmp_dir, shallow=shallow)
     finally:
         if owns_tmp and tmp_dir.exists():
             shutil.rmtree(tmp_dir, ignore_errors=True)
@@ -251,7 +249,6 @@ def _resolve_inner(
     manifest: Manifest,
     gh_token: str | None,
     cache_dir: Path,
-    manifest_path: Path,
     *,
     shallow: bool,
 ) -> Lockfile:
@@ -530,7 +527,7 @@ def _resolve_inner(
         pkg.assets = _collect_assets(releases[name])
 
     # 6. Assemble lockfile
-    manifest_hash = compute_manifest_hash(manifest_path)
+    manifest_hash = compute_manifest_hash(manifest_path())
 
     metadata = LockfileMetadata(
         manifest_hash=manifest_hash,
@@ -540,7 +537,7 @@ def _resolve_inner(
     return Lockfile(metadata=metadata, packages=list(resolved.values()))
 
 
-def is_stale(lockfile: Lockfile, manifest_path: Path) -> bool:
+def is_stale(lockfile: Lockfile) -> bool:
     """Check whether a lockfile is stale relative to its manifest.
 
     Compares the ``manifest_hash`` stored in the lockfile metadata
@@ -553,10 +550,9 @@ def is_stale(lockfile: Lockfile, manifest_path: Path) -> bool:
 
     Args:
         lockfile: The lockfile to check.
-        manifest_path: Path to the ``nanvix.toml`` file.
 
     Returns:
         ``True`` if the lockfile is stale (hashes differ).
     """
-    current_hash = compute_manifest_hash(manifest_path)
+    current_hash = compute_manifest_hash(manifest_path())
     return lockfile.metadata.manifest_hash != current_hash

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -198,7 +198,7 @@ class ZScript:
         self.config = Config()
         self.log = log
         self.targets: list[str] = []
-        self.manifest: Manifest = load_manifest(self.nanvix_dir / "nanvix.toml")
+        self.manifest: Manifest = load_manifest()
         self.sysroot: Sysroot | None = None
         self.buildroot: Buildroot | None = None
         self.docker: DockerConfig | None = None
@@ -552,7 +552,6 @@ class ZScript:
             self.manifest,
             gh_token=self.config.get(CFG_GH_TOKEN),
             shallow=shallow,
-            manifest_path=self.nanvix_dir / "nanvix.toml",
         )
         lock_path = self.nanvix_dir / "nanvix.lock"
         write_lockfile(lockfile, lock_path)
@@ -565,7 +564,6 @@ class ZScript:
         ``EXIT_INVALID_ARGS`` if it is stale relative to ``nanvix.toml``.
         """
         lock_path = self.nanvix_dir / "nanvix.lock"
-        manifest_path = self.nanvix_dir / "nanvix.toml"
         lockfile = read_lockfile(lock_path)
 
         # Warn when "latest" lockfile may silently be stale.
@@ -577,7 +575,7 @@ class ZScript:
                 " releases."
             )
 
-        if is_stale(lockfile, manifest_path):
+        if is_stale(lockfile):
             log.fatal(
                 "Lockfile is stale — nanvix.toml has changed since it was generated.",
                 code=EXIT_INVALID_ARGS,

--- a/tests/test_cli_lock.py
+++ b/tests/test_cli_lock.py
@@ -22,7 +22,7 @@ from nanvix_zutil.lockfile import (
     write_lockfile,
 )
 from nanvix_zutil.script import ZScript
-from tests.testutils import write_manifest
+from tests.testutils import chdir_to, write_manifest
 
 
 def _make_mock_lockfile(manifest_path: Path) -> Lockfile:
@@ -89,13 +89,13 @@ class TestLockMethod(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         log_mod.set_json_mode(True)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     @patch("nanvix_zutil.script.resolve")
@@ -129,13 +129,13 @@ class TestLockCheck(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         log_mod.set_json_mode(True)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_lock_check_exits_0_when_fresh(self) -> None:

--- a/tests/test_distclean_cmd.py
+++ b/tests/test_distclean_cmd.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from nanvix_zutil.distclean_cmd import _run_consumer_clean, distclean, main
 
-from tests.testutils import write_manifest
+from tests.testutils import chdir_to, write_manifest
 
 
 def _patch_prefix(nanvix_dir: Path):
@@ -34,9 +34,6 @@ class TestDistcleanFunction(unittest.TestCase):
         self.nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
         self.nanvix_dir.mkdir()
         (self.nanvix_dir / "nanvix.toml").write_text("")
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def test_removes_sysroot(self) -> None:
         sysroot = self.nanvix_dir / "sysroot"
@@ -210,12 +207,10 @@ class TestRunConsumerClean(unittest.TestCase):
         self.repo_root = Path(self._tmpdir.name)
         self.nanvix_dir = self.repo_root / ".nanvix"
         self.nanvix_dir.mkdir()
-        write_manifest(self.repo_root)
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         # Stamp file the consumer clean() can touch so we can assert it ran.
         self.stamp = self.repo_root / "clean.stamp"
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def _write_z_py(self, body: str) -> None:
         """Write a .nanvix/z.py whose ZScript subclass body is *body*."""
@@ -299,31 +294,31 @@ class TestMainIntegration(unittest.TestCase):
     """main() runs consumer clean() then removes artifacts in one call."""
 
     def test_main_calls_clean_then_distcleans(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            repo_root = Path(tmpdir)
-            nanvix_dir = repo_root / ".nanvix"
-            nanvix_dir.mkdir()
-            write_manifest(repo_root)
-            stamp = repo_root / "clean.stamp"
-            sysroot = nanvix_dir / "sysroot"
-            sysroot.mkdir()
-            (nanvix_dir / "z.py").write_text(
-                "from nanvix_zutil.script import ZScript\n"
-                "\n"
-                "class MyZ(ZScript):\n"
-                "    def clean(self) -> None:\n"
-                f"        open(r'{stamp}', 'w').close()\n"
-            )
+        tmpdir = tempfile.TemporaryDirectory()
+        chdir_to(self, tmpdir)
+        repo_root = Path(tmpdir.name)
+        nanvix_dir = repo_root / ".nanvix"
+        write_manifest()
+        stamp = repo_root / "clean.stamp"
+        sysroot = nanvix_dir / "sysroot"
+        sysroot.mkdir()
+        (nanvix_dir / "z.py").write_text(
+            "from nanvix_zutil.script import ZScript\n"
+            "\n"
+            "class MyZ(ZScript):\n"
+            "    def clean(self) -> None:\n"
+            f"        open(r'{stamp}', 'w').close()\n"
+        )
 
-            with (
-                _patch_prefix(nanvix_dir),
-                patch("sys.argv", ["nanvix-zutil distclean"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            self.assertEqual(ctx.exception.code, 0)
-            self.assertTrue(stamp.exists(), "consumer clean() was not invoked")
-            self.assertFalse(sysroot.exists(), "sysroot was not removed")
+        with (
+            _patch_prefix(nanvix_dir),
+            patch("sys.argv", ["nanvix-zutil distclean"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertTrue(stamp.exists(), "consumer clean() was not invoked")
+        self.assertFalse(sysroot.exists(), "sysroot was not removed")
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 import nanvix_zutil.log as log_mod
 from nanvix_zutil import ZScript
 from nanvix_zutil.helpers import run
-from tests.testutils import write_manifest
+from tests.testutils import chdir_to, write_manifest
 
 # ---------------------------------------------------------------------------
 # Mock consumer
@@ -64,14 +64,8 @@ class TestIntegrationLifecycle(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._repo_root = Path(self._tmpdir.name)
-        write_manifest(self._repo_root)
-        # Config and other path-based helpers resolve .nanvix/ from cwd.
-        # Override the autouse fixture's tmp_path so they find this test's repo.
-        self._orig_cwd = os.getcwd()
-        os.chdir(self._repo_root)
-        from nanvix_zutil.paths import nanvix_root
-
-        nanvix_root.cache_clear()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
         log_mod.set_json_mode(False)
@@ -80,9 +74,6 @@ class TestIntegrationLifecycle(unittest.TestCase):
         self.addCleanup(p.stop)
 
     def tearDown(self) -> None:
-        # Restore cwd before tmpdir cleanup so Windows can delete it.
-        os.chdir(self._orig_cwd)
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def _run_main(
@@ -266,13 +257,13 @@ class TestIntegrationConfigPersistence(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._repo_root = Path(self._tmpdir.name)
-        write_manifest(self._repo_root)
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_config_save_and_reload(self) -> None:
@@ -291,11 +282,11 @@ class TestIntegrationRunSubprocess(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._repo_root = Path(self._tmpdir.name)
-        write_manifest(self._repo_root)
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_run_echo_succeeds(self) -> None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -4,12 +4,11 @@
 """Tests for nanvix_zutil.manifest."""
 
 import os
-import tempfile
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 import nanvix_zutil.log as log_mod
+from nanvix_zutil import paths
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.manifest import load_manifest, is_local_path
 
@@ -20,18 +19,14 @@ class TestLoadManifestFileNotFound(unittest.TestCase):
     """load_manifest exits 3 when the file does not exist."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_missing_file_exits_3(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
-
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 3)
 
@@ -40,18 +35,16 @@ class TestLoadManifestBasic(unittest.TestCase):
     """load_manifest parses a well-formed nanvix.toml."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_single_dependency_commitish(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ commitish = "b7a6a3c" }'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.name, "myapp")
         self.assertEqual(m.version, "1.0.0")
@@ -64,10 +57,10 @@ class TestLoadManifestBasic(unittest.TestCase):
         self.assertEqual(m.dependencies[0].ref.value, "b7a6a3c")
 
     def test_single_dependency_version_string(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="1.2.3", deps={"zlib": '"4.5.6"'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
         self.assertEqual(m.sysroot_ref.value, "1.2.3")
@@ -75,36 +68,36 @@ class TestLoadManifestBasic(unittest.TestCase):
         self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.2.3")
 
     def test_single_dependency_version_table(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             make_toml(nanvix_version="1.2.3", deps={"zlib": '{ version = "4.5.6" }'})
         )
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
         self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.2.3")
 
     def test_single_dependency_tag(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ tag = "675d8f2-nanvix-e63706b" }'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.TAG)
         self.assertEqual(m.dependencies[0].ref.value, "675d8f2-nanvix-e63706b")
 
     def test_single_dependency_id(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": "{ id = 12345678 }"}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.ID)
         self.assertEqual(m.dependencies[0].ref.value, 12345678)
 
     def test_mixed_dependencies(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             make_toml(
                 nanvix_version="1.0.0",
@@ -112,7 +105,7 @@ class TestLoadManifestBasic(unittest.TestCase):
             )
         )
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.value, "1.0.0")
         self.assertEqual(len(m.dependencies), 2)
@@ -122,27 +115,27 @@ class TestLoadManifestBasic(unittest.TestCase):
         self.assertEqual(m.dependencies[1].ref.value, "2.0.0-nanvix-1.0.0")
 
     def test_no_dependencies_section(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml())
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(len(m.dependencies), 0)
         self.assertEqual(len(m.system_dependencies), 0)
 
     def test_empty_dependencies_section(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(len(m.dependencies), 0)
 
     def test_empty_system_dependencies_section(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(sys_deps={}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(len(m.system_dependencies), 0)
 
@@ -151,71 +144,69 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
     """Invalid version specs are rejected."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_empty_string_nanvix_version_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version=""))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_whitespace_nanvix_version_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="has space"))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_non_semver_nanvix_version_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="abc123"))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_latest_nanvix_version_accepted(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="latest"))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
         self.assertEqual(m.sysroot_ref.value, "latest")
 
     def test_latest_sysroot_skips_dep_suffix(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="latest", deps={"zlib": '"1.3.1"'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.value, "latest")
         # Dep should NOT be suffixed — deferred to resolver
         self.assertEqual(m.dependencies[0].ref.value, "1.3.1")
 
     def test_latest_sysroot_env_override_suffixes_normally(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="latest", deps={"zlib": '"1.3.1"'}))
 
         with patch.dict("os.environ", {"NANVIX_VERSION": "0.12.258"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.value, "0.12.258")
         self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-0.12.258")
 
     def test_nanvix_version_table_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             "[package]\n"
             'name = "myapp"\n'
@@ -224,61 +215,61 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_whitespace_dep_version_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"has space"'}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_empty_commitish_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ commitish = "" }'}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_non_string_commitish_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": "{ commitish = 123 }"}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_multiple_specifier_keys_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ version = "1.0", tag = "v1.0" }'}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_non_integer_id_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ id = "abc" }'}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_unknown_table_key_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ foo = "bar" }'}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
@@ -287,19 +278,17 @@ class TestLoadManifestLatestWarning(unittest.TestCase):
     """'latest' emits a warning but is accepted for dependencies."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_latest_dep_version_warns(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"latest"'}))
 
         with patch("nanvix_zutil.manifest.log") as mock_log:
-            m = load_manifest(path)
+            m = load_manifest()
 
         mock_log.warning.assert_called()
         self.assertEqual(m.dependencies[0].ref.value, "latest-nanvix-0.12.257")
@@ -309,55 +298,53 @@ class TestLoadManifestPackageValidation(unittest.TestCase):
     """Required [package] keys are validated."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_missing_package_section_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text("")
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_missing_name_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text('[package]\nversion = "1.0.0"\nnanvix-version = "0.12.257"\n')
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_missing_version_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text('[package]\nname = "myapp"\nnanvix-version = "0.12.257"\n')
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_missing_nanvix_version_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text('[package]\nname = "myapp"\nversion = "1.0.0"\n')
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_empty_file_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text("")
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
@@ -366,19 +353,17 @@ class TestLoadManifestMalformedToml(unittest.TestCase):
     """Invalid TOML syntax is rejected."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_invalid_toml_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text("this is not valid toml [[[")
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
@@ -387,75 +372,73 @@ class TestLoadManifestEnvOverride(unittest.TestCase):
     """Environment variables override manifest versions."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_nanvix_version_overrides_sysroot(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.0.0"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION": "override_sha"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.value, "override_sha")
         self.assertEqual(m.dependencies[0].ref.value, "1.0.0-nanvix-override_sha")
 
     def test_nanvix_version_v_prefix_stripped_in_suffix(self) -> None:
         """NANVIX_VERSION with 'v' prefix must strip it for dep suffix."""
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="latest", deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION": "v0.12.291"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.value, "v0.12.291")
         self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-0.12.291")
 
     def test_nanvix_version_dep_overrides_dep(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.0.0"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "env_sha"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.value, "0.12.257")
         self.assertEqual(m.dependencies[0].ref.value, "env_sha-nanvix-0.12.257")
 
     def test_env_overrides_both(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.0.0"'}))
 
         with patch.dict(
             os.environ,
             {"NANVIX_VERSION": "env_nanvix", "NANVIX_VERSION_ZLIB": "env_zlib"},
         ):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.value, "env_nanvix")
         self.assertEqual(m.dependencies[0].ref.value, "env_zlib-nanvix-env_nanvix")
 
     def test_env_override_with_nanvix_suffix_skips_auto_suffix(self) -> None:
         """NANVIX_VERSION_<NAME> with -nanvix- suffix bypasses auto-suffixing."""
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="0.12.410", deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "1.3.1-nanvix-99.99.99"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         # The env override already has the suffix — must NOT be double-suffixed.
         self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-99.99.99")
 
     def test_env_override_without_suffix_still_gets_suffixed(self) -> None:
         """NANVIX_VERSION_<NAME> without -nanvix- still gets auto-suffixed."""
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="0.12.410", deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "2.0.0"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         # Plain base version override still gets the nanvix suffix.
         self.assertEqual(m.dependencies[0].ref.value, "2.0.0-nanvix-0.12.410")
@@ -465,73 +448,71 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
     """Only VERSION refs are auto-suffixed with the nanvix version."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_version_string_dep_suffixed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="1.0.0", deps={"zlib": '"4.5.6"'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
         self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.0.0")
 
     def test_version_table_dep_suffixed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             make_toml(nanvix_version="1.0.0", deps={"zlib": '{ version = "4.5.6" }'})
         )
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
         self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.0.0")
 
     def test_commitish_dep_not_suffixed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ commitish = "b7a6a3c" }'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.COMMITISH)
         self.assertEqual(m.dependencies[0].ref.value, "b7a6a3c")
 
     def test_tag_dep_not_suffixed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '{ tag = "v1.0.0-nanvix-abc" }'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.TAG)
         self.assertEqual(m.dependencies[0].ref.value, "v1.0.0-nanvix-abc")
 
     def test_id_dep_not_suffixed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": "{ id = 99999 }"}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.ID)
         self.assertEqual(m.dependencies[0].ref.value, 99999)
 
     def test_full_ref_with_nanvix_rejected(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"b7a6a3c-nanvix-fa06b88"'}))
 
         log_mod.set_json_mode(True)
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
         log_mod.set_json_mode(False)
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_multiple_version_deps_suffixed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             make_toml(
                 nanvix_version="1.0.0",
@@ -539,16 +520,16 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
             )
         )
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.value, "1.2.3-nanvix-1.0.0")
         self.assertEqual(m.dependencies[1].ref.value, "2.0.0-nanvix-1.0.0")
 
     def test_system_deps_version_suffixed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(sys_deps={"foobar": '"1.2.3"'}))
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(m.system_dependencies[0].name, "foobar")
         self.assertEqual(m.system_dependencies[0].ref.kind, RefKind.VERSION)
@@ -559,22 +540,20 @@ class TestLoadManifestSystemDependencies(unittest.TestCase):
     """[system-dependencies] are parsed correctly."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_system_deps_parsed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             make_toml(
                 sys_deps={"foobar": '"1.2.3"', "bazqux": '{ commitish = "deadbeef" }'},
             )
         )
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(len(m.system_dependencies), 2)
         self.assertEqual(m.system_dependencies[0].name, "foobar")
@@ -586,7 +565,7 @@ class TestLoadManifestSystemDependencies(unittest.TestCase):
         self.assertEqual(m.system_dependencies[1].ref.value, "deadbeef")
 
     def test_both_dep_sections_parsed(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             make_toml(
                 deps={"zlib": '{ commitish = "aaa" }'},
@@ -594,7 +573,7 @@ class TestLoadManifestSystemDependencies(unittest.TestCase):
             )
         )
 
-        m = load_manifest(path)
+        m = load_manifest()
 
         self.assertEqual(len(m.dependencies), 1)
         self.assertEqual(len(m.system_dependencies), 1)
@@ -604,33 +583,31 @@ class TestLoadManifestTypeValidation(unittest.TestCase):
     """Non-string/non-table dependency values and non-table sections are rejected."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_integer_dependency_value_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": "123"}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_boolean_dependency_value_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": "true"}))
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_dependencies_not_table_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             'dependencies = "not-a-table"\n'
             "[package]\n"
@@ -640,12 +617,12 @@ class TestLoadManifestTypeValidation(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
     def test_system_dependencies_not_table_exits_2(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(
             "system-dependencies = 42\n"
             "[package]\n"
@@ -655,7 +632,7 @@ class TestLoadManifestTypeValidation(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            load_manifest(path)
+            load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
@@ -704,68 +681,66 @@ class TestLoadManifestLocalRef(unittest.TestCase):
     """Env var overrides with filesystem paths produce RefKind.LOCAL."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_dep_env_unix_path_produces_local(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/some/path"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.value, "/some/path")
 
     def test_dep_env_windows_path_produces_local(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "C:\\Users\\me\\build"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.value, "C:\\Users\\me\\build")
 
     def test_dep_env_relative_path_produces_local(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "./build/zlib"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.value, "./build/zlib")
 
     def test_dep_env_version_string_still_works(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "2.0.0"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
 
     def test_sysroot_env_unix_path_produces_local(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml())
 
         with patch.dict(os.environ, {"NANVIX_VERSION": "/path/to/sysroot"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
         self.assertEqual(m.sysroot_ref.value, "/path/to/sysroot")
 
     def test_sysroot_env_windows_path_produces_local(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml())
 
         with patch.dict(os.environ, {"NANVIX_VERSION": "C:\\nanvix\\sysroot"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
         self.assertEqual(m.sysroot_ref.value, "C:\\nanvix\\sysroot")
@@ -774,21 +749,21 @@ class TestLoadManifestLocalRef(unittest.TestCase):
         # make_toml default nanvix-version is a semver string, which
         # _parse_nanvix_version maps to RefKind.TAG.  The env override
         # keeps the manifest RefKind (TAG) and only replaces the value.
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="0.12.257"))
 
         with patch.dict(os.environ, {"NANVIX_VERSION": "0.12.258"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
 
     def test_local_sysroot_skips_dep_suffix(self) -> None:
         """When sysroot is LOCAL, VERSION deps must NOT be auto-suffixed."""
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION": "/path/to/sysroot"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
         # Dep should NOT be suffixed — sysroot is local.
@@ -796,11 +771,11 @@ class TestLoadManifestLocalRef(unittest.TestCase):
 
     def test_local_dep_no_suffix(self) -> None:
         """LOCAL dep refs are never suffixed, even with a concrete sysroot."""
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="0.12.410", deps={"zlib": '"1.3.1"'}))
 
         with patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": "/my/zlib"}):
-            m = load_manifest(path)
+            m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.LOCAL)
         self.assertEqual(m.dependencies[0].ref.value, "/my/zlib")

--- a/tests/test_resolve_cmd.py
+++ b/tests/test_resolve_cmd.py
@@ -6,12 +6,11 @@
 import json
 import os
 import sys
-import tempfile
 import unittest
 from io import StringIO
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from nanvix_zutil import paths
 from nanvix_zutil.buildroot import Ref, RefKind
 from nanvix_zutil.lockfile import Lockfile, LockfileMetadata, ResolvedPackage
 from nanvix_zutil.manifest import Manifest
@@ -68,6 +67,11 @@ def _make_lockfile_no_sysroot() -> Lockfile:
     )
 
 
+def _write_manifest() -> None:
+    """Write a minimal manifest into the autouse-fixture .nanvix/ dir."""
+    (paths.manifest_path()).write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -84,30 +88,26 @@ class TestDefaultOutput(unittest.TestCase):
         mock_load.return_value = _make_manifest()
         mock_resolve.return_value = _make_lockfile()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest = Path(tmpdir) / "nanvix.toml"
-            manifest.write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
+        _write_manifest()
 
-            buf = StringIO()
-            sys.stdout = buf
-            try:
-                with (
-                    patch(
-                        "sys.argv", ["nanvix-zutil resolve", f"--manifest={manifest}"]
-                    ),
-                    self.assertRaises(SystemExit) as ctx,
-                ):
-                    main()
-            finally:
-                sys.stdout = sys.__stdout__
+        buf = StringIO()
+        sys.stdout = buf
+        try:
+            with (
+                patch("sys.argv", ["nanvix-zutil resolve"]),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                main()
+        finally:
+            sys.stdout = sys.__stdout__
 
-            self.assertEqual(ctx.exception.code, 0)
-            output = buf.getvalue()
-            self.assertIn(f"nanvix_tag={_TAG}", output)
-            self.assertIn(f"nanvix_sha={_SHA[:7]}", output)
-            self.assertIn(f"nanvix_version={_TAG.lstrip('v')}", output)
-            self.assertIn(f"package_name={_NAME}", output)
-            self.assertIn(f"package_version={_VERSION}", output)
+        self.assertEqual(ctx.exception.code, 0)
+        output = buf.getvalue()
+        self.assertIn(f"nanvix_tag={_TAG}", output)
+        self.assertIn(f"nanvix_sha={_SHA[:7]}", output)
+        self.assertIn(f"nanvix_version={_TAG.lstrip('v')}", output)
+        self.assertIn(f"package_name={_NAME}", output)
+        self.assertIn(f"package_version={_VERSION}", output)
 
 
 class TestJsonOutput(unittest.TestCase):
@@ -119,31 +119,26 @@ class TestJsonOutput(unittest.TestCase):
         mock_load.return_value = _make_manifest()
         mock_resolve.return_value = _make_lockfile()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest = Path(tmpdir) / "nanvix.toml"
-            manifest.write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
+        _write_manifest()
 
-            buf = StringIO()
-            sys.stdout = buf
-            try:
-                with (
-                    patch(
-                        "sys.argv",
-                        ["nanvix-zutil resolve", f"--manifest={manifest}", "--json"],
-                    ),
-                    self.assertRaises(SystemExit) as ctx,
-                ):
-                    main()
-            finally:
-                sys.stdout = sys.__stdout__
+        buf = StringIO()
+        sys.stdout = buf
+        try:
+            with (
+                patch("sys.argv", ["nanvix-zutil resolve", "--json"]),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                main()
+        finally:
+            sys.stdout = sys.__stdout__
 
-            self.assertEqual(ctx.exception.code, 0)
-            obj = json.loads(buf.getvalue().strip())
-            self.assertEqual(obj["nanvix_tag"], _TAG)
-            self.assertEqual(obj["nanvix_sha"], _SHA[:7])
-            self.assertEqual(obj["nanvix_version"], _TAG.lstrip("v"))
-            self.assertEqual(obj["package_name"], _NAME)
-            self.assertEqual(obj["package_version"], _VERSION)
+        self.assertEqual(ctx.exception.code, 0)
+        obj = json.loads(buf.getvalue().strip())
+        self.assertEqual(obj["nanvix_tag"], _TAG)
+        self.assertEqual(obj["nanvix_sha"], _SHA[:7])
+        self.assertEqual(obj["nanvix_version"], _TAG.lstrip("v"))
+        self.assertEqual(obj["package_name"], _NAME)
+        self.assertEqual(obj["package_version"], _VERSION)
 
 
 class TestShallowFlag(unittest.TestCase):
@@ -157,31 +152,22 @@ class TestShallowFlag(unittest.TestCase):
         mock_load.return_value = _make_manifest()
         mock_resolve.return_value = _make_lockfile()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest = Path(tmpdir) / "nanvix.toml"
-            manifest.write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
+        _write_manifest()
 
-            buf = StringIO()
-            sys.stdout = buf
-            try:
-                with (
-                    patch(
-                        "sys.argv",
-                        [
-                            "nanvix-zutil resolve",
-                            f"--manifest={manifest}",
-                            "--shallow",
-                        ],
-                    ),
-                    self.assertRaises(SystemExit),
-                ):
-                    main()
-            finally:
-                sys.stdout = sys.__stdout__
+        buf = StringIO()
+        sys.stdout = buf
+        try:
+            with (
+                patch("sys.argv", ["nanvix-zutil resolve", "--shallow"]),
+                self.assertRaises(SystemExit),
+            ):
+                main()
+        finally:
+            sys.stdout = sys.__stdout__
 
-            mock_resolve.assert_called_once()
-            call_kwargs = mock_resolve.call_args
-            self.assertTrue(call_kwargs.kwargs.get("shallow", False))
+        mock_resolve.assert_called_once()
+        call_kwargs = mock_resolve.call_args
+        self.assertTrue(call_kwargs.kwargs.get("shallow", False))
 
 
 class TestGhToken(unittest.TestCase):
@@ -195,28 +181,23 @@ class TestGhToken(unittest.TestCase):
         mock_load.return_value = _make_manifest()
         mock_resolve.return_value = _make_lockfile()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest = Path(tmpdir) / "nanvix.toml"
-            manifest.write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
+        _write_manifest()
 
-            os.environ["GH_TOKEN"] = "env-token"
-            buf = StringIO()
-            sys.stdout = buf
-            try:
-                with (
-                    patch(
-                        "sys.argv",
-                        ["nanvix-zutil resolve", f"--manifest={manifest}"],
-                    ),
-                    self.assertRaises(SystemExit),
-                ):
-                    main()
-            finally:
-                sys.stdout = sys.__stdout__
-                os.environ.pop("GH_TOKEN", None)
+        os.environ["GH_TOKEN"] = "env-token"
+        buf = StringIO()
+        sys.stdout = buf
+        try:
+            with (
+                patch("sys.argv", ["nanvix-zutil resolve"]),
+                self.assertRaises(SystemExit),
+            ):
+                main()
+        finally:
+            sys.stdout = sys.__stdout__
+            os.environ.pop("GH_TOKEN", None)
 
-            call_kwargs = mock_resolve.call_args
-            self.assertEqual(call_kwargs.kwargs.get("gh_token"), "env-token")
+        call_kwargs = mock_resolve.call_args
+        self.assertEqual(call_kwargs.kwargs.get("gh_token"), "env-token")
 
     @patch("nanvix_zutil.resolve_cmd.resolve")
     @patch("nanvix_zutil.resolve_cmd.load_manifest")
@@ -226,43 +207,35 @@ class TestGhToken(unittest.TestCase):
         mock_load.return_value = _make_manifest()
         mock_resolve.return_value = _make_lockfile()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest = Path(tmpdir) / "nanvix.toml"
-            manifest.write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
+        _write_manifest()
 
-            os.environ["GH_TOKEN"] = "env-token"
-            buf = StringIO()
-            sys.stdout = buf
-            try:
-                with (
-                    patch(
-                        "sys.argv",
-                        [
-                            "nanvix-zutil resolve",
-                            f"--manifest={manifest}",
-                            "--gh-token=cli-token",
-                        ],
-                    ),
-                    self.assertRaises(SystemExit),
-                ):
-                    main()
-            finally:
-                sys.stdout = sys.__stdout__
-                os.environ.pop("GH_TOKEN", None)
+        os.environ["GH_TOKEN"] = "env-token"
+        buf = StringIO()
+        sys.stdout = buf
+        try:
+            with (
+                patch(
+                    "sys.argv",
+                    ["nanvix-zutil resolve", "--gh-token=cli-token"],
+                ),
+                self.assertRaises(SystemExit),
+            ):
+                main()
+        finally:
+            sys.stdout = sys.__stdout__
+            os.environ.pop("GH_TOKEN", None)
 
-            call_kwargs = mock_resolve.call_args
-            self.assertEqual(call_kwargs.kwargs.get("gh_token"), "cli-token")
+        call_kwargs = mock_resolve.call_args
+        self.assertEqual(call_kwargs.kwargs.get("gh_token"), "cli-token")
 
 
 class TestMissingManifest(unittest.TestCase):
     """Missing manifest exits with code 3."""
 
     def test_missing_manifest_exits_3(self) -> None:
+        # Autouse fixture provides an empty .nanvix/ (no nanvix.toml).
         with (
-            patch(
-                "sys.argv",
-                ["nanvix-zutil resolve", "--manifest=/nonexistent/nanvix.toml"],
-            ),
+            patch("sys.argv", ["nanvix-zutil resolve"]),
             self.assertRaises(SystemExit) as ctx,
         ):
             main()
@@ -280,19 +253,14 @@ class TestNoSysroot(unittest.TestCase):
         mock_load.return_value = _make_manifest()
         mock_resolve.return_value = _make_lockfile_no_sysroot()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest = Path(tmpdir) / "nanvix.toml"
-            manifest.write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
+        _write_manifest()
 
-            with (
-                patch(
-                    "sys.argv",
-                    ["nanvix-zutil resolve", f"--manifest={manifest}"],
-                ),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            self.assertEqual(ctx.exception.code, 3)
+        with (
+            patch("sys.argv", ["nanvix-zutil resolve"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5,12 +5,12 @@
 
 """Tests for nanvix_zutil.resolver."""
 
-import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.log as log_mod
+from nanvix_zutil import paths
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -75,17 +75,13 @@ class TestResolveSysrootOnly(unittest.TestCase):
     """Resolver with no dependencies (sysroot only)."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\nnanvix-version = "0.1.0"\n'
         )
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_sysroot_only(
@@ -107,11 +103,7 @@ class TestResolveSysrootOnly(unittest.TestCase):
         mock_download.return_value = None
 
         manifest = _make_manifest()
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         self.assertEqual(len(lockfile.packages), 1)
         self.assertEqual(lockfile.packages[0].name, "nanvix")
@@ -126,10 +118,7 @@ class TestResolveDirectDep(unittest.TestCase):
     """Resolver with one direct dependency."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "0.1.0"\n'
@@ -139,7 +128,6 @@ class TestResolveDirectDep(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_one_direct_dep(
@@ -166,11 +154,7 @@ class TestResolveDirectDep(unittest.TestCase):
                 )
             ]
         )
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         self.assertEqual(len(lockfile.packages), 2)
         names = [p.name for p in lockfile.packages]
@@ -189,10 +173,7 @@ class TestResolveTransitive(unittest.TestCase):
     """Resolver discovers transitive deps from a dep's lockfile asset."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "0.1.0"\n'
@@ -202,7 +183,6 @@ class TestResolveTransitive(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_transitive_discovery(
@@ -260,11 +240,7 @@ class TestResolveTransitive(unittest.TestCase):
                 )
             ]
         )
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         self.assertEqual(len(lockfile.packages), 3)
         names = [p.name for p in lockfile.packages]
@@ -284,10 +260,7 @@ class TestResolveShallow(unittest.TestCase):
     """shallow=True does not download lockfile assets."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "0.1.0"\n'
@@ -297,7 +270,6 @@ class TestResolveShallow(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_shallow_skips_transitive(
@@ -318,12 +290,7 @@ class TestResolveShallow(unittest.TestCase):
                 )
             ]
         )
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            shallow=True,
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache", shallow=True)
 
         # download_lockfile_asset should NOT be called
         mock_download.assert_not_called()
@@ -337,10 +304,7 @@ class TestCycleDetection(unittest.TestCase):
     """Resolver detects and rejects dependency cycles."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "0.1.0"\n'
@@ -350,7 +314,6 @@ class TestCycleDetection(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_cycle_detected(
@@ -411,11 +374,7 @@ class TestCycleDetection(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            resolve(
-                manifest,
-                cache_dir=Path(self._tmpdir.name) / "cache",
-                manifest_path=self._manifest_path,
-            )
+            resolve(manifest, cache_dir=Path.cwd() / "cache")
         self.assertEqual(ctx.exception.code, 2)
 
 
@@ -425,10 +384,7 @@ class TestVersionConflict(unittest.TestCase):
     """Resolver detects version conflicts."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "0.1.0"\n'
@@ -439,7 +395,6 @@ class TestVersionConflict(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_conflict_exits_2(
@@ -492,25 +447,15 @@ class TestVersionConflict(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            resolve(
-                manifest,
-                cache_dir=Path(self._tmpdir.name) / "cache",
-                manifest_path=self._manifest_path,
-            )
+            resolve(manifest, cache_dir=Path.cwd() / "cache")
         self.assertEqual(ctx.exception.code, 2)
 
 
 class TestIsStale(unittest.TestCase):
     """is_stale() returns correct results."""
 
-    def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
     def test_not_stale(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text('[package]\nname = "test"\n')
 
         from nanvix_zutil.lockfile import compute_manifest_hash
@@ -519,10 +464,10 @@ class TestIsStale(unittest.TestCase):
         lockfile = Lockfile(
             metadata=LockfileMetadata(manifest_hash=h, nanvix_zutil_version="0.2.2"),
         )
-        self.assertFalse(is_stale(lockfile, path))
+        self.assertFalse(is_stale(lockfile))
 
     def test_stale(self) -> None:
-        path = Path(self._tmpdir.name) / "nanvix.toml"
+        path = paths.manifest_path()
         path.write_text('[package]\nname = "test"\n')
 
         lockfile = Lockfile(
@@ -530,7 +475,7 @@ class TestIsStale(unittest.TestCase):
                 manifest_hash="sha256:old", nanvix_zutil_version="0.2.2"
             ),
         )
-        self.assertTrue(is_stale(lockfile, path))
+        self.assertTrue(is_stale(lockfile))
 
 
 @patch("nanvix_zutil.resolver.download_lockfile_asset")
@@ -540,10 +485,7 @@ class TestResolveLatestSysroot(unittest.TestCase):
     """Resolver with 'latest' sysroot and a VERSION dep."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "latest"\n'
@@ -553,7 +495,6 @@ class TestResolveLatestSysroot(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_latest_sysroot_deferred_suffix(
@@ -589,11 +530,7 @@ class TestResolveLatestSysroot(unittest.TestCase):
             sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
         )
 
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         self.assertEqual(len(lockfile.packages), 2)
         # Verify sysroot resolved correctly
@@ -621,17 +558,13 @@ class TestAssetFiltering(unittest.TestCase):
     """Resolver filters out non-archive assets and nanvix.lock."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\nnanvix-version = "0.1.0"\n'
         )
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_filters_non_tar_bz2(
@@ -657,11 +590,7 @@ class TestAssetFiltering(unittest.TestCase):
         mock_download.return_value = None
 
         manifest = _make_manifest()
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         sysroot_pkg = lockfile.packages[0]
         # .tar.bz2, .tar.gz, and .zip are collected; .txt and nanvix.lock are not.
@@ -711,10 +640,7 @@ class TestResolveVersionFallback(unittest.TestCase):
     """Tests for fallback version downgrade in the resolver."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "latest"\n'
@@ -724,7 +650,6 @@ class TestResolveVersionFallback(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_fallback_downgrades_sysroot(
@@ -763,11 +688,7 @@ class TestResolveVersionFallback(unittest.TestCase):
             sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
         )
 
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         # Sysroot should be downgraded to 0.12.291
         sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
@@ -837,11 +758,7 @@ class TestResolveVersionFallback(unittest.TestCase):
             sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
         )
 
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         # Sysroot should use the minimum: 0.12.291
         sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
@@ -881,11 +798,7 @@ class TestResolveVersionFallback(unittest.TestCase):
             sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
         )
 
-        lockfile = resolve(
-            manifest,
-            cache_dir=Path(self._tmpdir.name) / "cache",
-            manifest_path=self._manifest_path,
-        )
+        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
 
         sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
         self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.337")
@@ -897,10 +810,7 @@ class TestNoFallbackWhenPinned(unittest.TestCase):
     """Pinned sysroot preserves hard-fail behavior."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._manifest_dir = Path(self._tmpdir.name) / ".nanvix"
-        self._manifest_dir.mkdir(parents=True)
-        self._manifest_path = self._manifest_dir / "nanvix.toml"
+        self._manifest_path = paths.manifest_path()
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\n'
             'nanvix-version = "0.12.337"\n'
@@ -910,7 +820,6 @@ class TestNoFallbackWhenPinned(unittest.TestCase):
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_no_fallback_when_pinned(
@@ -940,11 +849,7 @@ class TestNoFallbackWhenPinned(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            resolve(
-                manifest,
-                cache_dir=Path(self._tmpdir.name) / "cache",
-                manifest_path=self._manifest_path,
-            )
+            resolve(manifest, cache_dir=Path.cwd() / "cache")
         self.assertEqual(ctx.exception.code, 3)
 
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -29,6 +29,7 @@ from nanvix_zutil.script import ZScript
 from tests.testutils import (
     MANIFEST_LATEST_WITH_DEPS,
     MANIFEST_WITH_DEPS,
+    chdir_to,
     write_manifest,
 )
 
@@ -38,12 +39,10 @@ class TestZScriptInit(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def test_repo_root_resolved(self) -> None:
         repo_root = Path(self._tmpdir.name)
@@ -82,8 +81,8 @@ class TestZScriptInit(unittest.TestCase):
 
     def test_missing_manifest_exits_3(self) -> None:
         tmpdir = tempfile.TemporaryDirectory()
-        self.addCleanup(tmpdir.cleanup)
         repo_root = Path(tmpdir.name)
+        chdir_to(self, tmpdir)
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
@@ -98,20 +97,10 @@ class TestZScriptAutoSetup(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-        # Config resolves .nanvix/ from cwd; override the autouse fixture.
-        self._orig_cwd = os.getcwd()
-        os.chdir(self._tmpdir.name)
-        from nanvix_zutil.paths import nanvix_root
-
-        nanvix_root.cache_clear()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        # Restore cwd before tmpdir cleanup so Windows can delete it.
-        os.chdir(self._orig_cwd)
-        self._tmpdir.cleanup()
 
     def test_setup_downloads_sysroot(self) -> None:
         """setup() calls Sysroot.download with config values."""
@@ -139,7 +128,7 @@ class TestZScriptAutoSetup(unittest.TestCase):
 
     def test_setup_with_deps_creates_buildroot(self) -> None:
         """setup() with manifest dependencies creates Buildroot and installs all deps."""
-        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+        write_manifest(MANIFEST_WITH_DEPS)
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
@@ -201,12 +190,10 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name), MANIFEST_LATEST_WITH_DEPS)
+        chdir_to(self, self._tmpdir)
+        write_manifest(MANIFEST_LATEST_WITH_DEPS)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def test_setup_latest_sysroot_suffixes_deps(self) -> None:
         """setup() suffixes VERSION deps with the resolved sysroot tag."""
@@ -261,12 +248,10 @@ class TestZScriptSyncConfigs(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def _run_setup(self) -> ZScript:
         fake_sysroot = MagicMock()
@@ -356,10 +341,8 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
 
     def _make_script(self) -> ZScript:
         return ZScript(Path(self._tmpdir.name))
@@ -385,10 +368,8 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
 
     def test_base_class_exposes_only_auto_hooks(self) -> None:
         script = ZScript(Path(self._tmpdir.name))
@@ -451,10 +432,8 @@ class TestHelpersRun(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
 
     def test_run_success(self) -> None:
         result = helpers.run(sys.executable, "-c", "print('ok')")
@@ -741,12 +720,11 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
@@ -800,10 +778,8 @@ class TestZScriptDockerConfig(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
 
     def _make_script(self) -> ZScript:
         return ZScript(Path(self._tmpdir.name))
@@ -860,12 +836,10 @@ class TestZScriptAutoDocker(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def test_build_auto_enables_docker_on_windows(self) -> None:
         """build on Windows uses the persisted Docker image."""
@@ -936,10 +910,8 @@ class TestZScriptCleanWindows(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
 
     @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_clean_removes_configured_artifact(self, _mock: object) -> None:
@@ -968,12 +940,10 @@ class TestZScriptSetupFallbackReporting(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+        chdir_to(self, self._tmpdir)
+        write_manifest(MANIFEST_WITH_DEPS)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def test_setup_returns_false_when_no_fallback(self) -> None:
         """setup() returns False when all deps resolve exactly."""
@@ -1019,7 +989,7 @@ class TestZScriptSetupFallbackReporting(unittest.TestCase):
 
     def test_setup_no_deps_returns_false(self) -> None:
         """setup() returns False when there are no dependencies."""
-        write_manifest(Path(self._tmpdir.name))  # default manifest, no deps
+        write_manifest()  # default manifest, no deps
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
@@ -1072,7 +1042,8 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+        chdir_to(self, self._tmpdir)
+        write_manifest(MANIFEST_WITH_DEPS)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
@@ -1082,9 +1053,6 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         p = patch("nanvix_zutil.script.check_docker", return_value=None)
         p.start()
         self.addCleanup(p.stop)
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def test_exit_degraded_setup_value(self) -> None:
         """EXIT_DEGRADED_SETUP has the expected value of 7."""
@@ -1175,7 +1143,8 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in (
             "NANVIX_MACHINE",
             "NANVIX_DEPLOYMENT_MODE",
@@ -1186,7 +1155,6 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
 
     def tearDown(self) -> None:
         os.environ.pop("WITH_NANVIX", None)
-        self._tmpdir.cleanup()
 
     def test_setup_calls_overlay_when_env_set(self) -> None:
         """setup() calls sysroot.overlay_local_nanvix when WITH_NANVIX is set."""
@@ -1218,7 +1186,7 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
 
     def test_setup_local_deps_skips_github(self) -> None:
         """setup() skips GitHub download for deps found locally."""
-        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+        write_manifest(MANIFEST_WITH_DEPS)
 
         local_dir = Path(self._tmpdir.name) / "local-nanvix"
         (local_dir / "deps" / "zlib" / "lib").mkdir(parents=True)
@@ -1247,11 +1215,11 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
+        chdir_to(self, self._tmpdir)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_local_sysroot_skips_github(self) -> None:
@@ -1261,7 +1229,7 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
         local_sysroot = repo_root / "my-sysroot"
         local_sysroot.mkdir()
 
-        write_manifest(repo_root)
+        write_manifest()
 
         with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
             script = ZScript(repo_root)
@@ -1286,7 +1254,7 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
         local_sysroot = repo_root / "my-sysroot"
         local_sysroot.mkdir()
 
-        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+        write_manifest(MANIFEST_WITH_DEPS)
 
         with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
             script = ZScript(repo_root)
@@ -1300,11 +1268,11 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
+        chdir_to(self, self._tmpdir)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_local_dep_uses_install_local_nanvix(self) -> None:
@@ -1315,7 +1283,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
         (local_dep_path / "deps" / "zlib" / "lib").mkdir(parents=True)
         (local_dep_path / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
 
-        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+        write_manifest(MANIFEST_WITH_DEPS)
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
@@ -1341,7 +1309,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
         (local_dep_path / "deps" / "zlib" / "lib").mkdir(parents=True)
         (local_dep_path / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
 
-        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+        write_manifest(MANIFEST_WITH_DEPS)
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
@@ -1365,7 +1333,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
         local_dep_path = repo_root / "empty-dir"
         local_dep_path.mkdir()
 
-        write_manifest(repo_root, MANIFEST_WITH_DEPS)
+        write_manifest(MANIFEST_WITH_DEPS)
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
@@ -1388,10 +1356,8 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
+        chdir_to(self, self._tmpdir)
+        write_manifest()
 
     def _make_script(self) -> ZScript:
         repo_root = Path(self._tmpdir.name)
@@ -1874,7 +1840,8 @@ class TestOfflineMode(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name), MANIFEST_WITH_DEPS)
+        chdir_to(self, self._tmpdir)
+        write_manifest(MANIFEST_WITH_DEPS)
         for key in (
             "NANVIX_MACHINE",
             "NANVIX_DEPLOYMENT_MODE",
@@ -1884,7 +1851,6 @@ class TestOfflineMode(unittest.TestCase):
             os.environ.pop(key, None)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_offline_default_false(self) -> None:
@@ -2039,12 +2005,10 @@ class TestInstallArtifacts(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        write_manifest(Path(self._tmpdir.name))
+        chdir_to(self, self._tmpdir)
+        write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
 
     def test_exports_from_output_dir(self) -> None:
         """install_artifacts copies from .nanvix/output/."""

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -3,7 +3,12 @@
 
 """Shared test helpers for nanvix_zutil tests."""
 
+import os
+import tempfile
+import unittest
 from pathlib import Path
+
+from nanvix_zutil.paths import nanvix_root
 
 # Minimal valid manifest content.
 MINIMAL_MANIFEST = (
@@ -64,8 +69,66 @@ def make_toml(
     return "\n".join(lines) + "\n"
 
 
-def write_manifest(repo_root: Path, content: str = MINIMAL_MANIFEST) -> None:
-    """Create ``.nanvix/nanvix.toml`` inside *repo_root*."""
-    nanvix_dir = repo_root / ".nanvix"
-    nanvix_dir.mkdir(parents=True, exist_ok=True)
-    (nanvix_dir / "nanvix.toml").write_text(content)
+def write_manifest(content: str = MINIMAL_MANIFEST) -> None:
+    """Create ``.nanvix/nanvix.toml`` under the current working directory.
+
+    Callers are expected to have already pointed cwd at the consumer
+    repo (typically via :func:`chdir_to`).
+    """
+    dest = Path.cwd() / ".nanvix" / "nanvix.toml"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(content)
+
+
+def chdir_to(
+    testcase: unittest.TestCase,
+    repo_root: Path | str | tempfile.TemporaryDirectory[str],
+) -> None:
+    """Point cwd at *repo_root* so .nanvix/ resolves there.
+
+    When *repo_root* is a :class:`tempfile.TemporaryDirectory`, its
+    ``cleanup()`` is registered via :meth:`unittest.TestCase.addCleanup`
+    so it runs **after** the cwd has been restored.  Callers must then
+    not also clean the tmpdir themselves in ``tearDown`` (doing so
+    runs before ``addCleanup`` and re-introduces the Windows
+    cwd-still-inside-tmpdir cleanup failure).
+
+    Ensures ``<repo_root>/.nanvix/`` exists so subsequent calls that
+    rely on :func:`nanvix_zutil.paths.nanvix_root` (which walks up
+    looking for a ``.nanvix/`` marker) succeed even when the caller
+    hasn't written any artifacts there yet.
+
+    Saves the previous cwd and registers an ``addCleanup`` that
+    restores it and clears the :func:`nanvix_root` cache.  Restoring
+    cwd before tmpdir cleanup is required on Windows, which refuses
+    to delete a directory that any process has as cwd.
+
+    The restore tolerates the previous cwd having been removed by
+    an earlier ``tearDown`` (common when callers nest ``chdir_to``
+    inside a tmpdir whose cleanup runs in tearDown); in that case it
+    falls back to the system temp directory.
+    """
+    if isinstance(repo_root, tempfile.TemporaryDirectory):
+        tmpdir = repo_root
+        target = Path(tmpdir.name)
+        # Registered first => runs LAST (after the cwd restore below).
+        testcase.addCleanup(tmpdir.cleanup)
+    else:
+        target = Path(repo_root)
+
+    (target / ".nanvix").mkdir(exist_ok=True)
+    orig_cwd = os.getcwd()
+    os.chdir(target)
+    nanvix_root.cache_clear()
+
+    def _restore_cwd() -> None:
+        try:
+            os.chdir(orig_cwd)
+        except FileNotFoundError:
+            os.chdir(tempfile.gettempdir())
+
+    testcase.addCleanup(nanvix_root.cache_clear)
+    # Registered last => runs FIRST, before any earlier-registered cleanup
+    # (notably the tmpdir cleanup above, which would otherwise fail on
+    # Windows while cwd is still inside the tmpdir).
+    testcase.addCleanup(_restore_cwd)


### PR DESCRIPTION
**Stacked on https://github.com/nanvix/zutils/pull/241**
Part 3 for #239 

This PR normalizes the manifest resolution step to use the canonical path. We also remove the --manifest directory, which was used to specify the manifest path. Confirmed that this flag is used nowhere in downstreams or CI.

The majority of this PR is test updates, as per usual.