### PR TITLE
[PATHS 5] ZScript class + __main__

### DIFF
--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -26,6 +26,7 @@ from nanvix_zutil import (
     log,
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
+from nanvix_zutil.paths import nanvix_root, repo_root
 from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
 
 
@@ -60,7 +61,7 @@ class BinHello(ZScript):
         """Return the effective buildroot path (translated for Docker if active)."""
         if self.docker:
             return BUILDROOT_CONTAINER_PATH
-        return self.nanvix_dir / "buildroot"
+        return nanvix_root() / "buildroot"
 
     # ------------------------------------------------------------------
     # Lifecycle hooks
@@ -104,7 +105,7 @@ class BinHello(ZScript):
             "-c",
             f"{cc} {cflags} -c -o main.o src/main.c"
             f" && {cc} {cflags} {ldflags} -o hello.elf main.o {libs}",
-            cwd=self.repo_root,
+            cwd=repo_root(),
             docker=self.docker,
         )
 
@@ -122,7 +123,7 @@ class BinHello(ZScript):
         not configured (the ``test`` subcommand does not enable Docker
         automatically).
         """
-        binary = self.repo_root / "hello.elf"
+        binary = repo_root() / "hello.elf"
 
         # Smoke: binary must exist and be non-trivially sized.
         log.info("=== bin-hello smoke tests ===")
@@ -199,7 +200,7 @@ class BinHello(ZScript):
             str(sysroot / "bin"),
             "--",
             str(binary),
-            cwd=self.repo_root,
+            cwd=repo_root(),
             timeout=60,
         )
         log.success("PASS: bin-hello functional tests")
@@ -207,7 +208,7 @@ class BinHello(ZScript):
     def clean(self) -> None:
         """Remove build artifacts."""
         for name in ("main.o", "hello.elf", "hello.img"):
-            artifact = self.repo_root / name
+            artifact = repo_root() / name
             if artifact.exists():
                 artifact.unlink()
 

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -25,6 +25,7 @@ from nanvix_zutil import (
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
 from nanvix_zutil.helpers import run
+from nanvix_zutil.paths import repo_root
 
 
 class LibHello(ZScript):
@@ -71,7 +72,7 @@ class LibHello(ZScript):
             "sh",
             "-c",
             f"{cc} {cflags} -c -o hello.o src/hello.c && {ar} rcs libhello.a hello.o",
-            cwd=self.repo_root,
+            cwd=repo_root(),
             docker=self.docker,
         )
 
@@ -81,7 +82,7 @@ class LibHello(ZScript):
         Smoke: libhello.a must exist and be non-trivially sized.
         Integration: verify archive magic (``!<arch>``).
         """
-        archive = self.repo_root / "libhello.a"
+        archive = repo_root() / "libhello.a"
 
         # Smoke: archive must exist and be non-trivially sized.
         log.info("=== lib-hello smoke tests ===")
@@ -106,7 +107,7 @@ class LibHello(ZScript):
     def clean(self) -> None:
         """Remove build artifacts."""
         for name in ("hello.o", "libhello.a"):
-            artifact = self.repo_root / name
+            artifact = repo_root() / name
             if artifact.exists():
                 artifact.unlink()
 

--- a/src/nanvix_zutil/__main__.py
+++ b/src/nanvix_zutil/__main__.py
@@ -23,6 +23,7 @@ from nanvix_zutil.format_cmd import HELP as _FORMAT_HELP
 from nanvix_zutil.info import HELP as _INFO_HELP
 from nanvix_zutil.lint_cmd import HELP as _LINT_HELP
 from nanvix_zutil.lockfile import get_zutil_version
+from nanvix_zutil.paths import z_py_path
 from nanvix_zutil.resolve_cmd import HELP as _RESOLVE_HELP
 from nanvix_zutil.script import ZScript
 
@@ -36,7 +37,7 @@ _STANDALONE_HELP: dict[str, str] = {
 }
 
 
-def discover_script_class(z_py: Path) -> type[ZScript]:
+def discover_script_class() -> type[ZScript]:
     """Import ``.nanvix/z.py`` and return the first ``ZScript`` subclass found.
 
     Args:
@@ -45,6 +46,13 @@ def discover_script_class(z_py: Path) -> type[ZScript]:
     Returns:
         The ``ZScript`` subclass defined in the consumer script.
     """
+    z_py = z_py_path()
+    if not z_py_path().exists():
+        log.fatal(
+            f".nanvix/z.py not found in {Path.cwd()}",
+            code=EXIT_MISSING_DEP,
+            hint="Run this command from a Nanvix consumer repo root.",
+        )
     spec = importlib.util.spec_from_file_location("_z_consumer", z_py)
     if spec is None or spec.loader is None:
         log.fatal(f"Cannot load {z_py}", code=EXIT_GENERAL_ERROR)
@@ -177,16 +185,8 @@ def main() -> None:
         build_parser().parse_args([subcmd, "--help"])
         return
 
-    z_py = Path.cwd() / ".nanvix" / "z.py"
-
-    if not z_py.exists():
-        log.fatal(
-            f".nanvix/z.py not found in {Path.cwd()}",
-            code=EXIT_MISSING_DEP,
-            hint="Run this command from a Nanvix consumer repo root.",
-        )
-    script_cls = discover_script_class(z_py)
-    script_cls.main(repo_root=Path.cwd())
+    script_cls = discover_script_class()
+    script_cls.main()
 
 
 if __name__ == "__main__":

--- a/src/nanvix_zutil/distclean_cmd.py
+++ b/src/nanvix_zutil/distclean_cmd.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 import argparse
 import shutil
 import sys
-from pathlib import Path
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_SUCCESS
+from nanvix_zutil.paths import nanvix_root
 
 HELP: str = "Remove all transient .nanvix/ artifacts"
 """One-line description surfaced in ``nanvix-zutil --help``."""
@@ -54,9 +54,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def distclean() -> None:
-    nanvix_dir = Path(sys.prefix).parent
     for artifact in _ARTIFACTS:
-        path = nanvix_dir / artifact
+        path = nanvix_root() / artifact
         if not path.exists() and not path.is_symlink():
             continue
         try:
@@ -72,19 +71,16 @@ def distclean() -> None:
 
 
 def _run_consumer_clean() -> None:
-    nanvix_dir = Path(sys.prefix).parent
-    z_py = nanvix_dir / "z.py"
+    z_py = nanvix_root() / "z.py"
     if not z_py.exists():
         return
-
-    repo_root = nanvix_dir.parent.resolve()
 
     # Lazy import: ``__main__`` imports this module at top level for HELP.
     from nanvix_zutil.__main__ import discover_script_class
 
     try:
-        script_cls = discover_script_class(z_py)
-        instance = script_cls(repo_root)
+        script_cls = discover_script_class()
+        instance = script_cls()
         instance.clean()
     except (Exception, SystemExit) as exc:
         log.warning(f"Consumer clean() failed: {exc}; continuing with distclean")

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -15,7 +15,7 @@ from nanvix_zutil import log
 from nanvix_zutil.config import CFG_SYSROOT
 from nanvix_zutil.docker import DockerConfig, is_windows
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
-from nanvix_zutil.paths import nanvix_root
+from nanvix_zutil.paths import nanvix_root, repo_root
 
 if TYPE_CHECKING:
     from nanvix_zutil.script import ZScript
@@ -223,7 +223,7 @@ def make_initrd(instance: "ZScript", app: str, args: InitRdArgs = InitRdArgs()) 
         )
 
     app_stem = Path(app).stem
-    output = instance.repo_root / f"{app_stem}.img"
+    output = repo_root() / f"{app_stem}.img"
 
     def _escape(arg: str) -> str:
         return arg.replace(";", "\\;")
@@ -258,7 +258,7 @@ def make_initrd(instance: "ZScript", app: str, args: InitRdArgs = InitRdArgs()) 
             ),
             _entry(args.bin_dir / "memd.elf", "memd", args.memd_args, args.memd_env),
             _entry(args.bin_dir / "vfsd.elf", "vfsd", args.vfsd_args, args.vfsd_env),
-            _entry(instance.repo_root / app, app, args.app_args, args.app_env),
+            _entry(repo_root() / app, app, args.app_args, args.app_env),
         ]
     )
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -65,6 +65,8 @@ from nanvix_zutil.helpers import (
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.paths import buildroot as _buildroot_dir
+from nanvix_zutil.paths import nanvix_root, out_dir, repo_root
+from nanvix_zutil.paths import sysroot as _sysroot_dir
 from nanvix_zutil.resolver import is_stale, resolve
 from nanvix_zutil.sysroot import Sysroot
 
@@ -91,8 +93,6 @@ class ZScript:
             ``.nanvix/env.json`` and environment variables.
         log: The :mod:`nanvix_zutil.log` module, accessible as ``self.log``
             for structured logging in lifecycle hooks.
-        repo_root: Absolute path to the consumer repository root.
-        nanvix_dir: Absolute path to the ``.nanvix/`` directory.
         targets: Arguments passed after ``--`` on the command line.
             Lifecycle hooks can use these to customise behavior
             (e.g. ``nanvix-zutil test -- smoke integration``).
@@ -187,15 +187,7 @@ class ZScript:
                 files.extend(self.SYSROOT_STANDALONE_FILES)
         return files
 
-    def __init__(self, repo_root: Path) -> None:
-        """Initialise ZScript for *repo_root*.
-
-        Args:
-            repo_root: Path to the consumer repository root.  Typically the
-                directory that contains the ``.nanvix/`` folder.
-        """
-        self.repo_root = repo_root.resolve()
-        self.nanvix_dir = self.repo_root / ".nanvix"
+    def __init__(self) -> None:
         self.config = Config()
         self.log = log
         self.targets: list[str] = []
@@ -237,7 +229,7 @@ class ZScript:
 
         Constructs a standard configuration that mounts:
 
-        * :attr:`repo_root` → ``/mnt/workspace`` (writable, workdir)
+        * :func:`repo_root()` → ``/mnt/workspace`` (writable, workdir)
         * sysroot path from :attr:`config` → ``/mnt/sysroot`` (read-only),
           if the sysroot has been configured
         * ``.nanvix/buildroot`` → ``/mnt/buildroot`` (writable),
@@ -253,7 +245,7 @@ class ZScript:
         """
         mounts: list[Mount] = [
             Mount(
-                host_path=self.repo_root,
+                host_path=repo_root(),
                 container_path=WORKSPACE_CONTAINER_PATH,
                 readonly=False,
             ),
@@ -370,7 +362,7 @@ class ZScript:
                 memory_size=self.config.memory_size,
                 tag=self.manifest.sysroot_ref.value,
                 gh_token=self.config.get(CFG_GH_TOKEN),
-                dest=self.nanvix_dir / "sysroot",
+                dest=_sysroot_dir(),
                 config=self.config,
             )
         self.config.set(CFG_SYSROOT, str(self.sysroot.path))
@@ -512,7 +504,7 @@ class ZScript:
         """Export build artifacts to a target directory.
 
         Copies the port's output ``.a`` libraries, headers, and binaries
-        into ``<output>/{lib,include,bin}/`` from ``.nanvix/output/``.
+        into ``<output>/{lib,include,bin}/`` from ``.nanvix/out/``.
 
         Note:
             This intentionally writes outside ``.nanvix/`` — it is the
@@ -524,11 +516,9 @@ class ZScript:
         output_path = Path(output)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        # Source: .nanvix/output/{lib,include,bin}/
-        src_output = self.nanvix_dir / "output"
-
+        # Source: .nanvix/out/{lib,include,bin}/
         for subdir in ("lib", "include", "bin"):
-            src = src_output / subdir
+            src = out_dir() / subdir
             if src.is_dir():
                 dst = output_path / subdir
                 dst.mkdir(parents=True, exist_ok=True)
@@ -553,7 +543,7 @@ class ZScript:
             gh_token=self.config.get(CFG_GH_TOKEN),
             shallow=shallow,
         )
