### PR TITLE
[PATHS 4]: Buildroot + helpers.sync_config()

### DIFF
--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import shutil
 import tarfile
 import zipfile
-from dataclasses import dataclass, replace as _dc_replace
+from dataclasses import dataclass
+from dataclasses import replace as _dc_replace
 from enum import Enum
 from pathlib import Path
 
@@ -24,12 +25,8 @@ from nanvix_zutil.config import (
     DEFAULT_MEMORY_SIZE,
 )
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
-from nanvix_zutil.paths import buildroot as _default_buildroot_dir
-
-# ---------------------------------------------------------------------------
-# Default locations
-# ---------------------------------------------------------------------------
-
+from nanvix_zutil.paths import buildroot as _buildroot_dir
+from nanvix_zutil.paths import nanvix_root
 
 # ---------------------------------------------------------------------------
 # Tarball path helpers
@@ -210,42 +207,25 @@ def parse_semver_tuple(version: str) -> tuple[int, ...]:
 
 
 class Buildroot:
-    """Manages the build-time dependency root (headers and static libraries).
-
-    Attributes:
-        path: Absolute path to the buildroot directory.
-    """
-
-    def __init__(self, path: Path) -> None:
-        """Initialise the Buildroot with an existing directory.
-
-        Args:
-            path: Path to the buildroot directory.
-        """
-        self.path = path
+    """Manages the build-time dependency root (headers and static libraries)."""
 
     # ------------------------------------------------------------------
     # Factory
     # ------------------------------------------------------------------
 
     @staticmethod
-    def create(dest: Path | None = None) -> "Buildroot":
+    def create() -> "Buildroot":
         """Create (or locate) the buildroot directory and return a
         :class:`Buildroot` instance.
 
-        Args:
-            dest: Directory to use.  Defaults to
-                ``.nanvix/buildroot`` relative to the current working
-                directory.
-
         Returns:
-            A :class:`Buildroot` pointing at *dest*.
+            A :class:`Buildroot` pointing at <buildroot>.
         """
-        path = dest if dest is not None else _default_buildroot_dir()
-        (path / "lib").mkdir(parents=True, exist_ok=True)
-        (path / "include").mkdir(parents=True, exist_ok=True)
-        log.info(f"Buildroot at {path}")
-        return Buildroot(path.resolve())
+        br = _buildroot_dir()
+        (br / "lib").mkdir(parents=True, exist_ok=True)
+        (br / "include").mkdir(parents=True, exist_ok=True)
+        log.info(f"Buildroot at {br}")
+        return Buildroot()
 
     # ------------------------------------------------------------------
     # Dependency installation
@@ -285,7 +265,7 @@ class Buildroot:
             mem=memory_size,
         )
 
-        cache_dir = self.path.parent / "cache"
+        cache_dir = nanvix_root() / "cache"
 
         asset_path = github.download_release_asset(
             repo=dep.repo,
@@ -320,14 +300,18 @@ class Buildroot:
                             dep.install_libs
                         ):
                             member.name = _relative_to_segment(member_path, "lib")
-                            tf.extract(member, path=self.path / "lib", filter="data")
+                            tf.extract(
+                                member, path=_buildroot_dir() / "lib", filter="data"
+                            )
                     elif member_path.suffix == ".h":
                         if dep.install_headers is None or member_path.name in (
                             dep.install_headers
                         ):
                             member.name = _relative_to_segment(member_path, "include")
                             tf.extract(
-                                member, path=self.path / "include", filter="data"
+                                member,
+                                path=_buildroot_dir() / "include",
+                                filter="data",
                             )
 
     def _extract_dep_zip(self, asset_path: Path, dep: Dependency) -> None:
@@ -345,7 +329,7 @@ class Buildroot:
                         dep.install_libs
                     ):
                         rel = _relative_to_segment(member_path, "lib")
-                        dest = self.path / "lib" / rel
+                        dest = _buildroot_dir() / "lib" / rel
                         dest.parent.mkdir(parents=True, exist_ok=True)
                         with zf.open(info) as src, dest.open("wb") as dst:
                             shutil.copyfileobj(src, dst)
