### PR TITLE
Chore: Ignore sync'd items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,17 @@ htmlcov/
 .basedpyright/
 .pyright/
 !pyrightconfig.json
-examples/lib-hello/.nanvix/pyrightconfig.json
-examples/bin-hello/.nanvix/pyrightconfig.json
+
+# Files synced into consumer .nanvix/ dirs by `nanvix-zutil setup` /
+# release tooling. The canonical copies live in
+# src/nanvix_zutil/configs/ and templates/; the in-tree copies under
+# .nanvix/ are regenerated on every run and would otherwise show up as
+# spurious diffs (especially in examples/, which are exercised by the
+# test suite).
+**/.nanvix/.gitignore
+**/.nanvix/.yamllint.yml
+**/.nanvix/black.toml
+**/.nanvix/pyrightconfig.json
 
 # Editor
 /.vscode

--- a/examples/bin-hello/.nanvix/.gitignore
+++ b/examples/bin-hello/.nanvix/.gitignore
@@ -1,9 +1,0 @@
-__pycache__
-venv
-cache
-sysroot
-buildroot
-.yamllint.yml
-black.toml
-env.json
-pyrightconfig.json

--- a/examples/lib-hello/.nanvix/.gitignore
+++ b/examples/lib-hello/.nanvix/.gitignore
@@ -1,9 +1,0 @@
-__pycache__
-venv
-cache
-sysroot
-buildroot
-.yamllint.yml
-black.toml
-env.json
-pyrightconfig.json

--- a/examples/lib-hello/.nanvix/.yamllint.yml
+++ b/examples/lib-hello/.nanvix/.yamllint.yml
@@ -1,8 +1,0 @@
-extends: default
-
-rules:
-  line-length:
-    max: 120
-  truthy:
-    check-keys: false
-  document-start: disable

--- a/src/nanvix_zutil/configs/.gitignore
+++ b/src/nanvix_zutil/configs/.gitignore
@@ -1,8 +1,8 @@
-__pycache__/
-venv/
-cache/
-sysroot/
-buildroot/
+__pycache__
+venv
+cache
+sysroot
+buildroot
 .yamllint.yml
 black.toml
 env.json

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,7 +1,7 @@
-venv/
-cache/
-sysroot/
-buildroot/
+venv
+cache
+sysroot
+buildroot
 env.json
 nanvix.lock
-__pycache__/
+__pycache__

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -258,7 +258,9 @@ class TestZScriptSyncConfigs(unittest.TestCase):
         self._run_setup()
         nanvix_dir = paths.nanvix_root()
         content = (nanvix_dir / ".gitignore").read_text()
-        for pattern in ("venv/", "cache/", "sysroot/", "__pycache__/"):
+        # Patterns are intentionally written without trailing slashes so they
+        # also match symlinks pointing at directories (e.g. sysroot -> ...).
+        for pattern in ("venv", "cache", "sysroot", "__pycache__"):
             self.assertIn(pattern, content)
 
     def test_gitignore_does_not_ignore_lockfile(self) -> None:


### PR DESCRIPTION
This updates the gitignore and tests to ensure that bootstrap-generated items in the examples/ directory are not tracked upstream. Reduces the likelihood of a spurious dirty worktree or tag-along commit item.