-        lock_path = self.nanvix_dir / "nanvix.lock"
+        lock_path = nanvix_root() / "nanvix.lock"
         write_lockfile(lockfile, lock_path)
         log.success(f"Wrote {lock_path}")
 
@@ -563,7 +553,7 @@ class ZScript:
         Exits with ``EXIT_MISSING_DEP`` if the lockfile does not exist, or
         ``EXIT_INVALID_ARGS`` if it is stale relative to ``nanvix.toml``.
         """
-        lock_path = self.nanvix_dir / "nanvix.lock"
+        lock_path = nanvix_root() / "nanvix.lock"
         lockfile = read_lockfile(lock_path)
 
         # Warn when "latest" lockfile may silently be stale.
@@ -621,7 +611,7 @@ class ZScript:
             # Common artifacts that consumers may produce.
             # Subclasses can override to add project-specific files.
             for name in (".nanvix-configured",):
-                p = self.repo_root / name
+                p = repo_root() / name
                 if p.is_file():
                     p.unlink()
                     log.info(f"Removed {name}")
@@ -719,7 +709,7 @@ class ZScript:
             )
 
         app_stem = Path(app).stem
-        output = self.repo_root / f"{app_stem}.img"
+        output = repo_root() / f"{app_stem}.img"
 
         def _escape(arg: str) -> str:
             return arg.replace(";", "\\;")
@@ -752,7 +742,7 @@ class ZScript:
                 _entry(bin_dir / "procd.elf", "procd", procd_args, procd_env),
                 _entry(bin_dir / "memd.elf", "memd", memd_args, memd_env),
                 _entry(bin_dir / "vfsd.elf", "vfsd", vfsd_args, vfsd_env),
-                _entry(self.repo_root / app, app, app_args, app_env),
+                _entry(repo_root() / app, app, app_args, app_env),
             ]
         )
 
@@ -781,7 +771,7 @@ class ZScript:
         Args:
             *args: Command and arguments to execute.
             cwd: Working directory for the subprocess.  Defaults to
-                :attr:`repo_root`.  Ignored when Docker wrapping is active
+                :func:`repo_root()`.  Ignored when Docker wrapping is active
                 (the container workdir is controlled by
                 :class:`~nanvix_zutil.DockerConfig`).
             env: Environment variables for the subprocess.  ``None`` inherits
@@ -815,11 +805,11 @@ class ZScript:
                 cmd = cfg.build_windows_run_cmd(*args)
             else:
                 cmd = cfg.build_run_cmd(*args)
-            working_dir = self.repo_root
+            working_dir = repo_root()
             subprocess_env: dict[str, str] | None = None
         else:
             cmd = list(args)
-            working_dir = cwd if cwd is not None else self.repo_root
+            working_dir = cwd if cwd is not None else repo_root()
             if env is not None:
                 subprocess_env = env
             else:
@@ -852,20 +842,9 @@ class ZScript:
     # ------------------------------------------------------------------
 
     @classmethod
-    def main(cls, *, repo_root: Path | None = None) -> None:
+    def main(cls) -> None:
         """Parse command-line arguments and dispatch to the appropriate
-        lifecycle hook.
-
-        When *repo_root* is ``None`` (the default — direct invocation via
-        ``python .nanvix/z.py``), the repository root is inferred from
-        ``sys.argv[0]``.  When provided (by the ``nanvix-zutil`` CLI),
-        the inference is skipped entirely.
-
-        Args:
-            repo_root: Optional explicit path to the consumer repository
-                root.  When ``None``, the root is inferred from the
-                location of the calling script.
-        """
+        lifecycle hook."""
         argv = sys.argv[1:]
 
         # Split sys.argv on '--' to separate framework args from targets.
@@ -911,15 +890,6 @@ class ZScript:
             build_parser().print_help()  # 'help' subcommand or no args
             return
 
-        # Infer repo root: the parent of the .nanvix/ directory.
-        if repo_root is None:
-            script_path = Path(sys.argv[0]).resolve()
-            # z.py lives at <repo>/.nanvix/z.py → repo_root is two levels up.
-            if script_path.parent.name == ".nanvix":
-                repo_root = script_path.parent.parent
-            else:
-                repo_root = script_path.parent
-
         # ------------------------------------------------------------------
         # Handle --mode: override NANVIX_DEPLOYMENT_MODE before Config
         # __init__ reads it during instance construction.
@@ -928,7 +898,7 @@ class ZScript:
         if cli_mode is not None:
             os.environ["NANVIX_DEPLOYMENT_MODE"] = cli_mode
 
-        instance = cls(repo_root)
+        instance = cls()
         instance.targets = targets
 
         # Build the parser dynamically: auto hooks are always registered;

--- a/tests/test_cli_lock.py
+++ b/tests/test_cli_lock.py
@@ -6,12 +6,12 @@
 from __future__ import annotations
 
 import os
-import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.log as log_mod
+from nanvix_zutil import paths
 from nanvix_zutil.buildroot import Ref, RefKind
 from nanvix_zutil.cli import build_parser
 from nanvix_zutil.lockfile import (
@@ -22,7 +22,7 @@ from nanvix_zutil.lockfile import (
     write_lockfile,
 )
 from nanvix_zutil.script import ZScript
-from tests.testutils import chdir_to, write_manifest
+from tests.testutils import write_manifest
 
 
 def _make_mock_lockfile(manifest_path: Path) -> Lockfile:
@@ -88,8 +88,6 @@ class TestLockMethod(unittest.TestCase):
     """ZScript.lock() resolves deps and writes a lockfile."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         log_mod.set_json_mode(True)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
@@ -100,24 +98,22 @@ class TestLockMethod(unittest.TestCase):
 
     @patch("nanvix_zutil.script.resolve")
     def test_lock_writes_lockfile(self, mock_resolve: MagicMock) -> None:
-        repo_root = Path(self._tmpdir.name)
-        manifest_path = repo_root / ".nanvix" / "nanvix.toml"
+        manifest_path = paths.manifest_path()
         mock_resolve.return_value = _make_mock_lockfile(manifest_path)
 
-        script = ZScript(repo_root)
+        script = ZScript()
         script.lock()
 
-        lock_path = repo_root / ".nanvix" / "nanvix.lock"
+        lock_path = paths.nanvix_root() / "nanvix.lock"
         self.assertTrue(lock_path.is_file())
         mock_resolve.assert_called_once()
 
     @patch("nanvix_zutil.script.resolve")
     def test_lock_shallow(self, mock_resolve: MagicMock) -> None:
-        repo_root = Path(self._tmpdir.name)
-        manifest_path = repo_root / ".nanvix" / "nanvix.toml"
+        manifest_path = paths.manifest_path()
         mock_resolve.return_value = _make_mock_lockfile(manifest_path)
 
-        script = ZScript(repo_root)
+        script = ZScript()
         script.lock(shallow=True)
 
         _, kwargs = mock_resolve.call_args
@@ -128,8 +124,6 @@ class TestLockCheck(unittest.TestCase):
     """ZScript.lock_check() verifies lockfile freshness."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         log_mod.set_json_mode(True)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
@@ -139,21 +133,19 @@ class TestLockCheck(unittest.TestCase):
         log_mod.set_json_mode(False)
 
     def test_lock_check_exits_0_when_fresh(self) -> None:
-        repo_root = Path(self._tmpdir.name)
-        manifest_path = repo_root / ".nanvix" / "nanvix.toml"
-        lock_path = repo_root / ".nanvix" / "nanvix.lock"
+        manifest_path = paths.manifest_path()
+        lock_path = paths.nanvix_root() / "nanvix.lock"
 
         lockfile = _make_mock_lockfile(manifest_path)
         write_lockfile(lockfile, lock_path)
 
-        script = ZScript(repo_root)
+        script = ZScript()
         # Should not raise
         script.lock_check()
 
     def test_lock_check_exits_2_when_stale(self) -> None:
-        repo_root = Path(self._tmpdir.name)
-        manifest_path = repo_root / ".nanvix" / "nanvix.toml"
-        lock_path = repo_root / ".nanvix" / "nanvix.lock"
+        manifest_path = paths.manifest_path()
+        lock_path = paths.nanvix_root() / "nanvix.lock"
 
         lockfile = _make_mock_lockfile(manifest_path)
         write_lockfile(lockfile, lock_path)
@@ -166,15 +158,13 @@ class TestLockCheck(unittest.TestCase):
             'nanvix-version = "0.2.0"\n'
         )
 
-        script = ZScript(repo_root)
+        script = ZScript()
         with self.assertRaises(SystemExit) as ctx:
             script.lock_check()
         self.assertEqual(ctx.exception.code, 2)
 
     def test_lock_check_exits_3_when_missing(self) -> None:
-        repo_root = Path(self._tmpdir.name)
-
-        script = ZScript(repo_root)
+        script = ZScript()
         with self.assertRaises(SystemExit) as ctx:
             script.lock_check()
         self.assertEqual(ctx.exception.code, 3)

--- a/tests/test_distclean_cmd.py
+++ b/tests/test_distclean_cmd.py
@@ -4,126 +4,101 @@
 # pyright: reportPrivateUsage=false
 """Tests for nanvix_zutil.distclean_cmd."""
 
-import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from nanvix_zutil import paths
 from nanvix_zutil.distclean_cmd import _run_consumer_clean, distclean, main