@@ -354,7 +338,7 @@ class Buildroot:
                         dep.install_headers
                     ):
                         rel = _relative_to_segment(member_path, "include")
-                        dest = self.path / "include" / rel
+                        dest = _buildroot_dir() / "include" / rel
                         dest.parent.mkdir(parents=True, exist_ok=True)
                         with zf.open(info) as src, dest.open("wb") as dst:
                             shutil.copyfileobj(src, dst)
@@ -387,7 +371,7 @@ class Buildroot:
         installed = False
         lib_dir = dep_dir / "lib"
         if lib_dir.is_dir():
-            dst_lib = self.path / "lib"
+            dst_lib = _buildroot_dir() / "lib"
             dst_lib.mkdir(parents=True, exist_ok=True)
             for src_file in lib_dir.iterdir():
                 if src_file.is_file() and src_file.suffix == ".a":
@@ -397,7 +381,7 @@ class Buildroot:
 
         include_dir = dep_dir / "include"
         if include_dir.is_dir():
-            dst_inc = self.path / "include"
+            dst_inc = _buildroot_dir() / "include"
             dst_inc.mkdir(parents=True, exist_ok=True)
             for src_file in include_dir.rglob("*"):
                 if src_file.is_file() and src_file.suffix == ".h":
@@ -430,10 +414,11 @@ class Buildroot:
             SystemExit: With exit code ``3`` if any required file is missing.
         """
         for lib in required_libs:
-            lib_path = self.path / "lib" / lib
+            br = _buildroot_dir()
+            lib_path = br / "lib" / lib
             if not lib_path.exists():
                 log.fatal(
-                    f"Required library '{lib}' not found in buildroot at {self.path}",
+                    f"Required library '{lib}' not found in buildroot at {br}",
                     code=EXIT_MISSING_DEP,
                     hint="Run `./z setup` to download build-time dependencies.",
                 )

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -15,6 +15,7 @@ from nanvix_zutil import log
 from nanvix_zutil.config import CFG_SYSROOT
 from nanvix_zutil.docker import DockerConfig, is_windows
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
+from nanvix_zutil.paths import nanvix_root
 
 if TYPE_CHECKING:
     from nanvix_zutil.script import ZScript
@@ -115,7 +116,7 @@ _CONFIG_FILES: dict[str, str] = {
 }
 
 
-def sync_configs(nanvix_dir: Path) -> None:
+def sync_configs() -> None:
     """Sync canonical tool configuration files into ``.nanvix/``.
 
     Copies config files shipped inside ``nanvix_zutil.configs`` to the
@@ -127,7 +128,7 @@ def sync_configs(nanvix_dir: Path) -> None:
     configs = importlib.resources.files("nanvix_zutil.configs")
     for src_name, dst_rel in _CONFIG_FILES.items():
         src = configs / src_name
-        dst = nanvix_dir / dst_rel
+        dst = nanvix_root() / dst_rel
         content = src.read_bytes()
         if dst.exists() and dst.read_bytes() == content:
             continue

--- a/src/nanvix_zutil/paths.py
+++ b/src/nanvix_zutil/paths.py
@@ -27,13 +27,16 @@ def nanvix_root() -> Path:
     """Path to the ``.nanvix`` directory.
 
     Resolved by walking up the file tree from the current working
-    directory.  Result is cached; call ``nanvix_root.cache_clear()`` to
-    re-resolve (primarily for tests).
+    directory.  The returned path is canonicalised via ``Path.resolve``
+    so that downstream comparisons are insensitive to platform path
+    aliasing (notably Windows 8.3 short names such as ``RUNNER~1``
+    versus their long-form equivalents).  Result is cached; call
+    ``nanvix_root.cache_clear()`` to re-resolve (primarily for tests).
     """
     for p in (Path.cwd(), *Path.cwd().parents):
         candidate = p / ".nanvix"
         if candidate.is_dir():