-
-from tests.testutils import chdir_to, write_manifest
-
-
-def _patch_prefix(nanvix_dir: Path):
-    """Patch ``sys.prefix`` so distclean helpers resolve *nanvix_dir*.
-
-    ``distclean()`` and ``_run_consumer_clean()`` compute
-    ``nanvix_dir = Path(sys.prefix).parent`` on the assumption that the
-    active venv lives at ``<nanvix-dir>/venv``.  Tests fake this by
-    pointing ``sys.prefix`` at ``<nanvix-dir>/venv`` (the path need not
-    exist on disk).
-    """
-    return patch("nanvix_zutil.distclean_cmd.sys.prefix", str(nanvix_dir / "venv"))
+from tests.testutils import write_manifest
 
 
 class TestDistcleanFunction(unittest.TestCase):
     """Behaviour of the standalone ``distclean()`` helper."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self.nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
-        self.nanvix_dir.mkdir()
-        (self.nanvix_dir / "nanvix.toml").write_text("")
+        # Autouse fixture provides Path.cwd()/.nanvix as a fresh dir.
+        self.nanvix_dir = paths.nanvix_root()
+        (paths.manifest_path()).write_text("")
 
     def test_removes_sysroot(self) -> None:
-        sysroot = self.nanvix_dir / "sysroot"
+        sysroot = paths.sysroot()
         sysroot.mkdir()
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(sysroot.exists())
 
     def test_removes_buildroot(self) -> None:
-        buildroot = self.nanvix_dir / "buildroot"
+        buildroot = paths.buildroot()
         buildroot.mkdir()
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(buildroot.exists())
 
     def test_removes_cache(self) -> None:
         cache = self.nanvix_dir / "cache"
         cache.mkdir()
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(cache.exists())
 
     def test_preserves_manifest(self) -> None:
-        manifest = self.nanvix_dir / "nanvix.toml"
+        manifest = paths.manifest_path()
         self.assertTrue(manifest.exists())
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertTrue(manifest.exists())
 
     def test_removes_env_json(self) -> None:
         cfg = self.nanvix_dir / "env.json"
         cfg.write_text("{}")
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(cfg.exists())
 
     def test_removes_venv(self) -> None:
         venv = self.nanvix_dir / "venv"
         venv.mkdir()
         (venv / "pyvenv.cfg").write_text("home = /usr/bin")
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(venv.exists())
 
     def test_removes_pycache(self) -> None:
         pycache = self.nanvix_dir / "__pycache__"
         pycache.mkdir()
         (pycache / "z.cpython-312.pyc").write_bytes(b"\x00")
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(pycache.exists())
 
     def test_noop_when_nothing_exists(self) -> None:
         """distclean does not raise when artifact dirs are absent."""
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
 
     def test_removes_file_artifact(self) -> None:
         """A regular file at an artifact path is unlinked."""
-        sysroot_file = self.nanvix_dir / "sysroot"
+        sysroot_file = paths.sysroot()
         sysroot_file.write_text("not a directory")
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(sysroot_file.exists())
 
     def test_removes_symlink_artifact(self) -> None:
         """A symlink at an artifact path is unlinked."""
         target = self.nanvix_dir / "real_sysroot"
         target.mkdir()
-        link = self.nanvix_dir / "sysroot"
+        link = paths.sysroot()
         try:
             link.symlink_to(target)
         except (OSError, NotImplementedError):
             self.skipTest("Symlinks not supported on this platform")
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(link.exists())
 
     def test_removes_broken_symlink(self) -> None:
         """A dangling symlink is unlinked."""
         target = self.nanvix_dir / "real_sysroot"
         target.mkdir()
-        link = self.nanvix_dir / "sysroot"
+        link = paths.sysroot()
         try:
             link.symlink_to(target)
         except (OSError, NotImplementedError):
             self.skipTest("Symlinks not supported on this platform")
         target.rmdir()
-        with _patch_prefix(self.nanvix_dir):
-            distclean()
+        distclean()
         self.assertFalse(link.is_symlink())
 
     def test_continues_on_permission_error(self) -> None:
@@ -140,10 +115,7 @@ class TestDistcleanFunction(unittest.TestCase):
                 raise PermissionError("locked by running process")
             original_rmtree(path, *args, **kwargs)  # type: ignore[arg-type]
 
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("shutil.rmtree", side_effect=_rmtree_fail_on_venv),
-        ):
+        with patch("shutil.rmtree", side_effect=_rmtree_fail_on_venv):
             distclean()
 
         self.assertTrue(venv.exists())
@@ -155,59 +127,44 @@ class TestDistcleanMain(unittest.TestCase):
 
     def test_main_no_artifacts_exits_zero(self) -> None:
         """Exits 0 when there is nothing to clean."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / ".nanvix"