-            return candidate
+            return candidate.resolve()
     log.fatal(
         "Could not find .nanvix directory.",
         code=EXIT_MISSING_DEP,

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -64,6 +64,7 @@ from nanvix_zutil.helpers import (
 )
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
+from nanvix_zutil.paths import buildroot as _buildroot_dir
 from nanvix_zutil.resolver import is_stale, resolve
 from nanvix_zutil.sysroot import Sysroot
 
@@ -268,11 +269,10 @@ class ZScript:
                 )
             )
 
-        buildroot_dir = self.nanvix_dir / "buildroot"
-        if buildroot_dir.is_dir():
+        if _buildroot_dir().is_dir():
             mounts.append(
                 Mount(
-                    host_path=buildroot_dir,
+                    host_path=_buildroot_dir(),
                     container_path=BUILDROOT_CONTAINER_PATH,
                     readonly=False,
                 )
@@ -424,7 +424,7 @@ class ZScript:
             # paths (deps/<name>/) which are version-agnostic.
 
         if deps:
-            self.buildroot = Buildroot.create(self.nanvix_dir / "buildroot")
+            self.buildroot = Buildroot.create()
             for dep in deps:
                 # LOCAL deps: install from the filesystem path directly.
                 if dep.ref.kind == RefKind.LOCAL:
@@ -505,7 +505,7 @@ class ZScript:
                     raise
 
         self.config.save()
-        sync_configs(self.nanvix_dir)
+        sync_configs()
         return self._used_fallback
 
     def install_artifacts(self, output: str) -> None:

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -5,7 +5,6 @@
 
 import io
 import tarfile
-import tempfile
 import unittest
 import zipfile
 from pathlib import Path
@@ -22,6 +21,7 @@ from nanvix_zutil.buildroot import (
     parse_semver_tuple,
     suffix_dep,
 )
+from nanvix_zutil.paths import buildroot as _buildroot
 
 
 def _make_tar_bz2(members: dict[str, bytes]) -> bytes:
@@ -102,63 +102,52 @@ class TestBuildrootCreate(unittest.TestCase):
     """Buildroot.create() sets up the expected directory layout."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_creates_lib_dir(self) -> None:
-        dest = Path(self._tmpdir.name) / "br"
-        br = Buildroot.create(dest=dest)
-        self.assertTrue((br.path / "lib").is_dir())
+        Buildroot.create()
+        self.assertTrue((_buildroot() / "lib").is_dir())
 
     def test_creates_include_dir(self) -> None:
-        dest = Path(self._tmpdir.name) / "br"
-        br = Buildroot.create(dest=dest)
-        self.assertTrue((br.path / "include").is_dir())
+        Buildroot.create()
+        self.assertTrue((_buildroot() / "include").is_dir())
 
     def test_path_is_absolute(self) -> None:
-        dest = Path(self._tmpdir.name) / "br"
-        br = Buildroot.create(dest=dest)
-        self.assertTrue(br.path.is_absolute())
+        Buildroot.create()
+        self.assertTrue(_buildroot().is_absolute())
 
     def test_idempotent(self) -> None:
-        dest = Path(self._tmpdir.name) / "br"
-        br1 = Buildroot.create(dest=dest)
-        br2 = Buildroot.create(dest=dest)
-        self.assertEqual(br1.path, br2.path)
+        Buildroot.create()
+        Buildroot.create()
+        self.assertTrue((_buildroot() / "lib").is_dir())
 
 
 class TestBuildrootVerify(unittest.TestCase):
     """Buildroot.verify() checks that required libraries exist."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def test_verify_passes_when_libs_present(self) -> None:
-        dest = Path(self._tmpdir.name) / "br"
-        br = Buildroot.create(dest=dest)
-        (br.path / "lib" / "libz.a").write_bytes(b"")
+        br = Buildroot.create()
+        (_buildroot() / "lib" / "libz.a").write_bytes(b"")
         # Should not raise.
         br.verify(required_libs=["libz.a"])
 
     def test_verify_exits_3_when_lib_missing(self) -> None:
-        dest = Path(self._tmpdir.name) / "br"
-        br = Buildroot.create(dest=dest)
+        br = Buildroot.create()
         with self.assertRaises(SystemExit) as ctx:
             br.verify(required_libs=["libposix.a"])
         self.assertEqual(ctx.exception.code, 3)
 
     def test_verify_empty_list_passes(self) -> None:
-        dest = Path(self._tmpdir.name) / "br"
-        br = Buildroot.create(dest=dest)
+        br = Buildroot.create()
         br.verify(required_libs=[])
 
 
@@ -166,16 +155,13 @@ class TestBuildrootInstallDep(unittest.TestCase):
     """Buildroot.install_dep() extracts libs and headers correctly."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def _setup_buildroot(self) -> Buildroot:
-        dest = Path(self._tmpdir.name) / "br"
-        return Buildroot.create(dest=dest)
+        return Buildroot.create()
 
     def test_install_dep_extracts_lib(self) -> None:
         br = self._setup_buildroot()
@@ -188,19 +174,16 @@ class TestBuildrootInstallDep(unittest.TestCase):
         dep = Dependency(
             name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
         )
+        archive_path = Path.cwd() / "zlib.tar.bz2"
+        archive_path.write_bytes(archive)
 
         with patch(
             "nanvix_zutil.github.download_release_asset",
-            return_value=Path(self._tmpdir.name) / "zlib.tar.bz2",
-        ) as mock_dl:
-            # Write the fake archive so tarfile.open can read it.
-            archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
-            archive_path.write_bytes(archive)
-            mock_dl.return_value = archive_path
-
+            return_value=archive_path,
+        ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "lib" / "libz.a").exists())
+        self.assertTrue((_buildroot() / "lib" / "libz.a").exists())
 
     def test_install_dep_extracts_header(self) -> None:
         br = self._setup_buildroot()
@@ -213,7 +196,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
         dep = Dependency(
             name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
         )
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -222,7 +205,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "include" / "zlib.h").exists())
+        self.assertTrue((_buildroot() / "include" / "zlib.h").exists())
 
     def test_install_dep_selective_libs(self) -> None:
         br = self._setup_buildroot()
@@ -238,7 +221,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
             ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
             install_libs=["libz.a"],
         )
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -247,8 +230,8 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "lib" / "libz.a").exists())
-        self.assertFalse((br.path / "lib" / "libextra.a").exists())
+        self.assertTrue((_buildroot() / "lib" / "libz.a").exists())
+        self.assertFalse((_buildroot() / "lib" / "libextra.a").exists())
 
     def test_install_dep_selective_headers(self) -> None:
         br = self._setup_buildroot()
@@ -264,7 +247,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
             ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
             install_headers=["zlib.h"],
         )
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -273,13 +256,13 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "include" / "zlib.h").exists())
-        self.assertFalse((br.path / "include" / "internal.h").exists())
+        self.assertTrue((_buildroot() / "include" / "zlib.h").exists())
+        self.assertFalse((_buildroot() / "include" / "internal.h").exists())
 
     def test_install_dep_artifact_name_interpolated(self) -> None:
         br = self._setup_buildroot()
         archive = _make_tar_bz2({"sysroot/lib/libz.a": b""})
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
         dep = Dependency(
@@ -331,7 +314,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
             repo="nanvix/openssl",
             ref=Ref(kind=RefKind.TAG, value="v3.5.0"),
         )
-        archive_path = Path(self._tmpdir.name) / "openssl.tar.bz2"
+        archive_path = Path.cwd() / "openssl.tar.bz2"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -340,11 +323,11 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "include" / "openssl" / "ssl.h").exists())
-        self.assertTrue((br.path / "include" / "openssl" / "crypto.h").exists())
-        self.assertTrue((br.path / "lib" / "libssl.a").exists())
+        self.assertTrue((_buildroot() / "include" / "openssl" / "ssl.h").exists())
+        self.assertTrue((_buildroot() / "include" / "openssl" / "crypto.h").exists())
+        self.assertTrue((_buildroot() / "lib" / "libssl.a").exists())
         # Verify headers are NOT flattened to include/ssl.h
-        self.assertFalse((br.path / "include" / "ssl.h").exists())
+        self.assertFalse((_buildroot() / "include" / "ssl.h").exists())
 
     def test_install_dep_preserves_lib_subdirectory(self) -> None:
         """Libraries in subdirectories are extracted with directory structure preserved."""
@@ -360,7 +343,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
             repo="nanvix/openssl",
             ref=Ref(kind=RefKind.TAG, value="v3.5.0"),
         )
-        archive_path = Path(self._tmpdir.name) / "openssl.tar.bz2"
+        archive_path = Path.cwd() / "openssl.tar.bz2"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -369,8 +352,8 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "lib" / "engines" / "libcapi.a").exists())
-        self.assertTrue((br.path / "lib" / "libssl.a").exists())
+        self.assertTrue((_buildroot() / "lib" / "engines" / "libcapi.a").exists())
+        self.assertTrue((_buildroot() / "lib" / "libssl.a").exists())
 
     def test_install_dep_flat_tarball_without_segments(self) -> None:
         """Tarballs with bare filenames (no include/ or lib/ segment) still work."""
@@ -386,7 +369,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
             repo="nanvix/zlib",
             ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
         )
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -395,8 +378,8 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "lib" / "libz.a").exists())
-        self.assertTrue((br.path / "include" / "zlib.h").exists())
+        self.assertTrue((_buildroot() / "lib" / "libz.a").exists())
+        self.assertTrue((_buildroot() / "include" / "zlib.h").exists())
 
 
 class TestSuffixDep(unittest.TestCase):
@@ -468,16 +451,13 @@ class TestInstallDepPreResolvedRelease(unittest.TestCase):
     """Buildroot.install_dep with _release pre-resolved."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def _setup_buildroot(self) -> Buildroot:
-        dest = Path(self._tmpdir.name) / "br"
-        return Buildroot.create(dest=dest)
+        return Buildroot.create()
 
     def _make_archive(self) -> bytes:
         return _make_tar_bz2(
@@ -491,7 +471,7 @@ class TestInstallDepPreResolvedRelease(unittest.TestCase):
         """When _release is provided, it's forwarded to download_release_asset."""
         br = self._setup_buildroot()
         archive = self._make_archive()
-        archive_path = Path(self._tmpdir.name) / "zlib.tar.bz2"
+        archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
         dep = Dependency(
@@ -559,16 +539,13 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
     """Buildroot.install_dep() extracts libs and headers from .zip archives."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
         log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup()
         log_mod.set_json_mode(False)
 
     def _setup_buildroot(self) -> Buildroot:
-        dest = Path(self._tmpdir.name) / "br"
-        return Buildroot.create(dest=dest)
+        return Buildroot.create()
 
     def test_install_dep_zip_extracts_lib(self) -> None:
         br = self._setup_buildroot()
@@ -581,7 +558,7 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         dep = Dependency(
             name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
         )
-        archive_path = Path(self._tmpdir.name) / "zlib.zip"
+        archive_path = Path.cwd() / "zlib.zip"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -590,8 +567,8 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "lib" / "libz.a").exists())
-        self.assertEqual((br.path / "lib" / "libz.a").read_bytes(), b"lib-content")
+        self.assertTrue((_buildroot() / "lib" / "libz.a").exists())
+        self.assertEqual((_buildroot() / "lib" / "libz.a").read_bytes(), b"lib-content")
 
     def test_install_dep_zip_extracts_header(self) -> None:
         br = self._setup_buildroot()
@@ -604,7 +581,7 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         dep = Dependency(
             name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
         )
-        archive_path = Path(self._tmpdir.name) / "zlib.zip"
+        archive_path = Path.cwd() / "zlib.zip"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -613,9 +590,9 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "include" / "zlib.h").exists())
+        self.assertTrue((_buildroot() / "include" / "zlib.h").exists())
         self.assertEqual(
-            (br.path / "include" / "zlib.h").read_bytes(), b"header-content"
+            (_buildroot() / "include" / "zlib.h").read_bytes(), b"header-content"
         )
 
     def test_install_dep_zip_selective_libs(self) -> None:
@@ -632,7 +609,7 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
             ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
             install_libs=["libz.a"],
         )
-        archive_path = Path(self._tmpdir.name) / "zlib.zip"
+        archive_path = Path.cwd() / "zlib.zip"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -641,8 +618,8 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "lib" / "libz.a").exists())
-        self.assertFalse((br.path / "lib" / "libextra.a").exists())
+        self.assertTrue((_buildroot() / "lib" / "libz.a").exists())
+        self.assertFalse((_buildroot() / "lib" / "libextra.a").exists())
 
     def test_install_dep_zip_preserves_header_subdirectory(self) -> None:
         br = self._setup_buildroot()
@@ -658,7 +635,7 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
             repo="nanvix/openssl",
             ref=Ref(kind=RefKind.TAG, value="v3.5.0"),
         )
-        archive_path = Path(self._tmpdir.name) / "openssl.zip"
+        archive_path = Path.cwd() / "openssl.zip"
         archive_path.write_bytes(archive)
 
         with patch(
@@ -667,9 +644,9 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         ):
             br.install_dep(dep)
 
-        self.assertTrue((br.path / "include" / "openssl" / "ssl.h").exists())
-        self.assertTrue((br.path / "include" / "openssl" / "crypto.h").exists())
-        self.assertTrue((br.path / "lib" / "libssl.a").exists())
+        self.assertTrue((_buildroot() / "include" / "openssl" / "ssl.h").exists())
+        self.assertTrue((_buildroot() / "include" / "openssl" / "crypto.h").exists())
+        self.assertTrue((_buildroot() / "lib" / "libssl.a").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.log as log_mod
 from nanvix_zutil import helpers
+from nanvix_zutil import paths
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
@@ -149,10 +150,8 @@ class TestZScriptAutoSetup(unittest.TestCase):
             script = ZScript(Path(self._tmpdir.name))
             script.setup()
 
-        # Buildroot.create called once with the nanvix_dir/buildroot path.
-        mock_create.assert_called_once()
-        (create_path,), _ = mock_create.call_args
-        self.assertEqual(create_path, script.nanvix_dir / "buildroot")
+        # Buildroot.create called once (now takes no arguments).
+        mock_create.assert_called_once_with()
 
         # install_dep called once per dependency in the manifest.
         dep_count = len(script.manifest.dependencies)
@@ -1299,7 +1298,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
         # Dep was installed locally, buildroot should exist.
         self.assertIsNotNone(script.buildroot)
         # The local lib should have been copied into the buildroot.
-        buildroot_lib = script.buildroot.path / "lib" / "libz.a"  # type: ignore[union-attr]
+        buildroot_lib = paths.buildroot() / "lib" / "libz.a"  # type: ignore[union-attr]
         self.assertTrue(buildroot_lib.exists())
 
     def test_local_dep_no_github_call(self) -> None:
@@ -1996,7 +1995,7 @@ class TestOfflineMode(unittest.TestCase):
         mock_resolve.assert_not_called()
         # Dep should be installed in buildroot
         self.assertIsNotNone(script.buildroot)
-        buildroot_lib = script.buildroot.path / "lib" / "libz.a"  # type: ignore[union-attr]
+        buildroot_lib = paths.buildroot() / "lib" / "libz.a"  # type: ignore[union-attr]
         self.assertTrue(buildroot_lib.exists())
 
 


### PR DESCRIPTION
**Stacked on #242**
Part 4 of #239 

This PR migrates the buildroot class to remove any paths parameters and reference the canonical paths instead. With this, the buildroot class becomes stateless. Candidate to transfer to plain helper functions.

As a tag-along, helpers.sync_config() is migrated. This causes no test or downstream changes as this function is only used internally.

Note: There are no changes to sysroot's API intended in this stack. See #244 