-            nanvix_dir.mkdir()
-            with (
-                _patch_prefix(nanvix_dir),
-                patch("sys.argv", ["nanvix-zutil distclean"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            self.assertEqual(ctx.exception.code, 0)
+        with (
+            patch("sys.argv", ["nanvix-zutil distclean"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 0)
 
     def test_main_removes_resolved_artifacts(self) -> None:
-        """Artifacts under the dir resolved from ``sys.prefix`` are removed."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / "custom-dir"
-            nanvix_dir.mkdir()
-            (nanvix_dir / "sysroot").mkdir()
-            with (
-                _patch_prefix(nanvix_dir),
-                patch("sys.argv", ["nanvix-zutil distclean"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            self.assertEqual(ctx.exception.code, 0)
-            self.assertFalse((nanvix_dir / "sysroot").exists())
+        """Artifacts under the .nanvix dir in CWD are removed."""
+        paths.sysroot().mkdir()
+        with (
+            patch("sys.argv", ["nanvix-zutil distclean"]),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertFalse((paths.sysroot()).exists())
 
     def test_main_rejects_unknown_args(self) -> None:
-        """The parser no longer accepts ``--nanvix-dir`` (resolved via sys.prefix)."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nanvix_dir = Path(tmpdir) / "custom-dir"
-            nanvix_dir.mkdir()
-            with (
-                _patch_prefix(nanvix_dir),
-                patch(
-                    "sys.argv",
-                    ["nanvix-zutil distclean", "--nanvix-dir", str(nanvix_dir)],
-                ),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-            # argparse exits 2 on unrecognised args
-            self.assertEqual(ctx.exception.code, 2)
+        """The parser no longer accepts ``--nanvix-dir`` (resolved from CWD)."""
+        with (
+            patch(
+                "sys.argv",
+                ["nanvix-zutil distclean", "--nanvix-dir", "/tmp"],
+            ),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            main()
+        # argparse exits 2 on unrecognised args
+        self.assertEqual(ctx.exception.code, 2)
 
 
 class TestRunConsumerClean(unittest.TestCase):
     """_run_consumer_clean() invokes the subclass clean() hook, best-effort."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self.repo_root = Path(self._tmpdir.name)
-        self.nanvix_dir = self.repo_root / ".nanvix"
-        self.nanvix_dir.mkdir()
-        chdir_to(self, self._tmpdir)
+        self.repo_root = paths.repo_root()
+        self.nanvix_dir = paths.nanvix_root()
         write_manifest()
         # Stamp file the consumer clean() can touch so we can assert it ran.
         self.stamp = self.repo_root / "clean.stamp"
@@ -224,10 +181,7 @@ class TestRunConsumerClean(unittest.TestCase):
 
     def test_no_z_py_is_silent_noop(self) -> None:
         """When .nanvix/z.py is absent, the helper returns silently."""
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("nanvix_zutil.distclean_cmd.log") as mock_log,
-        ):
+        with patch("nanvix_zutil.distclean_cmd.log") as mock_log:
             _run_consumer_clean()
         mock_log.warning.assert_not_called()
         mock_log.info.assert_not_called()
@@ -238,8 +192,7 @@ class TestRunConsumerClean(unittest.TestCase):
             "    def clean(self) -> None:\n"
             f"        open(r'{self.stamp}', 'w').close()\n"
         )
-        with _patch_prefix(self.nanvix_dir):
-            _run_consumer_clean()
+        _run_consumer_clean()
         self.assertTrue(self.stamp.exists(), "consumer clean() was not invoked")
 
     def test_clean_failure_is_swallowed(self) -> None:
@@ -247,10 +200,7 @@ class TestRunConsumerClean(unittest.TestCase):
         self._write_z_py(
             "    def clean(self) -> None:\n" "        raise RuntimeError('boom')\n"
         )
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("nanvix_zutil.distclean_cmd.log") as mock_log,
-        ):
+        with patch("nanvix_zutil.distclean_cmd.log") as mock_log:
             _run_consumer_clean()
         mock_log.warning.assert_called_once()
         self.assertIn("boom", mock_log.warning.call_args[0][0])
@@ -258,10 +208,7 @@ class TestRunConsumerClean(unittest.TestCase):
     def test_import_failure_is_swallowed(self) -> None:
         """A malformed z.py is logged and does not propagate."""
         (self.nanvix_dir / "z.py").write_text("this is not valid python(\n")
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("nanvix_zutil.distclean_cmd.log") as mock_log,
-        ):
+        with patch("nanvix_zutil.distclean_cmd.log") as mock_log:
             _run_consumer_clean()
         mock_log.warning.assert_called_once()
         self.assertIn("Consumer clean() failed", mock_log.warning.call_args[0][0])
@@ -269,22 +216,16 @@ class TestRunConsumerClean(unittest.TestCase):
     def test_missing_subclass_is_swallowed(self) -> None:
         """A z.py with no ZScript subclass is logged and skipped."""
         (self.nanvix_dir / "z.py").write_text("x = 1\n")
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("nanvix_zutil.distclean_cmd.log") as mock_log,
-        ):
+        with patch("nanvix_zutil.distclean_cmd.log") as mock_log:
             _run_consumer_clean()
         mock_log.warning.assert_called_once()
         self.assertIn("Consumer clean() failed", mock_log.warning.call_args[0][0])
 
     def test_missing_manifest_is_swallowed(self) -> None:
         """ZScript.__init__ failing (no manifest) is logged and skipped."""
-        (self.nanvix_dir / "nanvix.toml").unlink()
+        (paths.manifest_path()).unlink()
         self._write_z_py("    def clean(self) -> None:\n" "        pass\n")
-        with (
-            _patch_prefix(self.nanvix_dir),
-            patch("nanvix_zutil.distclean_cmd.log") as mock_log,
-        ):
+        with patch("nanvix_zutil.distclean_cmd.log") as mock_log:
             _run_consumer_clean()
         mock_log.warning.assert_called_once()
         self.assertIn("clean() failed", mock_log.warning.call_args[0][0])
@@ -294,13 +235,11 @@ class TestMainIntegration(unittest.TestCase):
     """main() runs consumer clean() then removes artifacts in one call."""
 
     def test_main_calls_clean_then_distcleans(self) -> None:
-        tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, tmpdir)
-        repo_root = Path(tmpdir.name)
-        nanvix_dir = repo_root / ".nanvix"
+        repo_root = paths.repo_root()
+        nanvix_dir = paths.nanvix_root()
         write_manifest()
         stamp = repo_root / "clean.stamp"
-        sysroot = nanvix_dir / "sysroot"
+        sysroot = paths.sysroot()
         sysroot.mkdir()
         (nanvix_dir / "z.py").write_text(
             "from nanvix_zutil.script import ZScript\n"
@@ -311,7 +250,6 @@ class TestMainIntegration(unittest.TestCase):
         )
 
         with (
-            _patch_prefix(nanvix_dir),
             patch("sys.argv", ["nanvix-zutil distclean"]),
             self.assertRaises(SystemExit) as ctx,
         ):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,6 @@ subclasses :class:`~nanvix_zutil.ZScript` and implements all lifecycle hooks.
 import json
 import os
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -18,7 +17,8 @@ from unittest.mock import patch
 import nanvix_zutil.log as log_mod
 from nanvix_zutil import ZScript
 from nanvix_zutil.helpers import run
-from tests.testutils import chdir_to, write_manifest
+from nanvix_zutil.paths import manifest_path, nanvix_root, repo_root
+from tests.testutils import write_manifest
 
 # ---------------------------------------------------------------------------
 # Mock consumer
@@ -28,8 +28,8 @@ from tests.testutils import chdir_to, write_manifest
 class _MockConsumer(ZScript):
     """Mock consumer that records which lifecycle hooks are called."""
 
-    def __init__(self, repo_root: Path) -> None:
-        super().__init__(repo_root)
+    def __init__(self) -> None:
+        super().__init__()
         self.called: list[str] = []
 
     def setup(self) -> bool:
@@ -62,9 +62,7 @@ class TestIntegrationLifecycle(unittest.TestCase):
     """Full lifecycle dispatch through ZScript.main()."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._repo_root = Path(self._tmpdir.name)
-        chdir_to(self, self._tmpdir)
+        # Autouse fixture supplies a tmp CWD with .nanvix/.
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -79,13 +77,8 @@ class TestIntegrationLifecycle(unittest.TestCase):
     def _run_main(
         self, subcommand: str, extra_argv: list[str] | None = None
     ) -> _MockConsumer:
-        """Run _MockConsumer.main() with *subcommand* and return the instance.
-
-        Patches ``sys.argv`` and captures the created instance by
-        temporarily monkeypatching the class constructor.
-        """
-        # z.py lives at <repo>/.nanvix/z.py — script_path.parent.name == ".nanvix"
-        fake_script = str(self._repo_root / ".nanvix" / "z.py")
+        """Run _MockConsumer.main() with *subcommand* and return the instance."""
+        fake_script = str(repo_root() / ".nanvix" / "z.py")
         argv = [fake_script, subcommand] + (extra_argv or [])
 
         # setup requires --with-docker IMAGE on the CLI.
@@ -95,7 +88,7 @@ class TestIntegrationLifecycle(unittest.TestCase):
         # build/release/clean need a persisted Docker image.
         _DOCKER_COMMANDS = {"build", "release", "clean"}
         if subcommand in _DOCKER_COMMANDS:
-            nanvix_dir = self._repo_root / ".nanvix"
+            nanvix_dir = nanvix_root()
             env_json = nanvix_dir / "env.json"
             if not env_json.exists():
                 env_json.write_text('{"NANVIX_DOCKER_IMAGE": "test/image:tag"}')
@@ -103,8 +96,8 @@ class TestIntegrationLifecycle(unittest.TestCase):
         created: list[_MockConsumer] = []
         original_init = _MockConsumer.__init__
 
-        def capturing_init(self_: _MockConsumer, repo_root: Path) -> None:
-            original_init(self_, repo_root)
+        def capturing_init(self_: _MockConsumer) -> None:
+            original_init(self_)
             created.append(self_)
 
         with (
@@ -143,10 +136,10 @@ class TestIntegrationLifecycle(unittest.TestCase):
         """--json flag produces JSON output on stderr."""
         from io import StringIO
 
-        fake_script = str(self._repo_root / ".nanvix" / "z.py")
+        fake_script = str(nanvix_root() / "z.py")
 
         # build needs a persisted Docker image.
-        nanvix_dir = self._repo_root / ".nanvix"
+        nanvix_dir = repo_root() / ".nanvix"
         (nanvix_dir / "env.json").write_text(
             '{"NANVIX_DOCKER_IMAGE": "test/image:tag"}'
         )
@@ -171,54 +164,48 @@ class TestIntegrationLifecycle(unittest.TestCase):
 
     def test_help_subcommand_returns(self) -> None:
         """help subcommand prints help and returns without calling any hook."""
-        fake_script = str(self._repo_root / ".nanvix" / "z.py")
+        fake_script = str(nanvix_root() / "z.py")
         with patch("sys.argv", [fake_script, "help"]):
             # Should not raise.
             _MockConsumer.main()
 
     def test_no_subcommand_returns(self) -> None:
         """Missing subcommand prints help and returns without calling any hook."""
-        fake_script = str(self._repo_root / ".nanvix" / "z.py")
+        fake_script = str(nanvix_root() / "z.py")
         with patch("sys.argv", [fake_script]):
             _MockConsumer.main()
 
     def test_help_without_manifest_does_not_exit_with_missing_dep(self) -> None:
         """'help' works even when nanvix.toml is absent (no EXIT_MISSING_DEP)."""
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as empty_dir:
-            fake_script = str(Path(empty_dir) / ".nanvix" / "z.py")
-            with patch("sys.argv", [fake_script, "help"]):
-                # Must not raise SystemExit(3) or any other error.
-                _MockConsumer.main()
+        manifest_path().unlink()
+        fake_script = str(nanvix_root() / "z.py")
+        with patch("sys.argv", [fake_script, "help"]):
+            _MockConsumer.main()
 
     def test_no_subcommand_without_manifest_does_not_exit_with_missing_dep(
         self,
     ) -> None:
         """No-subcommand invocation works even when nanvix.toml is absent."""
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as empty_dir:
-            fake_script = str(Path(empty_dir) / ".nanvix" / "z.py")
-            with patch("sys.argv", [fake_script]):
-                _MockConsumer.main()
+        manifest_path().unlink()
+        fake_script = str(nanvix_root() / "z.py")
+        with patch("sys.argv", [fake_script]):
+            _MockConsumer.main()
 
     def test_repo_root_inferred_from_nanvix_dir(self) -> None:
-        """Repo root is the parent of the .nanvix/ directory."""
-        fake_script = str(self._repo_root / ".nanvix" / "z.py")
-
+        """paths.repo_root() resolves to the parent of the .nanvix/ directory."""
         # build needs a persisted Docker image.
-        nanvix_dir = self._repo_root / ".nanvix"
+        nanvix_dir = nanvix_root()
         (nanvix_dir / "env.json").write_text(
             '{"NANVIX_DOCKER_IMAGE": "test/image:tag"}'
         )
 
+        fake_script = str(nanvix_root() / "z.py")
         captured: list[Path] = []
         original_init = _MockConsumer.__init__
 
-        def capturing_init(self_: _MockConsumer, repo_root: Path) -> None:
-            original_init(self_, repo_root)
-            captured.append(repo_root)
+        def capturing_init(self_: _MockConsumer) -> None:
+            original_init(self_)
+            captured.append(repo_root())
 
         with (
             patch.object(_MockConsumer, "__init__", capturing_init),
@@ -226,7 +213,7 @@ class TestIntegrationLifecycle(unittest.TestCase):
         ):
             _MockConsumer.main()
 
-        self.assertEqual(captured[0], self._repo_root.resolve())
+        self.assertEqual(captured[0], repo_root())
 
     def test_config_defaults_accessible(self) -> None:
         """Config is accessible from the script and has expected defaults."""
@@ -255,9 +242,6 @@ class TestIntegrationConfigPersistence(unittest.TestCase):
     """Config.save() / load() round-trip via ZScript."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._repo_root = Path(self._tmpdir.name)
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -267,12 +251,12 @@ class TestIntegrationConfigPersistence(unittest.TestCase):
         log_mod.set_json_mode(False)
 
     def test_config_save_and_reload(self) -> None:
-        script = _MockConsumer(self._repo_root)
+        script = _MockConsumer()
         script.config.set("NANVIX_SYSROOT", "/tmp/sysroot")
         script.config.save()
 
         # A fresh instance should see the persisted value.
-        script2 = _MockConsumer(self._repo_root)
+        script2 = _MockConsumer()
         self.assertEqual(script2.config.get("NANVIX_SYSROOT"), "/tmp/sysroot")
 
 
@@ -280,9 +264,6 @@ class TestIntegrationRunSubprocess(unittest.TestCase):
     """The ``run`` helper executes subprocesses and propagates errors."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._repo_root = Path(self._tmpdir.name)
-        chdir_to(self, self._tmpdir)
         write_manifest()
         log_mod.set_json_mode(False)
 
@@ -290,21 +271,14 @@ class TestIntegrationRunSubprocess(unittest.TestCase):
         log_mod.set_json_mode(False)
 
     def test_run_echo_succeeds(self) -> None:
-        result = run(
-            sys.executable, "-c", "import sys; sys.exit(0)", cwd=self._repo_root
-        )
+        result = run(sys.executable, "-c", "import sys; sys.exit(0)", cwd=repo_root())
         self.assertEqual(result.returncode, 0)
 
     def test_run_exit_nonzero_raises_system_exit_5(self) -> None:
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                run(
-                    sys.executable,
-                    "-c",
-                    "import sys; sys.exit(2)",
-                    cwd=self._repo_root,
-                )
+                run(sys.executable, "-c", "import sys; sys.exit(2)", cwd=repo_root())
             self.assertEqual(ctx.exception.code, 5)
         finally:
             log_mod.set_json_mode(False)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 from nanvix_zutil.__main__ import main
 from nanvix_zutil.lockfile import get_zutil_version
+from nanvix_zutil.paths import manifest_path, z_py_path
 
 
 class TestVersionFlag(unittest.TestCase):
@@ -159,42 +160,33 @@ class TestConsumerCommandWithZPy(unittest.TestCase):
             discover_script_class,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            repo_root = Path(tmpdir)
-            nanvix_dir = repo_root / ".nanvix"
-            nanvix_dir.mkdir()
-            (nanvix_dir / "nanvix.toml").write_text(
-                '[package]\nname = "test"\nversion = "0.1.0"\n'
-                'nanvix-version = "0.1.0"\n'
-            )
-            (nanvix_dir / "z.py").write_text(textwrap.dedent("""\
-                from nanvix_zutil.script import ZScript
+        manifest_path().write_text(
+            '[package]\nname = "test"\nversion = "0.1.0"\n' 'nanvix-version = "0.1.0"\n'
+        )
+        z_py_path().write_text(textwrap.dedent("""\
+            from nanvix_zutil.script import ZScript
 
-                class TestScript(ZScript):
-                    def build(self):
-                        pass
+            class TestScript(ZScript):
+                def build(self):
+                    pass
 
-                if __name__ == "__main__":
-                    TestScript.main()
-                """))
+            if __name__ == "__main__":
+                TestScript.main()
+            """))
 
-            cls = discover_script_class(nanvix_dir / "z.py")
-            self.assertEqual(cls.__name__, "TestScript")
+        cls = discover_script_class()
+        self.assertEqual(cls.__name__, "TestScript")
 
-            # Verify main() dispatches correctly by mocking the
-            # discovered class's main().
-            with (
-                patch("sys.argv", ["nanvix-zutil", "build"]),
-                patch(
-                    "nanvix_zutil.__main__.Path.cwd",
-                    return_value=repo_root,
-                ),
-                patch("nanvix_zutil.__main__.discover_script_class") as mock_discover,
-            ):
-                mock_cls = MagicMock()
-                mock_discover.return_value = mock_cls
-                main()
-                mock_cls.main.assert_called_once_with(repo_root=repo_root)
+        # Verify main() dispatches correctly by mocking the
+        # discovered class's main().
+        with (
+            patch("sys.argv", ["nanvix-zutil", "build"]),
+            patch("nanvix_zutil.__main__.discover_script_class") as mock_discover,
+        ):
+            mock_cls = MagicMock()
+            mock_discover.return_value = mock_cls
+            main()
+            mock_cls.main.assert_called_once_with()
 
     def test_discover_subclass(self) -> None:
         """discover_script_class finds the ZScript subclass in z.py."""
@@ -202,23 +194,21 @@ class TestConsumerCommandWithZPy(unittest.TestCase):
             discover_script_class,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            z_py = Path(tmpdir) / "z.py"
-            z_py.write_text(textwrap.dedent("""\
-                from nanvix_zutil.script import ZScript
+        z_py_path().write_text(textwrap.dedent("""\
+            from nanvix_zutil.script import ZScript
 
-                class MyBuild(ZScript):
-                    def build(self):
-                        pass
+            class MyBuild(ZScript):
+                def build(self):
+                    pass
 
-                if __name__ == "__main__":
-                    MyBuild.main()
-                """))
-            cls = discover_script_class(z_py)
-            self.assertIsNot(
-                cls, __import__("nanvix_zutil.script", fromlist=["ZScript"]).ZScript
-            )
-            self.assertEqual(cls.__name__, "MyBuild")
+            if __name__ == "__main__":
+                MyBuild.main()
+            """))
+        cls = discover_script_class()
+        self.assertIsNot(
+            cls, __import__("nanvix_zutil.script", fromlist=["ZScript"]).ZScript
+        )
+        self.assertEqual(cls.__name__, "MyBuild")
 
     def test_no_subclass_exits(self) -> None:
         """discover_script_class exits with error if no subclass found."""
@@ -226,23 +216,19 @@ class TestConsumerCommandWithZPy(unittest.TestCase):
             discover_script_class,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            z_py = Path(tmpdir) / "z.py"
-            z_py.write_text("x = 42\n")
-            with self.assertRaises(SystemExit) as ctx:
-                discover_script_class(z_py)
-            self.assertEqual(ctx.exception.code, 1)
+        z_py_path().write_text("x = 42\n")
+        with self.assertRaises(SystemExit) as ctx:
+            discover_script_class()
+        self.assertEqual(ctx.exception.code, 1)
 
     def test_import_error_cleans_up_sys_modules(self) -> None:
         """discover_script_class cleans up sys.modules on import failure."""
         from nanvix_zutil.__main__ import discover_script_class
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            z_py = Path(tmpdir) / "z.py"
-            z_py.write_text("raise RuntimeError('boom')\n")
-            with self.assertRaises(SystemExit):
-                discover_script_class(z_py)
-            self.assertNotIn("_z_consumer", sys.modules)
+        z_py_path().write_text("raise RuntimeError('boom')\n")
+        with self.assertRaises(SystemExit):
+            discover_script_class()
+        self.assertNotIn("_z_consumer", sys.modules)
 
 
 class TestUnknownCommand(unittest.TestCase):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -8,15 +8,13 @@ import json
 import os
 import subprocess as sp
 import sys
-import tempfile
 import unittest
 from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.log as log_mod
-from nanvix_zutil import helpers
-from nanvix_zutil import paths
+from nanvix_zutil import helpers, paths
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
@@ -30,7 +28,6 @@ from nanvix_zutil.script import ZScript
 from tests.testutils import (
     MANIFEST_LATEST_WITH_DEPS,
     MANIFEST_WITH_DEPS,
-    chdir_to,
     write_manifest,
 )
 
@@ -39,55 +36,48 @@ class TestZScriptInit(unittest.TestCase):
     """ZScript initialises correctly."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def test_repo_root_resolved(self) -> None:
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
-        self.assertEqual(script.repo_root, repo_root.resolve())
+        repo_root = paths.repo_root()
+        self.assertEqual(paths.repo_root(), repo_root.resolve())
 
     def test_nanvix_dir(self) -> None:
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
-        self.assertEqual(script.nanvix_dir, repo_root.resolve() / ".nanvix")
+        repo_root = paths.repo_root()
+        self.assertEqual(paths.nanvix_root(), repo_root.resolve() / ".nanvix")
 
     def test_config_accessible(self) -> None:
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        script = ZScript()
         self.assertEqual(script.config.machine, "microvm")
 
     def test_manifest_loaded(self) -> None:
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        script = ZScript()
         self.assertEqual(script.manifest.sysroot_ref.value, "0.1.0")
 
     def test_sysroot_initially_none(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         self.assertIsNone(script.sysroot)
 
     def test_buildroot_initially_none(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         self.assertIsNone(script.buildroot)
 
     def test_log_attribute_is_log_module(self) -> None:
         """self.log refers to the nanvix_zutil.log module."""
         import nanvix_zutil.log as log_module
 
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         self.assertIs(script.log, log_module)
 
     def test_missing_manifest_exits_3(self) -> None:
-        tmpdir = tempfile.TemporaryDirectory()
-        repo_root = Path(tmpdir.name)
-        chdir_to(self, tmpdir)
+        # Autouse fixture wrote a manifest in setUp; remove it.
+        (paths.manifest_path()).unlink()
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                ZScript(repo_root)
+                ZScript()
             self.assertEqual(ctx.exception.code, 3)
         finally:
             log_mod.set_json_mode(False)
@@ -97,8 +87,6 @@ class TestZScriptAutoSetup(unittest.TestCase):
     """Base setup() auto-downloads sysroot and dependencies."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -111,7 +99,7 @@ class TestZScriptAutoSetup(unittest.TestCase):
         with patch(
             "nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot
         ) as mock_download:
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
             # Assert Sysroot.download was called once with the expected kwargs.
@@ -122,7 +110,7 @@ class TestZScriptAutoSetup(unittest.TestCase):
             self.assertEqual(kwargs["memory_size"], script.config.memory_size)
             self.assertEqual(kwargs["tag"], script.manifest.sysroot_ref.value)
             self.assertIsInstance(kwargs["dest"], Path)
-            self.assertTrue(str(kwargs["dest"]).startswith(str(script.nanvix_dir)))
+            self.assertTrue(str(kwargs["dest"]).startswith(str(paths.nanvix_root())))
             self.assertIs(kwargs["config"], script.config)
         fake_sysroot.verify.assert_called_once()
         self.assertIs(script.sysroot, fake_sysroot)
@@ -147,7 +135,7 @@ class TestZScriptAutoSetup(unittest.TestCase):
                 return_value=(fake_release, "0.1.0"),
             ),
         ):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
         # Buildroot.create called once (now takes no arguments).
@@ -166,7 +154,7 @@ class TestZScriptAutoSetup(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
 
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
         self.assertIsNone(script.buildroot)
@@ -177,10 +165,10 @@ class TestZScriptAutoSetup(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
 
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
-        config_file = Path(self._tmpdir.name) / ".nanvix" / "env.json"
+        config_file = paths.nanvix_root() / "env.json"
         self.assertTrue(config_file.exists())
 
 
@@ -188,8 +176,6 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
     """setup() with nanvix-version = "latest" suffixes deps correctly."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest(MANIFEST_LATEST_WITH_DEPS)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -211,7 +197,7 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
                 return_value=(fake_release, "0.12.277"),
             ),
         ):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
         # install_dep should be called with the suffixed ref value.
@@ -234,7 +220,7 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
                 ),
                 self.assertRaises(SystemExit) as ctx,
             ):
-                script = ZScript(Path(self._tmpdir.name))
+                script = ZScript()
                 script.setup()
 
             self.assertEqual(ctx.exception.code, 3)
@@ -246,8 +232,6 @@ class TestZScriptSyncConfigs(unittest.TestCase):
     """setup() syncs canonical configs into .nanvix/."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -256,14 +240,14 @@ class TestZScriptSyncConfigs(unittest.TestCase):
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
         return script
 
     def test_setup_creates_config_files(self) -> None:
         """setup() creates config files under .nanvix/."""
         self._run_setup()
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         self.assertTrue((nanvix_dir / "pyrightconfig.json").exists())
         self.assertTrue((nanvix_dir / ".yamllint.yml").exists())
         self.assertTrue((nanvix_dir / "black.toml").exists())
@@ -272,7 +256,7 @@ class TestZScriptSyncConfigs(unittest.TestCase):
     def test_gitignore_contains_expected_patterns(self) -> None:
         """Synced .gitignore includes transient artifact patterns."""
         self._run_setup()
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         content = (nanvix_dir / ".gitignore").read_text()
         for pattern in ("venv/", "cache/", "sysroot/", "__pycache__/"):
             self.assertIn(pattern, content)
@@ -280,14 +264,14 @@ class TestZScriptSyncConfigs(unittest.TestCase):
     def test_gitignore_does_not_ignore_lockfile(self) -> None:
         """Synced .gitignore must not ignore nanvix.lock (committed for reproducibility)."""
         self._run_setup()
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         content = (nanvix_dir / ".gitignore").read_text()
         self.assertNotIn("nanvix.lock", content)
 
     def test_setup_skips_identical_configs(self) -> None:
         """setup() is a no-op for configs when content already matches."""
         self._run_setup()
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         pyright_cfg = nanvix_dir / "pyrightconfig.json"
         mtime_before = pyright_cfg.stat().st_mtime
         import time
@@ -299,7 +283,7 @@ class TestZScriptSyncConfigs(unittest.TestCase):
 
     def test_setup_updates_config_when_different(self) -> None:
         """setup() overwrites config when content differs."""
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         pyright_cfg = nanvix_dir / "pyrightconfig.json"
         pyright_cfg.write_text("{}")
         self._run_setup()
@@ -308,7 +292,7 @@ class TestZScriptSyncConfigs(unittest.TestCase):
     def test_setup_confines_configs_to_nanvix_dir(self) -> None:
         """setup() never writes config files outside .nanvix/."""
         self._run_setup()
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         self.assertFalse((repo_root / "pyrightconfig.json").exists())
         self.assertFalse((repo_root / ".yamllint.yml").exists())
 
@@ -317,7 +301,7 @@ class TestZScriptSyncConfigs(unittest.TestCase):
         import json
 
         self._run_setup()
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         cfg = json.loads((nanvix_dir / "pyrightconfig.json").read_text())
         self.assertIn(".", cfg["include"])
 
@@ -326,7 +310,7 @@ class TestZScriptSyncConfigs(unittest.TestCase):
         import json
 
         self._run_setup()
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         cfg = json.loads((nanvix_dir / "pyrightconfig.json").read_text())
         for entry in cfg["include"]:
             self.assertFalse(
@@ -339,12 +323,10 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
     """Default consumer lifecycle hooks are no-ops."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
 
     def _make_script(self) -> ZScript:
-        return ZScript(Path(self._tmpdir.name))
+        return ZScript()
 
     def test_build_noop(self) -> None:
         self._make_script().build()
@@ -366,12 +348,10 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
     """available_subcommands() reflects hook overrides."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
 
     def test_base_class_exposes_only_auto_hooks(self) -> None:
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         available = script.available_subcommands()
         for hook in ZScript.AUTO_HOOKS:
             self.assertIn(hook, available, f"{hook!r} should always be available")
@@ -388,7 +368,7 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
             def test(self) -> None:
                 pass
 
-        script = _Sub(Path(self._tmpdir.name))
+        script = _Sub()
         available = script.available_subcommands()
         self.assertIn("build", available)
         self.assertIn("test", available)
@@ -398,7 +378,7 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
             def build(self) -> None:
                 pass
 
-        script = _Sub(Path(self._tmpdir.name))
+        script = _Sub()
         available = script.available_subcommands()
         self.assertNotIn("clean", available)
         self.assertNotIn("benchmark", available)
@@ -420,7 +400,7 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
             def clean(self) -> None:
                 pass
 
-        script = _FullSub(Path(self._tmpdir.name))
+        script = _FullSub()
         available = script.available_subcommands()
         for hook in ZScript.CONSUMER_HOOKS:
             self.assertIn(hook, available)
@@ -430,8 +410,6 @@ class TestHelpersRun(unittest.TestCase):
     """helpers.run() executes subprocesses correctly."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
 
     def test_run_success(self) -> None:
@@ -479,7 +457,7 @@ class TestHelpersRun(unittest.TestCase):
     @patch("nanvix_zutil.helpers.is_windows", return_value=True)
     def test_run_uses_windows_cmd_on_windows(self, _mock: object) -> None:
         """run() delegates to build_windows_run_cmd on Windows."""
-        docker = self._make_docker(Path(self._tmpdir.name))
+        docker = self._make_docker(Path.cwd())
         captured_cmds: list[list[str]] = []
 
         def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
@@ -504,7 +482,7 @@ class TestHelpersRun(unittest.TestCase):
             image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
             mounts=[
                 Mount(
-                    host_path=Path(self._tmpdir.name),
+                    host_path=Path.cwd(),
                     container_path=WORKSPACE_CONTAINER_PATH,
                 )
             ],
@@ -532,7 +510,7 @@ class TestHelpersRun(unittest.TestCase):
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_run_dispatch_linux_uses_build_run_cmd(self, *_mocks: object) -> None:
         """run() uses build_run_cmd on Linux (not the Windows tar-copy path)."""
-        docker = self._make_docker(Path(self._tmpdir.name))
+        docker = self._make_docker(Path.cwd())
         captured_cmds: list[list[str]] = []
 
         def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
@@ -554,7 +532,7 @@ class TestHelpersRun(unittest.TestCase):
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_run_with_docker_wraps_command(self, *_mocks: object) -> None:
         """When a docker config is supplied, run() prepends docker run."""
-        docker = self._make_docker(Path(self._tmpdir.name))
+        docker = self._make_docker(Path.cwd())
         captured: list[list[str]] = []
 
         def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
@@ -718,32 +696,31 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
     """sysroot_required_files() varies by deployment mode."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
+    def tearDown(self) -> None:
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def test_multi_process_includes_linuxd_and_uservm(self) -> None:
         os.environ["NANVIX_DEPLOYMENT_MODE"] = "multi-process"
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         files = script.sysroot_required_files()
         self.assertIn("bin/linuxd.elf", files)
         self.assertIn("bin/uservm.elf", files)
 
     def test_single_process_excludes_linuxd_and_uservm(self) -> None:
         os.environ["NANVIX_DEPLOYMENT_MODE"] = "single-process"
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         files = script.sysroot_required_files()
         self.assertNotIn("bin/linuxd.elf", files)
         self.assertNotIn("bin/uservm.elf", files)
 
     def test_standalone_excludes_linuxd_and_uservm(self) -> None:
         os.environ["NANVIX_DEPLOYMENT_MODE"] = "standalone"
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         files = script.sysroot_required_files()
         self.assertNotIn("bin/linuxd.elf", files)
         self.assertNotIn("bin/uservm.elf", files)
@@ -756,7 +733,7 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
         mkramfs = "bin/mkramfs.exe" if sys.platform == "win32" else "bin/mkramfs.elf"
         for mode in ("multi-process", "single-process", "standalone"):
             os.environ["NANVIX_DEPLOYMENT_MODE"] = mode
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             files = script.sysroot_required_files()
             self.assertIn("lib/libposix.a", files, f"missing in {mode}")
             self.assertIn("lib/user.ld", files, f"missing in {mode}")
@@ -766,7 +743,7 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
 
     def test_default_deployment_mode_is_standalone(self) -> None:
         """Default (no env override) should be standalone."""
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         files = script.sysroot_required_files()
         self.assertNotIn("bin/linuxd.elf", files)
         self.assertNotIn("bin/uservm.elf", files)
@@ -776,12 +753,10 @@ class TestZScriptDockerConfig(unittest.TestCase):
     """Tests for ZScript.docker / ZScript.docker_config()."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
 
     def _make_script(self) -> ZScript:
-        return ZScript(Path(self._tmpdir.name))
+        return ZScript()
 
     def test_docker_not_active_by_default(self) -> None:
         script = self._make_script()
@@ -802,7 +777,7 @@ class TestZScriptDockerConfig(unittest.TestCase):
         )
         self.assertIsNotNone(workspace_mount)
         assert workspace_mount is not None
-        self.assertEqual(workspace_mount.host_path, script.repo_root)
+        self.assertEqual(workspace_mount.host_path, paths.repo_root())
 
     def test_docker_config_no_buildroot_mount_when_absent(self) -> None:
         """No buildroot mount is added when the buildroot dir does not exist."""
@@ -817,7 +792,7 @@ class TestZScriptDockerConfig(unittest.TestCase):
     def test_docker_config_auto_mounts_buildroot_when_present(self) -> None:
         """Buildroot is auto-mounted when nanvix_dir/buildroot exists."""
         script = self._make_script()
-        buildroot_dir = script.nanvix_dir / "buildroot"
+        buildroot_dir = paths.buildroot()
         buildroot_dir.mkdir(parents=True, exist_ok=True)
         cfg = script.docker_config("test-image")
         buildroot_mount = next(
@@ -834,8 +809,6 @@ class TestZScriptAutoDocker(unittest.TestCase):
     """Docker is always enabled for setup/build/release/clean (hard fail)."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -854,7 +827,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
             docker_configured = self_inner.docker is not None
 
         # Pre-persist Docker image so build can find it.
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         (nanvix_dir / "env.json").write_text(
             '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"}'
         )
@@ -865,7 +838,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
             patch.object(BuildScript, "build", _fake_build),
             patch("nanvix_zutil.script.log"),
         ):
-            BuildScript.main(repo_root=Path(self._tmpdir.name))
+            BuildScript.main()
 
         self.assertTrue(docker_configured)
 
@@ -883,7 +856,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
             docker_configured = self_inner.docker is not None
 
         # Pre-persist Docker image so build can find it.
-        nanvix_dir = Path(self._tmpdir.name) / ".nanvix"
+        nanvix_dir = paths.nanvix_root()
         (nanvix_dir / "env.json").write_text(
             '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"}'
         )
@@ -899,7 +872,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
             patch.object(BuildScript, "build", _fake_build),
             patch("nanvix_zutil.script.log"),
         ):
-            BuildScript.main(repo_root=Path(self._tmpdir.name))
+            BuildScript.main()
 
         self.assertTrue(docker_configured)
 
@@ -908,15 +881,13 @@ class TestZScriptCleanWindows(unittest.TestCase):
     """ZScript.clean() Windows behavior."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
 
     @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_clean_removes_configured_artifact(self, _mock: object) -> None:
         """clean() removes .nanvix-configured on Windows."""
-        script = ZScript(Path(self._tmpdir.name))
-        artifact = script.repo_root / ".nanvix-configured"
+        script = ZScript()
+        artifact = paths.repo_root() / ".nanvix-configured"
         artifact.write_text("marker")
         script.clean()
         self.assertFalse(artifact.exists())
@@ -924,13 +895,13 @@ class TestZScriptCleanWindows(unittest.TestCase):
     @patch("nanvix_zutil.script.is_windows", return_value=True)
     def test_clean_noop_when_no_artifacts(self, _mock: object) -> None:
         """clean() does not raise when no artifacts exist on Windows."""
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         script.clean()  # Should not raise.
 
     @patch("nanvix_zutil.script.is_windows", return_value=False)
     def test_clean_noop_on_linux(self, _mock: object) -> None:
         """clean() is a no-op on Linux (base class)."""
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         script.clean()  # Should not raise.
 
 
@@ -938,8 +909,6 @@ class TestZScriptSetupFallbackReporting(unittest.TestCase):
     """setup() reports fallback state correctly."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest(MANIFEST_WITH_DEPS)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -960,7 +929,7 @@ class TestZScriptSetupFallbackReporting(unittest.TestCase):
                 return_value=(fake_release, None),  # None = no fallback
             ),
         ):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             result = script.setup()
 
         self.assertFalse(result)
@@ -981,7 +950,7 @@ class TestZScriptSetupFallbackReporting(unittest.TestCase):
                 return_value=(fake_release, "0.0.9"),  # non-None = fallback used
             ),
         ):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             result = script.setup()
 
         self.assertTrue(result)
@@ -994,7 +963,7 @@ class TestZScriptSetupFallbackReporting(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
 
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             result = script.setup()
 
         self.assertFalse(result)
@@ -1016,7 +985,7 @@ class TestZScriptSetupFallbackReporting(unittest.TestCase):
             ),
             patch("nanvix_zutil.script.log") as mock_log,
         ):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
         # Verify warning was called (not info) for fallback message.
@@ -1040,8 +1009,6 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
     """main() exits with EXIT_DEGRADED_SETUP when setup uses fallback."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest(MANIFEST_WITH_DEPS)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
@@ -1072,7 +1039,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
             patch.object(ZScript, "setup", _setup_with_fallback),
             self.assertRaises(SystemExit) as ctx,
         ):
-            ZScript.main(repo_root=Path(self._tmpdir.name))
+            ZScript.main()
 
         self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
 
@@ -1085,7 +1052,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
             patch.object(ZScript, "setup", return_value=True),
             self.assertRaises(SystemExit) as ctx,
         ):
-            ZScript.main(repo_root=Path(self._tmpdir.name))
+            ZScript.main()
 
         self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
 
@@ -1097,7 +1064,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
             patch("nanvix_zutil.script.log") as mock_log,
         ):
             # Should not raise SystemExit.
-            ZScript.main(repo_root=Path(self._tmpdir.name))
+            ZScript.main()
 
         # Verify success log was emitted.
         success_calls = [
@@ -1124,7 +1091,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
                 patch.object(ZScript, "setup", return_value=True),
                 self.assertRaises(SystemExit) as ctx,
             ):
-                ZScript.main(repo_root=Path(self._tmpdir.name))
+                ZScript.main()
         finally:
             sys.stderr = original_stderr
             log_mod.set_json_mode(False)
@@ -1141,8 +1108,6 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
     """setup() with WITH_NANVIX overlays local artifacts."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in (
             "NANVIX_MACHINE",
@@ -1157,7 +1122,7 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
 
     def test_setup_calls_overlay_when_env_set(self) -> None:
         """setup() calls sysroot.overlay_local_nanvix when WITH_NANVIX is set."""
-        local_dir = Path(self._tmpdir.name) / "local-nanvix"
+        local_dir = Path.cwd() / "local-nanvix"
         local_dir.mkdir()
 
         fake_sysroot = MagicMock()
@@ -1166,7 +1131,7 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         os.environ["WITH_NANVIX"] = str(local_dir)
 
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
         fake_sysroot.overlay_local_nanvix.assert_called_once_with(local_dir)
@@ -1178,7 +1143,7 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
 
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
         fake_sysroot.overlay_local_nanvix.assert_not_called()
@@ -1187,7 +1152,7 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         """setup() skips GitHub download for deps found locally."""
         write_manifest(MANIFEST_WITH_DEPS)
 
-        local_dir = Path(self._tmpdir.name) / "local-nanvix"
+        local_dir = Path.cwd() / "local-nanvix"
         (local_dir / "deps" / "zlib" / "lib").mkdir(parents=True)
         (local_dir / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"local-zlib")
 
@@ -1201,7 +1166,7 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             patch("nanvix_zutil.script.resolve_release_with_fallback") as mock_resolve,
         ):
-            script = ZScript(Path(self._tmpdir.name))
+            script = ZScript()
             script.setup()
 
         # The dependency was satisfied locally so GitHub resolve should not
@@ -1213,8 +1178,6 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
     """setup() with RefKind.LOCAL sysroot uses from_local, no GitHub."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
@@ -1223,7 +1186,7 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
 
     def test_local_sysroot_skips_github(self) -> None:
         """When sysroot ref is LOCAL, Sysroot.from_local is used."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         # Create a local sysroot directory.
         local_sysroot = repo_root / "my-sysroot"
         local_sysroot.mkdir()
@@ -1231,7 +1194,7 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
         write_manifest()
 
         with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
-            script = ZScript(repo_root)
+            script = ZScript()
 
         # Verify manifest parsed as LOCAL.
         self.assertEqual(script.manifest.sysroot_ref.kind, RefKind.LOCAL)
@@ -1249,14 +1212,14 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
 
     def test_local_sysroot_no_dep_suffix(self) -> None:
         """When sysroot is LOCAL, VERSION deps are not suffixed."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         local_sysroot = repo_root / "my-sysroot"
         local_sysroot.mkdir()
 
         write_manifest(MANIFEST_WITH_DEPS)
 
         with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
-            script = ZScript(repo_root)
+            script = ZScript()
 
         # VERSION dep should NOT be suffixed (sysroot is LOCAL).
         self.assertEqual(script.manifest.dependencies[0].ref.value, "1.0")
@@ -1266,8 +1229,6 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
     """setup() with RefKind.LOCAL dep installs from filesystem."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
@@ -1276,7 +1237,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
 
     def test_local_dep_uses_install_local_nanvix(self) -> None:
         """LOCAL deps call install_local_nanvix instead of GitHub."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         local_dep_path = repo_root / "local-zlib"
         # Create the expected local layout.
         (local_dep_path / "deps" / "zlib" / "lib").mkdir(parents=True)
@@ -1292,7 +1253,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
             patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": str(local_dep_path)}),
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
         ):
-            script = ZScript(repo_root)
+            script = ZScript()
             script.setup()
 
         # Dep was installed locally, buildroot should exist.
@@ -1303,7 +1264,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
 
     def test_local_dep_no_github_call(self) -> None:
         """LOCAL deps do not call resolve_release or download_release_asset."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         local_dep_path = repo_root / "local-zlib"
         (local_dep_path / "deps" / "zlib" / "lib").mkdir(parents=True)
         (local_dep_path / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
@@ -1320,7 +1281,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
             patch("nanvix_zutil.script.resolve_release") as mock_resolve,
             patch("nanvix_zutil.script.resolve_release_with_fallback") as mock_fallback,
         ):
-            script = ZScript(repo_root)
+            script = ZScript()
             script.setup()
 
         mock_resolve.assert_not_called()
@@ -1328,7 +1289,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
 
     def test_local_dep_missing_artifacts_exits(self) -> None:
         """LOCAL dep with no artifacts at the path exits with code 3."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         local_dep_path = repo_root / "empty-dir"
         local_dep_path.mkdir()
 
@@ -1344,7 +1305,7 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             self.assertRaises(SystemExit) as ctx,
         ):
-            script = ZScript(repo_root)
+            script = ZScript()
             script.setup()
 
         self.assertEqual(ctx.exception.code, 3)
@@ -1354,20 +1315,17 @@ class TestHelpersMakeInitrd(unittest.TestCase):
     """helpers.make_initrd() builds the correct mkimage command."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
 
     def _make_script(self) -> ZScript:
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        script = ZScript()
         # Set up a fake sysroot with a bin/ directory and mkimage stub.
-        sysroot_bin = repo_root / ".nanvix" / "sysroot" / "bin"
+        sysroot_bin = paths.sysroot() / "bin"
         sysroot_bin.mkdir(parents=True, exist_ok=True)
         (sysroot_bin / "mkimage.elf").touch()
         (sysroot_bin / "mkimage.exe").touch()
         fake_sysroot = MagicMock()
-        fake_sysroot.path = repo_root / ".nanvix" / "sysroot"
+        fake_sysroot.path = paths.sysroot()
         script.sysroot = fake_sysroot
         return script
 
@@ -1382,18 +1340,18 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
-            result = helpers.make_initrd(script, "my-app.elf", InitRdArgs())
+            result = helpers.make_initrd(script, "my-app.elf", args=InitRdArgs())
 
-        self.assertEqual(result, script.repo_root / "my-app.img")
+        self.assertEqual(result, paths.repo_root() / "my-app.img")
         cmd = captured[0]
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
         self.assertEqual(cmd[0], str(bin_dir / "mkimage.elf"))
         self.assertEqual(cmd[1], "-o")
-        self.assertEqual(cmd[2], str(script.repo_root / "my-app.img"))
+        self.assertEqual(cmd[2], str(paths.repo_root() / "my-app.img"))
         self.assertEqual(cmd[3], f"{bin_dir / 'procd.elf'};procd")
         self.assertEqual(cmd[4], f"{bin_dir / 'memd.elf'};memd")
         self.assertEqual(cmd[5], f"{bin_dir / 'vfsd.elf'};vfsd")
-        self.assertEqual(cmd[6], f"{script.repo_root / 'my-app.elf'};my-app.elf")
+        self.assertEqual(cmd[6], f"{paths.repo_root() / 'my-app.elf'};my-app.elf")
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=True)
     def test_basic_invocation_windows(self, _mock: object) -> None:
@@ -1406,7 +1364,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
-            helpers.make_initrd(script, "my-app.elf", InitRdArgs())
+            helpers.make_initrd(script, "my-app.elf", args=InitRdArgs())
 
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
         self.assertEqual(captured[0][0], str(bin_dir / "mkimage.exe"))
@@ -1423,13 +1381,15 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
-                script, "my-app.elf", InitRdArgs(app_args=["--verbose", "--port=8080"])
+                script,
+                "my-app.elf",
+                args=InitRdArgs(app_args=["--verbose", "--port=8080"]),
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{script.repo_root / 'my-app.elf'};my-app.elf --verbose --port=8080",
+            f"{paths.repo_root() / 'my-app.elf'};my-app.elf --verbose --port=8080",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1446,7 +1406,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 "my-app.elf",
-                InitRdArgs(
+                args=InitRdArgs(
                     procd_args=["--debug"],
                     memd_args=["--heap=64m"],
                     vfsd_args=["--cache=off"],
@@ -1470,7 +1430,9 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
-                script, "my-app.elf", InitRdArgs(kernel_args=["console=ttyS0", "debug"])
+                script,
+                "my-app.elf",
+                args=InitRdArgs(kernel_args=["console=ttyS0", "debug"]),
             )
 
         cmd = captured[0]
@@ -1489,11 +1451,13 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
-            helpers.make_initrd(script, "my-app.elf", InitRdArgs(app_args=["--sep=;"]))
+            helpers.make_initrd(
+                script, "my-app.elf", args=InitRdArgs(app_args=["--sep=;"])
+            )
 
         app_entry = captured[0][6]
         self.assertEqual(
-            app_entry, f"{script.repo_root / 'my-app.elf'};my-app.elf --sep=\\;"
+            app_entry, f"{paths.repo_root() / 'my-app.elf'};my-app.elf --sep=\\;"
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1507,7 +1471,9 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
-            helpers.make_initrd(script, "my-app.elf", InitRdArgs(kernel_args=["a;b"]))
+            helpers.make_initrd(
+                script, "my-app.elf", args=InitRdArgs(kernel_args=["a;b"])
+            )
 
         cmd = captured[0]
         ka_idx = cmd.index("-kernel-args")
@@ -1517,7 +1483,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
     def test_custom_bin_dir(self, _mock: object) -> None:
         """A custom bin_dir is used instead of the sysroot."""
         script = self._make_script()
-        custom_bin = Path(self._tmpdir.name) / "custom" / "bin"
+        custom_bin = Path.cwd() / "custom" / "bin"
         custom_bin.mkdir(parents=True)
         (custom_bin / "mkimage.elf").touch()
         captured: list[list[str]] = []
@@ -1527,19 +1493,21 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
-            helpers.make_initrd(script, "my-app.elf", InitRdArgs(bin_dir=custom_bin))
+            helpers.make_initrd(
+                script, "my-app.elf", args=InitRdArgs(bin_dir=custom_bin)
+            )
 
         self.assertEqual(captured[0][0], str(custom_bin / "mkimage.elf"))
         self.assertIn(str(custom_bin / "procd.elf"), captured[0][3])
 
     def test_no_sysroot_exits(self) -> None:
         """Exits with EXIT_MISSING_DEP when sysroot is None and config lacks one."""
-        script = ZScript(Path(self._tmpdir.name))
+        script = ZScript()
         script.sysroot = None
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                helpers.make_initrd(script, "my-app.elf", InitRdArgs())
+                helpers.make_initrd(script, "my-app.elf", args=InitRdArgs())
             self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
@@ -1555,11 +1523,11 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
-            result = helpers.make_initrd(script, "hello-world.elf", InitRdArgs())
+            result = helpers.make_initrd(script, "hello-world.elf", args=InitRdArgs())
 
-        self.assertEqual(result, script.repo_root / "hello-world.img")
+        self.assertEqual(result, paths.repo_root() / "hello-world.img")
         self.assertEqual(
-            captured[0][6], f"{script.repo_root / 'hello-world.elf'};hello-world.elf"
+            captured[0][6], f"{paths.repo_root() / 'hello-world.elf'};hello-world.elf"
         )
 
     def test_app_with_path_separator_exits(self) -> None:
@@ -1568,7 +1536,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                helpers.make_initrd(script, "build/hello.elf", InitRdArgs())
+                helpers.make_initrd(script, "build/hello.elf", args=InitRdArgs())
             self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
@@ -1576,18 +1544,17 @@ class TestHelpersMakeInitrd(unittest.TestCase):
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_mkimage_not_found_exits(self, _mock: object) -> None:
         """Exits with EXIT_MISSING_DEP when mkimage binary is missing."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        script = ZScript()
         # Sysroot bin dir exists but mkimage.elf does not.
-        sysroot_bin = repo_root / ".nanvix" / "sysroot" / "bin"
+        sysroot_bin = paths.sysroot() / "bin"
         sysroot_bin.mkdir(parents=True, exist_ok=True)
         fake_sysroot = MagicMock()
-        fake_sysroot.path = repo_root / ".nanvix" / "sysroot"
+        fake_sysroot.path = paths.sysroot()
         script.sysroot = fake_sysroot
         log_mod.set_json_mode(True)
         try:
             with self.assertRaises(SystemExit) as ctx:
-                helpers.make_initrd(script, "my-app.elf", InitRdArgs())
+                helpers.make_initrd(script, "my-app.elf", args=InitRdArgs())
             self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         finally:
             log_mod.set_json_mode(False)
@@ -1604,13 +1571,13 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
-                script, "my-app.elf", InitRdArgs(app_env=["VAR1=foo", "VAR2=bar"])
+                script, "my-app.elf", args=InitRdArgs(app_env=["VAR1=foo", "VAR2=bar"])
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{script.repo_root / 'my-app.elf'};my-app.elf;VAR1=foo VAR2=bar",
+            f"{paths.repo_root() / 'my-app.elf'};my-app.elf;VAR1=foo VAR2=bar",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1627,13 +1594,13 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 "my-app.elf",
-                InitRdArgs(app_args=["--verbose"], app_env=["DEBUG=1"]),
+                args=InitRdArgs(app_args=["--verbose"], app_env=["DEBUG=1"]),
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{script.repo_root / 'my-app.elf'};my-app.elf --verbose;DEBUG=1",
+            f"{paths.repo_root() / 'my-app.elf'};my-app.elf --verbose;DEBUG=1",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1650,7 +1617,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 "my-app.elf",
-                InitRdArgs(
+                args=InitRdArgs(
                     procd_env=["LOG=debug"],
                     memd_env=["HEAP=64m"],
                     vfsd_env=["CACHE=off"],
@@ -1674,13 +1641,13 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
-                script, "my-app.elf", InitRdArgs(app_env=["PATH=/a;/b"])
+                script, "my-app.elf", args=InitRdArgs(app_env=["PATH=/a;/b"])
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{script.repo_root / 'my-app.elf'};my-app.elf;PATH=/a\\;/b",
+            f"{paths.repo_root() / 'my-app.elf'};my-app.elf;PATH=/a\\;/b",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1697,7 +1664,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 "my-app.elf",
-                InitRdArgs(
+                args=InitRdArgs(
                     procd_args=["--log-level", "trace"], procd_env=["LOG=debug"]
                 ),
             )
@@ -1722,7 +1689,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 "my-app.elf",
-                InitRdArgs(
+                args=InitRdArgs(
                     app_args=["--verbose"], app_env=["DEBUG=1"], procd_env=["LOG=debug"]
                 ),
             )
@@ -1732,7 +1699,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         self.assertEqual(captured[0][3], f"{bin_dir / 'procd.elf'};procd;LOG=debug")
         self.assertEqual(
             captured[0][6],
-            f"{script.repo_root / 'my-app.elf'};my-app.elf --verbose;DEBUG=1",
+            f"{paths.repo_root() / 'my-app.elf'};my-app.elf --verbose;DEBUG=1",
         )
 
 
@@ -1838,8 +1805,6 @@ class TestOfflineMode(unittest.TestCase):
     """Tests for offline mode (--offline flag)."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest(MANIFEST_WITH_DEPS)
         for key in (
             "NANVIX_MACHINE",
@@ -1854,30 +1819,26 @@ class TestOfflineMode(unittest.TestCase):
 
     def test_offline_default_false(self) -> None:
         """Offline mode defaults to False."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        script = ZScript()
         self.assertFalse(script._offline)
 
     def test_with_nanvix_env_sets_path(self) -> None:
         """WITH_NANVIX env sets _with_nanvix_path."""
-        repo_root = Path(self._tmpdir.name)
         with patch.dict(os.environ, {"WITH_NANVIX": "/some/build"}):
-            script = ZScript(repo_root)
+            script = ZScript()
         self.assertEqual(script._with_nanvix_path, "/some/build")
 
     def test_cli_sysroot_path_initially_none(self) -> None:
         """_cli_sysroot_path starts as None."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        script = ZScript()
         self.assertIsNone(script._cli_sysroot_path)
 
     def test_offline_with_sysroot_path_uses_from_local(self) -> None:
         """In offline mode with --sysroot-path, Sysroot.from_local is used."""
-        repo_root = Path(self._tmpdir.name)
-        sysroot_dir = repo_root / "my-sysroot"
+        sysroot_dir = paths.repo_root() / "my-sysroot"
         sysroot_dir.mkdir()
 
-        script = ZScript(repo_root)
+        script = ZScript()
         script._offline = True
         script._cli_sysroot_path = str(sysroot_dir)
 
@@ -1891,7 +1852,7 @@ class TestOfflineMode(unittest.TestCase):
                 "nanvix_zutil.script.Sysroot.from_local",
                 return_value=fake_sysroot,
             ) as mock_from_local,
-            patch.dict(os.environ, {"WITH_NANVIX": str(repo_root)}),
+            patch.dict(os.environ, {"WITH_NANVIX": str(paths.repo_root())}),
         ):
             script.setup()
             mock_download.assert_not_called()
@@ -1899,8 +1860,7 @@ class TestOfflineMode(unittest.TestCase):
 
     def test_offline_without_sysroot_exits(self) -> None:
         """Offline mode without a local sysroot path exits fatally."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        script = ZScript()
         script._offline = True
 
         log_mod.set_json_mode(True)
@@ -1911,11 +1871,11 @@ class TestOfflineMode(unittest.TestCase):
 
     def test_offline_without_with_nanvix_exits(self) -> None:
         """Offline mode with sysroot but no --with-nanvix exits fatally."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         sysroot_dir = repo_root / "my-sysroot"
         sysroot_dir.mkdir()
 
-        script = ZScript(repo_root)
+        script = ZScript()
         script._offline = True
         script._cli_sysroot_path = str(sysroot_dir)
 
@@ -1937,7 +1897,7 @@ class TestOfflineMode(unittest.TestCase):
 
     def test_offline_missing_dep_warns_not_fatal(self) -> None:
         """Offline mode warns (not fatal) when a dep has no local artifacts."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         sysroot_dir = repo_root / "my-sysroot"
         sysroot_dir.mkdir()
         # Create WITH_NANVIX dir without deps
@@ -1945,7 +1905,7 @@ class TestOfflineMode(unittest.TestCase):
         build_dir.mkdir()
 
         with patch.dict(os.environ, {"WITH_NANVIX": str(build_dir)}):
-            script = ZScript(repo_root)
+            script = ZScript()
         script._offline = True
         script._cli_sysroot_path = str(sysroot_dir)
 
@@ -1965,7 +1925,7 @@ class TestOfflineMode(unittest.TestCase):
 
     def test_offline_with_local_dep_installs(self) -> None:
         """Offline mode installs dep from local path when artifacts exist."""
-        repo_root = Path(self._tmpdir.name)
+        repo_root = paths.repo_root()
         sysroot_dir = repo_root / "my-sysroot"
         sysroot_dir.mkdir()
         build_dir = repo_root / "build"
@@ -1973,7 +1933,7 @@ class TestOfflineMode(unittest.TestCase):
         (build_dir / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
 
         with patch.dict(os.environ, {"WITH_NANVIX": str(build_dir)}):
-            script = ZScript(repo_root)
+            script = ZScript()
         script._offline = True
         script._cli_sysroot_path = str(sysroot_dir)
 
@@ -2003,19 +1963,17 @@ class TestInstallArtifacts(unittest.TestCase):
     """Tests for ZScript.install_artifacts()."""
 
     def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-        chdir_to(self, self._tmpdir)
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
     def test_exports_from_output_dir(self) -> None:
-        """install_artifacts copies from .nanvix/output/."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        """install_artifacts copies from .nanvix/out/."""
+        repo_root = paths.repo_root()
+        script = ZScript()
 
-        # Create .nanvix/output/{lib,include}/
-        output_src = script.nanvix_dir / "output"
+        # Create .nanvix/out/{lib,include}/
+        output_src = paths.out_dir()
         (output_src / "lib").mkdir(parents=True)
         (output_src / "lib" / "libfoo.a").write_bytes(b"lib")
         (output_src / "include").mkdir(parents=True)
@@ -2029,10 +1987,10 @@ class TestInstallArtifacts(unittest.TestCase):
 
     def test_exports_nested_includes(self) -> None:
         """install_artifacts preserves nested include directory structure."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        repo_root = paths.repo_root()
+        script = ZScript()
 
-        output_src = script.nanvix_dir / "output"
+        output_src = paths.out_dir()
         (output_src / "include" / "sub").mkdir(parents=True)
         (output_src / "include" / "sub" / "bar.h").write_text("// bar")
 
@@ -2042,9 +2000,9 @@ class TestInstallArtifacts(unittest.TestCase):
         self.assertTrue((target / "include" / "sub" / "bar.h").exists())
 
     def test_no_output_dir_produces_empty_export(self) -> None:
-        """install_artifacts with no .nanvix/output/ produces empty target."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        """install_artifacts with no .nanvix/out/ produces empty target."""
+        repo_root = paths.repo_root()
+        script = ZScript()
 
         target = repo_root / "export"
         script.install_artifacts(str(target))
@@ -2056,8 +2014,8 @@ class TestInstallArtifacts(unittest.TestCase):
 
     def test_creates_output_directory(self) -> None:
         """install_artifacts creates the target directory if missing."""
-        repo_root = Path(self._tmpdir.name)
-        script = ZScript(repo_root)
+        repo_root = paths.repo_root()
+        script = ZScript()
 
         target = repo_root / "nonexistent" / "path"
         script.install_artifacts(str(target))

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -3,12 +3,7 @@
 
 """Shared test helpers for nanvix_zutil tests."""
 
-import os
-import tempfile
-import unittest
-from pathlib import Path
-
-from nanvix_zutil.paths import nanvix_root
+from nanvix_zutil.paths import manifest_path
 
 # Minimal valid manifest content.
 MINIMAL_MANIFEST = (
@@ -70,65 +65,5 @@ def make_toml(
 
 
 def write_manifest(content: str = MINIMAL_MANIFEST) -> None:
-    """Create ``.nanvix/nanvix.toml`` under the current working directory.
-
-    Callers are expected to have already pointed cwd at the consumer
-    repo (typically via :func:`chdir_to`).
-    """
-    dest = Path.cwd() / ".nanvix" / "nanvix.toml"
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(content)
-
-
-def chdir_to(
-    testcase: unittest.TestCase,
-    repo_root: Path | str | tempfile.TemporaryDirectory[str],
-) -> None:
-    """Point cwd at *repo_root* so .nanvix/ resolves there.
-
-    When *repo_root* is a :class:`tempfile.TemporaryDirectory`, its
-    ``cleanup()`` is registered via :meth:`unittest.TestCase.addCleanup`
-    so it runs **after** the cwd has been restored.  Callers must then
-    not also clean the tmpdir themselves in ``tearDown`` (doing so
-    runs before ``addCleanup`` and re-introduces the Windows
-    cwd-still-inside-tmpdir cleanup failure).
-
-    Ensures ``<repo_root>/.nanvix/`` exists so subsequent calls that
-    rely on :func:`nanvix_zutil.paths.nanvix_root` (which walks up
-    looking for a ``.nanvix/`` marker) succeed even when the caller
-    hasn't written any artifacts there yet.
-
-    Saves the previous cwd and registers an ``addCleanup`` that
-    restores it and clears the :func:`nanvix_root` cache.  Restoring
-    cwd before tmpdir cleanup is required on Windows, which refuses
-    to delete a directory that any process has as cwd.
-
-    The restore tolerates the previous cwd having been removed by
-    an earlier ``tearDown`` (common when callers nest ``chdir_to``
-    inside a tmpdir whose cleanup runs in tearDown); in that case it
-    falls back to the system temp directory.
-    """
-    if isinstance(repo_root, tempfile.TemporaryDirectory):
-        tmpdir = repo_root
-        target = Path(tmpdir.name)
-        # Registered first => runs LAST (after the cwd restore below).
-        testcase.addCleanup(tmpdir.cleanup)
-    else:
-        target = Path(repo_root)
-
-    (target / ".nanvix").mkdir(exist_ok=True)
-    orig_cwd = os.getcwd()
-    os.chdir(target)
-    nanvix_root.cache_clear()
-
-    def _restore_cwd() -> None:
-        try:
-            os.chdir(orig_cwd)
-        except FileNotFoundError:
-            os.chdir(tempfile.gettempdir())
-
-    testcase.addCleanup(nanvix_root.cache_clear)
-    # Registered last => runs FIRST, before any earlier-registered cleanup
-    # (notably the tmpdir cleanup above, which would otherwise fail on
-    # Windows while cwd is still inside the tmpdir).
-    testcase.addCleanup(_restore_cwd)
+    """Create ``.nanvix/nanvix.toml`` inside *repo_root*."""
+    manifest_path().write_text(content)


### PR DESCRIPTION
**Stacked on #243**

Part 5 of #239. Closes #239. 

This PR finishes the migration by removing hardcoded path references from ZScript and `__main__`.

Removes the `chdir_to` test helper introduced in prior PRs as it is no longer needed.