### PR TITLE
[zutils] F: Remove --json mode API

### DIFF
--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -79,12 +79,6 @@ def build_parser(
     )
 
     parser.add_argument(
-        "--json",
-        action="store_true",
-        default=False,
-        help="Emit machine-parseable JSON output",
-    )
-    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s (nanvix-zutil {get_zutil_version()})",

--- a/src/nanvix_zutil/commands/info.py
+++ b/src/nanvix_zutil/commands/info.py
@@ -5,21 +5,18 @@
 
 Queries the GitHub Releases API for a Nanvix release, extracts the short
 commit SHA embedded in the sysroot asset filename, and optionally resolves
-the semver version from the release name.  Output is either a series of
-``key=value`` lines (suitable for ``>> $GITHUB_OUTPUT`` in CI) or a single
-JSON object (``--json``).
+the semver version from the release name.  Output is a series of
+``key=value`` lines (suitable for ``>> $GITHUB_OUTPUT`` in CI).
 
 Example usage::
 
     nanvix-info
     nanvix-info --version latest --machine microvm --mode standalone
-    nanvix-info --json
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -283,12 +280,6 @@ def _build_parser(prog: str = "nanvix-info") -> argparse.ArgumentParser:
         help=f"Memory size string used in asset names (default: {DEFAULT_MEMORY_SIZE})",
     )
     parser.add_argument(
-        "--json",
-        action="store_true",
-        default=False,
-        help="Emit a single JSON object instead of key=value lines",
-    )
-    parser.add_argument(
         "--gh-token",
         default=None,
         metavar="TOKEN",
@@ -302,7 +293,7 @@ def main() -> None:
     """Entry point for the ``nanvix-info`` command.
 
     Parses command-line arguments, resolves release information, and prints
-    the result to stdout as either ``key=value`` lines or JSON.
+    the result to stdout as ``key=value`` lines.
     """
     parser = _build_parser()
     args = parser.parse_args()
@@ -316,9 +307,6 @@ def main() -> None:
 
     gh_token: str | None = args.gh_token or os.environ.get("GH_TOKEN")
 
-    if args.json:
-        log.set_json_mode(True)
-
     info = get_nanvix_info(
         repo=args.repo,
         version=args.version,
@@ -329,13 +317,8 @@ def main() -> None:
         gh_token=gh_token,
     )
 
-    if args.json:
-        # Emit a single JSON object to stdout (not via log machinery).
-        log.set_json_mode(False)
-        print(json.dumps(info.to_dict()))
-    else:
-        for key, value in info.to_dict().items():
-            print(f"{key}={value}")
+    for key, value in info.to_dict().items():
+        print(f"{key}={value}")
 
     sys.exit(EXIT_SUCCESS)
 

--- a/src/nanvix_zutil/commands/resolve.py
+++ b/src/nanvix_zutil/commands/resolve.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 
@@ -30,15 +29,8 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="nanvix-zutil resolve",
         description=(
             "Resolve the .nanvix/nanvix.toml manifest and emit release "
-            "metadata as key=value lines (suitable for $GITHUB_OUTPUT) "
-            "or JSON."
+            "metadata as key=value lines (suitable for $GITHUB_OUTPUT)."
         ),
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        default=False,
-        help="Emit a single JSON object instead of key=value lines",
     )
     parser.add_argument(
         "--shallow",
@@ -70,9 +62,6 @@ def main() -> None:
 
     gh_token: str | None = args.gh_token or os.environ.get("GH_TOKEN")
 
-    if args.json:
-        log.set_json_mode(True)
-
     manifest = load_manifest()
     lockfile = resolve(
         manifest,
@@ -99,11 +88,7 @@ def main() -> None:
         "package_version": manifest.version,
     }
 
-    if args.json:
-        log.set_json_mode(False)
-        print(json.dumps(result))
-    else:
-        for key, value in result.items():
-            print(f"{key}={value}")
+    for key, value in result.items():
+        print(f"{key}={value}")
 
     sys.exit(EXIT_SUCCESS)

--- a/src/nanvix_zutil/log.py
+++ b/src/nanvix_zutil/log.py
@@ -3,14 +3,12 @@
 
 """Structured logging for nanvix_zutil.
 
-Provides colored terminal output and ``--json`` mode. In JSON mode every
-message is emitted as a single-line JSON object with ``level``, ``code``,
-``message``, and an optional ``hint`` field.
+Provides colored terminal output to stderr. Every log call emits a single
+line prefixed by a colored severity tag (``info:``, ``warning:`` …).
 """
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 from typing import NoReturn
@@ -66,38 +64,10 @@ def _enable_ansi_on_windows() -> None:
 
 _enable_ansi_on_windows()
 
-# ---------------------------------------------------------------------------
-# Module-level state
-# ---------------------------------------------------------------------------
-
-_json_mode: bool = False
-
 
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
-
-
-def set_json_mode(enabled: bool) -> None:
-    """Enable or disable JSON output mode.
-
-    When enabled every log call emits a single-line JSON object instead of
-    colored plain text.
-
-    Args:
-        enabled: ``True`` to enable JSON mode, ``False`` to disable it.
-    """
-    global _json_mode
-    _json_mode = enabled
-
-
-def is_json_mode() -> bool:
-    """Return whether JSON output mode is currently enabled.
-
-    Returns:
-        ``True`` if JSON mode is active, ``False`` otherwise.
-    """
-    return _json_mode
 
 
 def info(msg: str) -> None:
@@ -106,14 +76,7 @@ def info(msg: str) -> None:
     Args:
         msg: The message text.
     """
-    if _json_mode:
-        print(
-            json.dumps({"level": "info", "message": msg}),
-            file=sys.stderr,
-            flush=True,
-        )
-    else:
-        print(f"\033[36minfo:\033[0m {msg}", file=sys.stderr, flush=True)
+    print(f"\033[36minfo:\033[0m {msg}", file=sys.stderr, flush=True)
 
 
 def success(msg: str) -> None:
@@ -122,30 +85,16 @@ def success(msg: str) -> None:
     Args:
         msg: The message text.
     """
-    if _json_mode:
-        print(
-            json.dumps({"level": "success", "message": msg}),
-            file=sys.stderr,
-            flush=True,
-        )
-    else:
-        print(f"\033[32msuccess:\033[0m {msg}", file=sys.stderr, flush=True)
+    print(f"\033[32msuccess:\033[0m {msg}", file=sys.stderr, flush=True)
 
 
-def warning(msg: str, code: int | None = None) -> None:
+def warning(msg: str) -> None:
     """Emit a warning message.
 
     Args:
         msg: The message text.
-        code: Optional process exit code associated with the warning.
     """
-    if _json_mode:
-        obj: dict[str, object] = {"level": "warning", "message": msg}
-        if code is not None:
-            obj["code"] = code
-        print(json.dumps(obj), file=sys.stderr, flush=True)
-    else:
-        print(f"\033[33mwarning:\033[0m {msg}", file=sys.stderr, flush=True)
+    print(f"\033[33mwarning:\033[0m {msg}", file=sys.stderr, flush=True)
 
 
 def error(msg: str, hint: str | None = None) -> None:
@@ -155,15 +104,9 @@ def error(msg: str, hint: str | None = None) -> None:
         msg: The error message text.
         hint: Optional hint to help the user recover.
     """
-    if _json_mode:
-        obj: dict[str, object] = {"level": "error", "message": msg}
-        if hint is not None:
-            obj["hint"] = hint
-        print(json.dumps(obj), file=sys.stderr, flush=True)
-    else:
-        print(f"\033[31merror:\033[0m {msg}", file=sys.stderr, flush=True)
-        if hint is not None:
-            print(f"\033[90mhint:\033[0m {hint}", file=sys.stderr, flush=True)
+    print(f"\033[31merror:\033[0m {msg}", file=sys.stderr, flush=True)
+    if hint is not None:
+        print(f"\033[90mhint:\033[0m {hint}", file=sys.stderr, flush=True)
 
 
 def note(msg: str) -> None:
@@ -172,14 +115,7 @@ def note(msg: str) -> None:
     Args:
         msg: The note text.
     """
-    if _json_mode:
-        print(
-            json.dumps({"level": "note", "message": msg}),
-            file=sys.stderr,
-            flush=True,
-        )
-    else:
-        print(f"\033[90mnote:\033[0m {msg}", file=sys.stderr, flush=True)
+    print(f"\033[90mnote:\033[0m {msg}", file=sys.stderr, flush=True)
 
 
 def fatal(msg: str, code: int = 1, hint: str | None = None) -> NoReturn:
@@ -190,13 +126,7 @@ def fatal(msg: str, code: int = 1, hint: str | None = None) -> NoReturn:
         code: The process exit code (default ``1``).
         hint: Optional hint to help the user recover.
     """
-    if _json_mode:
-        obj: dict[str, object] = {"level": "error", "code": code, "message": msg}
-        if hint is not None:
-            obj["hint"] = hint
-        print(json.dumps(obj), file=sys.stderr, flush=True)
-    else:
-        print(f"\033[31merror:\033[0m {msg}", file=sys.stderr, flush=True)
-        if hint is not None:
-            print(f"\033[90mhint:\033[0m {hint}", file=sys.stderr, flush=True)
+    print(f"\033[31merror:\033[0m {msg}", file=sys.stderr, flush=True)
+    if hint is not None:
+        print(f"\033[90mhint:\033[0m {hint}", file=sys.stderr, flush=True)
     sys.exit(code)

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -614,13 +614,11 @@ class ZScript:
             framework_argv = argv
             targets = []
 
-        # Pre-parse --json and --version before creating the instance so
-        # that JSON mode is active for any errors raised during __init__,
-        # and --version can exit cleanly without requiring a valid manifest.
-        # Also pre-parse --mode so that --mode can override
-        # NANVIX_DEPLOYMENT_MODE before Config.__init__ runs.
+        # Pre-parse --version and --mode before creating the instance so
+        # that --version can exit cleanly without requiring a valid manifest,
+        # and so that --mode can override NANVIX_DEPLOYMENT_MODE before
+        # Config.__init__ runs.
         pre_parser = argparse.ArgumentParser(add_help=False)
-        pre_parser.add_argument("--json", action="store_true", default=False)
         pre_parser.add_argument(
             "--version",
             action="version",
@@ -628,9 +626,6 @@ class ZScript:
         )
         pre_parser.add_argument("--mode", default=None, dest="mode")
         pre_args, _ = pre_parser.parse_known_args(framework_argv)
-
-        if pre_args.json:
-            log.set_json_mode(True)
 
         # Detect --help/-h and the 'help' subcommand (or no subcommand at
         # all) BEFORE loading the manifest.  A missing nanvix.toml must not

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -10,7 +10,6 @@ import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
@@ -101,12 +100,6 @@ class TestDependency(unittest.TestCase):
 class TestBuildrootCreate(unittest.TestCase):
     """Buildroot.create() sets up the expected directory layout."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_creates_lib_dir(self) -> None:
         Buildroot.create()
         self.assertTrue((_buildroot() / "lib").is_dir())
@@ -128,12 +121,6 @@ class TestBuildrootCreate(unittest.TestCase):
 class TestBuildrootVerify(unittest.TestCase):
     """Buildroot.verify() checks that required libraries exist."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_verify_passes_when_libs_present(self) -> None:
         br = Buildroot.create()
         (_buildroot() / "lib" / "libz.a").write_bytes(b"")
@@ -153,12 +140,6 @@ class TestBuildrootVerify(unittest.TestCase):
 
 class TestBuildrootInstallDep(unittest.TestCase):
     """Buildroot.install_dep() extracts libs and headers correctly."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def _setup_buildroot(self) -> Buildroot:
         return Buildroot.create()
@@ -450,12 +431,6 @@ class TestParseSemverTuple(unittest.TestCase):
 class TestInstallDepPreResolvedRelease(unittest.TestCase):
     """Buildroot.install_dep with _release pre-resolved."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def _setup_buildroot(self) -> Buildroot:
         return Buildroot.create()
 
@@ -537,12 +512,6 @@ class TestRefKindLocal(unittest.TestCase):
 
 class TestBuildrootInstallDepZip(unittest.TestCase):
     """Buildroot.install_dep() extracts libs and headers from .zip archives."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def _setup_buildroot(self) -> Buildroot:
         return Buildroot.create()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,16 +17,6 @@ class TestBuildParser(unittest.TestCase):
         parser = build_parser()
         self.assertIsInstance(parser, argparse.ArgumentParser)
 
-    def test_json_flag(self) -> None:
-        parser = build_parser()
-        args = parser.parse_args(["--json", "build"])
-        self.assertTrue(args.json)
-
-    def test_no_json_by_default(self) -> None:
-        parser = build_parser()
-        args = parser.parse_args(["build"])
-        self.assertFalse(args.json)
-
     def test_subcommands_registered(self) -> None:
         parser = build_parser()
         for cmd in SUBCOMMANDS:

--- a/tests/test_cli_lock.py
+++ b/tests/test_cli_lock.py
@@ -10,7 +10,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil import paths
 from nanvix_zutil.buildroot import Ref, RefKind
 from nanvix_zutil.cli import build_parser
@@ -89,12 +88,8 @@ class TestLockMethod(unittest.TestCase):
 
     def setUp(self) -> None:
         write_manifest()
-        log_mod.set_json_mode(True)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     @patch("nanvix_zutil.script.resolve")
     def test_lock_writes_lockfile(self, mock_resolve: MagicMock) -> None:
@@ -125,12 +120,8 @@ class TestLockCheck(unittest.TestCase):
 
     def setUp(self) -> None:
         write_manifest()
-        log_mod.set_json_mode(True)
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_lock_check_exits_0_when_fresh(self) -> None:
         manifest_path = paths.manifest_path()

--- a/tests/test_format_cmd.py
+++ b/tests/test_format_cmd.py
@@ -7,7 +7,6 @@ import subprocess as sp
 import unittest
 from unittest.mock import patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil import paths
 from nanvix_zutil.commands.format import format, main
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
@@ -88,32 +87,24 @@ class TestFormatCmd(unittest.TestCase):
             cmd = list(args)
             raise sp.CalledProcessError(returncode=1, cmd=cmd)
 
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
-                patch("importlib.util.find_spec", return_value=True),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                format()
-            self.assertEqual(ctx.exception.code, 5)
-        finally:
-            log_mod.set_json_mode(False)
+        with (
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            format()
+        self.assertEqual(ctx.exception.code, 5)
 
     def test_exits_when_tool_missing(self) -> None:
         """Exits with EXIT_MISSING_DEP when black is not installed."""
         (self.nanvix_dir / "z.py").write_text("x = 1\n")
 
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch("importlib.util.find_spec", return_value=None),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                format()
-            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-        finally:
-            log_mod.set_json_mode(False)
+        with (
+            patch("importlib.util.find_spec", return_value=None),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            format()
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
 
 class TestFormatCmdMain(unittest.TestCase):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import nanvix_zutil.github as github_mod
-import nanvix_zutil.log as log_mod
 
 
 def _make_urlopen_response(body: bytes, chunked: bool = False) -> MagicMock:
@@ -58,11 +57,9 @@ class TestDownloadReleaseAssetAlreadyExists(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_returns_existing_path_without_network(self) -> None:
         dest = Path(self._tmpdir.name)
@@ -86,11 +83,9 @@ class TestDownloadReleaseAssetSuccess(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_downloads_and_writes_file(self) -> None:
         dest = Path(self._tmpdir.name)
@@ -152,11 +147,9 @@ class TestDownloadReleaseAssetNotFound(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_asset_not_in_release_exits_3(self) -> None:
         dest = Path(self._tmpdir.name)
@@ -179,11 +172,9 @@ class TestDownloadReleaseAssetNetworkError(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_metadata_network_error_exits_4(self) -> None:
         dest = Path(self._tmpdir.name)
@@ -256,11 +247,9 @@ class TestDownloadReleaseAssetLatestTag(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_latest_tag_uses_releases_latest_endpoint(self) -> None:
         dest = Path(self._tmpdir.name)
@@ -336,11 +325,9 @@ class TestDownloadReleaseAssetPrefixMatch(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_prefix_match_finds_asset_with_sha(self) -> None:
         dest = Path(self._tmpdir.name)
@@ -390,7 +377,6 @@ class TestDownloadReleaseAssetPrefixMatch(unittest.TestCase):
         metadata_resp = _make_urlopen_response(
             _make_release_payload("unrelated-asset.tar.bz2", "https://example.com/x")
         )
-        log_mod.set_json_mode(True)
 
         with patch("urllib.request.urlopen", return_value=metadata_resp):
             with self.assertRaises(SystemExit) as ctx:
@@ -409,11 +395,9 @@ class TestDownloadReleaseAssetPrefixPreference(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def _make_multi_asset_release(self, assets: list[tuple[str, str]]) -> bytes:
         """Build a release payload with multiple assets."""
@@ -677,12 +661,6 @@ class TestFetchJson(unittest.TestCase):
 
     _headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_404_without_allow_404_exits_3(self) -> None:
         """HTTP 404 (allow_404=False) exits with EXIT_MISSING_DEP (3)."""
         url = "https://api.github.com/repos/nanvix/zlib/releases/tags/v0.0.0"
@@ -746,12 +724,6 @@ class TestListReleases(unittest.TestCase):
 
     _headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_single_page_no_link_header(self) -> None:
         releases_data: list[dict[str, object]] = [
             {"tag_name": "v1", "target_commitish": "a" * 40},
@@ -814,12 +786,6 @@ class TestResolveRelease(unittest.TestCase):
     """Tests for :func:`github._resolve_release` (full hash resolution)."""
 
     _headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_latest_uses_releases_latest_endpoint(self) -> None:
         release_data: dict[str, object] = {"tag_name": "latest", "assets": []}
@@ -1052,12 +1018,6 @@ class TestResolveReleaseSemver(unittest.TestCase):
 
     _headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_semver_resolves_via_v_prefix_tag(self) -> None:
         """``"1.2.3"`` resolves via ``GET /releases/tags/v1.2.3``."""
         release_data: dict[str, object] = {"tag_name": "v1.2.3", "assets": []}
@@ -1194,11 +1154,9 @@ class TestDownloadReleaseAssetFullHash(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_full_hash_downloads_correct_asset(self) -> None:
         dest = Path(self._tmpdir.name)
@@ -1243,7 +1201,6 @@ class TestDownloadReleaseAssetFullHash(unittest.TestCase):
             {"tag_name": "latest", "target_commitish": "b" * 40, "assets": []},
         ]
         resp = _make_urlopen_response(json.dumps(releases_list).encode())
-        log_mod.set_json_mode(True)
 
         with patch("urllib.request.urlopen", return_value=resp):
             with self.assertRaises(SystemExit) as ctx:
@@ -1266,12 +1223,6 @@ class TestResolveReleaseId(unittest.TestCase):
     """Tests for integer release ID resolution."""
 
     _headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_int_tag_fetches_releases_id_endpoint(self) -> None:
         release_data: dict[str, object] = {"id": 12345678, "assets": []}
@@ -1302,12 +1253,6 @@ class TestResolveReleaseSemverGating(unittest.TestCase):
     """Semver cascade only runs when ``semver=True``."""
 
     _headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_semver_string_without_flag_uses_plain_tag(self) -> None:
         """``1.2.3`` without ``semver=True`` goes to /releases/tags/1.2.3."""
@@ -1353,12 +1298,6 @@ class TestResolveReleaseSemverGating(unittest.TestCase):
 
 class TestFindBestRelease(unittest.TestCase):
     """Tests for _find_best_release()."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_finds_matching_release(self) -> None:
         """First release whose tag matches the prefix is returned."""
@@ -1411,12 +1350,6 @@ class TestFindBestRelease(unittest.TestCase):
 
 class TestResolveReleaseWithFallback(unittest.TestCase):
     """Tests for resolve_release_with_fallback()."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     @patch.object(github_mod, "_find_best_release")
     @patch.object(github_mod, "_resolve_release")

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -3,7 +3,6 @@
 
 """Tests for nanvix_zutil.commands.info."""
 
-import json
 import sys
 import unittest
 from io import StringIO
@@ -213,41 +212,6 @@ class TestNanvixInfoMain(unittest.TestCase):
         self.assertEqual(call_args[0][0], "nanvix/nanvix")
         self.assertEqual(call_args[0][1], "latest")
 
-    @patch("nanvix_zutil.commands.info.resolve_release")
-    def test_json_output(self, mock_resolve: MagicMock) -> None:
-        mock_resolve.return_value = _make_release()
-        buf = StringIO()
-        sys.stdout = buf
-        try:
-            with (
-                patch("sys.argv", ["nanvix-info", "--json"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-        finally:
-            sys.stdout = sys.__stdout__
-        self.assertEqual(ctx.exception.code, 0)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["tag"], _TAG)
-        self.assertEqual(obj["sha"], _SHA)
-        self.assertEqual(obj["version"], _VERSION)
-
-    @patch("nanvix_zutil.commands.info.resolve_release")
-    def test_json_output_without_version(self, mock_resolve: MagicMock) -> None:
-        mock_resolve.return_value = _make_release(name="no version here")
-        buf = StringIO()
-        sys.stdout = buf
-        try:
-            with (
-                patch("sys.argv", ["nanvix-info", "--json"]),
-                self.assertRaises(SystemExit),
-            ):
-                main()
-        finally:
-            sys.stdout = sys.__stdout__
-        obj = json.loads(buf.getvalue().strip())
-        self.assertNotIn("version", obj)
-
     def test_invalid_repo_format_exits(self) -> None:
         with (
             patch("sys.argv", ["nanvix-info", "--repo", "invalid"]),
@@ -343,6 +307,22 @@ class TestNanvixInfoMain(unittest.TestCase):
         output = buf.getvalue()
         self.assertIn("sha=deadbee", output)
 
+    @patch("nanvix_zutil.commands.info.resolve_release")
+    def test_release_name_without_version(self, mock_resolve: MagicMock) -> None:
+        """Release name without semver omits the version line entirely."""
+        mock_resolve.return_value = _make_release(name="no version here")
+        buf = StringIO()
+        sys.stdout = buf
+        try:
+            with (
+                patch("sys.argv", ["nanvix-info"]),
+                self.assertRaises(SystemExit),
+            ):
+                main()
+        finally:
+            sys.stdout = sys.__stdout__
+        self.assertNotIn("version=", buf.getvalue())
+
 
 class TestNanvixZutilInfoInvocation(unittest.TestCase):
     """Tests for invocation via ``nanvix-zutil info`` (CLI dispatcher)."""
@@ -365,25 +345,6 @@ class TestNanvixZutilInfoInvocation(unittest.TestCase):
         output = buf.getvalue()
         self.assertIn(f"tag={_TAG}", output)
         self.assertIn(f"sha={_SHA}", output)
-
-    @patch("nanvix_zutil.commands.info.resolve_release")
-    def test_nanvix_zutil_info_json(self, mock_resolve: MagicMock) -> None:
-        """nanvix-zutil info --json produces valid JSON."""
-        mock_resolve.return_value = _make_release()
-        buf = StringIO()
-        sys.stdout = buf
-        try:
-            with (
-                patch("sys.argv", ["nanvix-zutil info", "--json"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-        finally:
-            sys.stdout = sys.__stdout__
-        self.assertEqual(ctx.exception.code, 0)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["tag"], _TAG)
-        self.assertEqual(obj["sha"], _SHA)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,14 +7,12 @@ These tests exercise the full lifecycle of a mock consumer ``z.py`` that
 subclasses :class:`~nanvix_zutil.ZScript` and implements all lifecycle hooks.
 """
 
-import json
 import os
 import sys
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil import ZScript
 from nanvix_zutil.helpers import run
 from nanvix_zutil.paths import manifest_path, nanvix_root, repo_root
@@ -66,13 +64,9 @@ class TestIntegrationLifecycle(unittest.TestCase):
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-        log_mod.set_json_mode(False)
         p = patch("nanvix_zutil.script.check_docker", return_value=None)
         p.start()
         self.addCleanup(p.stop)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def _run_main(
         self, subcommand: str, extra_argv: list[str] | None = None
@@ -131,36 +125,6 @@ class TestIntegrationLifecycle(unittest.TestCase):
     def test_clean_hook_called(self) -> None:
         instance = self._run_main("clean")
         self.assertIn("clean", instance.called)
-
-    def test_json_flag_enables_json_mode(self) -> None:
-        """--json flag produces JSON output on stderr."""
-        from io import StringIO
-
-        fake_script = str(nanvix_root() / "z.py")
-
-        # build needs a persisted Docker image.
-        nanvix_dir = repo_root() / ".nanvix"
-        (nanvix_dir / "env.json").write_text(
-            '{"NANVIX_DOCKER_IMAGE": "test/image:tag"}'
-        )
-
-        with (patch("sys.argv", [fake_script, "--json", "build"]),):
-            _MockConsumer.main()
-
-        # After main(), log mode was set to True. Verify it produces JSON output.
-        buf = StringIO()
-        original_stderr = sys.stderr
-        sys.stderr = buf
-        try:
-            log_mod.info("json-check")
-        finally:
-            sys.stderr = original_stderr
-            log_mod.set_json_mode(False)
-
-        raw: object = json.loads(buf.getvalue().strip())
-        self.assertIsInstance(raw, dict)
-        assert isinstance(raw, dict)
-        self.assertEqual(raw["level"], "info")
 
     def test_help_subcommand_returns(self) -> None:
         """help subcommand prints help and returns without calling any hook."""
@@ -245,10 +209,6 @@ class TestIntegrationConfigPersistence(unittest.TestCase):
         write_manifest()
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_config_save_and_reload(self) -> None:
         script = _MockConsumer()
@@ -265,23 +225,15 @@ class TestIntegrationRunSubprocess(unittest.TestCase):
 
     def setUp(self) -> None:
         write_manifest()
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_run_echo_succeeds(self) -> None:
         result = run(sys.executable, "-c", "import sys; sys.exit(0)", cwd=repo_root())
         self.assertEqual(result.returncode, 0)
 
     def test_run_exit_nonzero_raises_system_exit_5(self) -> None:
-        log_mod.set_json_mode(True)
-        try:
-            with self.assertRaises(SystemExit) as ctx:
-                run(sys.executable, "-c", "import sys; sys.exit(2)", cwd=repo_root())
-            self.assertEqual(ctx.exception.code, 5)
-        finally:
-            log_mod.set_json_mode(False)
+        with self.assertRaises(SystemExit) as ctx:
+            run(sys.executable, "-c", "import sys; sys.exit(2)", cwd=repo_root())
+        self.assertEqual(ctx.exception.code, 5)
 
 
 if __name__ == "__main__":

--- a/tests/test_lint_cmd.py
+++ b/tests/test_lint_cmd.py
@@ -7,7 +7,6 @@ import subprocess as sp
 import unittest
 from unittest.mock import patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil import paths
 from nanvix_zutil.commands.lint import lint, main
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
@@ -65,32 +64,24 @@ class TestLintCmd(unittest.TestCase):
             cmd = list(args)
             raise sp.CalledProcessError(returncode=1, cmd=cmd)
 
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
-                patch("importlib.util.find_spec", return_value=True),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                lint()
-            self.assertEqual(ctx.exception.code, 5)
-        finally:
-            log_mod.set_json_mode(False)
+        with (
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+            patch("importlib.util.find_spec", return_value=True),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            lint()
+        self.assertEqual(ctx.exception.code, 5)
 
     def test_exits_when_tool_missing(self) -> None:
         """Exits with EXIT_MISSING_DEP when black is not installed."""
         (self.nanvix_dir / "z.py").write_text("x = 1\n")
 
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch("importlib.util.find_spec", return_value=None),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                lint()
-            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-        finally:
-            log_mod.set_json_mode(False)
+        with (
+            patch("importlib.util.find_spec", return_value=None),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            lint()
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
 
 class TestLintCmdMain(unittest.TestCase):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -8,7 +8,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil.buildroot import Ref, RefKind
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -73,11 +72,9 @@ class TestLockfileRoundTrip(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_round_trip(self) -> None:
         lockfile = _make_sample_lockfile()
@@ -216,11 +213,9 @@ class TestReadLockfileMalformed(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_missing_file_exits_3(self) -> None:
         path = Path(self._tmpdir.name) / "nanvix.lock"
@@ -248,11 +243,9 @@ class TestDownloadLockfileAsset(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_returns_none_when_no_lockfile_asset(self) -> None:
         release: dict[str, object] = {

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -3,7 +3,6 @@
 
 """Tests for nanvix_zutil.log."""
 
-import json
 import sys
 import unittest
 from io import StringIO
@@ -14,9 +13,6 @@ import nanvix_zutil.log as log_mod
 class TestInfo(unittest.TestCase):
     """Tests for log.info."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_basic(self) -> None:
         buf = StringIO()
         sys.stderr = buf
@@ -26,25 +22,9 @@ class TestInfo(unittest.TestCase):
             sys.stderr = sys.__stderr__
         self.assertIn("hello", buf.getvalue())
 
-    def test_json_mode(self) -> None:
-        log_mod.set_json_mode(True)
-        buf = StringIO()
-        sys.stderr = buf
-        try:
-            log_mod.info("hello json")
-        finally:
-            sys.stderr = sys.__stderr__
-            log_mod.set_json_mode(False)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["level"], "info")
-        self.assertEqual(obj["message"], "hello json")
-
 
 class TestSuccess(unittest.TestCase):
     """Tests for log.success."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_basic(self) -> None:
         buf = StringIO()
@@ -55,24 +35,9 @@ class TestSuccess(unittest.TestCase):
             sys.stderr = sys.__stderr__
         self.assertIn("done", buf.getvalue())
 
-    def test_json_mode(self) -> None:
-        log_mod.set_json_mode(True)
-        buf = StringIO()
-        sys.stderr = buf
-        try:
-            log_mod.success("all good")
-        finally:
-            sys.stderr = sys.__stderr__
-            log_mod.set_json_mode(False)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["level"], "success")
-
 
 class TestWarning(unittest.TestCase):
     """Tests for log.warning."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_basic(self) -> None:
         buf = StringIO()
@@ -83,37 +48,9 @@ class TestWarning(unittest.TestCase):
             sys.stderr = sys.__stderr__
         self.assertIn("careful", buf.getvalue())
 
-    def test_json_mode(self) -> None:
-        log_mod.set_json_mode(True)
-        buf = StringIO()
-        sys.stderr = buf
-        try:
-            log_mod.warning("watch out")
-        finally:
-            sys.stderr = sys.__stderr__
-            log_mod.set_json_mode(False)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["level"], "warning")
-
-    def test_json_mode_with_code(self) -> None:
-        log_mod.set_json_mode(True)
-        buf = StringIO()
-        sys.stderr = buf
-        try:
-            log_mod.warning("degraded", code=7)
-        finally:
-            sys.stderr = sys.__stderr__
-            log_mod.set_json_mode(False)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["level"], "warning")
-        self.assertEqual(obj["code"], 7)
-
 
 class TestError(unittest.TestCase):
     """Tests for log.error."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_basic(self) -> None:
         buf = StringIO()
@@ -135,25 +72,9 @@ class TestError(unittest.TestCase):
         self.assertIn("oops", output)
         self.assertIn("try this", output)
 
-    def test_json_mode_with_hint(self) -> None:
-        log_mod.set_json_mode(True)
-        buf = StringIO()
-        sys.stderr = buf
-        try:
-            log_mod.error("bad", hint="fix it")
-        finally:
-            sys.stderr = sys.__stderr__
-            log_mod.set_json_mode(False)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["level"], "error")
-        self.assertEqual(obj["hint"], "fix it")
-
 
 class TestFatal(unittest.TestCase):
     """Tests for log.fatal."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_exits(self) -> None:
         with self.assertRaises(SystemExit) as ctx:
@@ -165,8 +86,7 @@ class TestFatal(unittest.TestCase):
             log_mod.fatal("network error", code=4)
         self.assertEqual(ctx.exception.code, 4)
 
-    def test_json_mode(self) -> None:
-        log_mod.set_json_mode(True)
+    def test_emits_hint(self) -> None:
         buf = StringIO()
         sys.stderr = buf
         try:
@@ -174,11 +94,9 @@ class TestFatal(unittest.TestCase):
                 log_mod.fatal("kaboom", code=5, hint="check logs")
         finally:
             sys.stderr = sys.__stderr__
-            log_mod.set_json_mode(False)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["level"], "error")
-        self.assertEqual(obj["code"], 5)
-        self.assertEqual(obj["hint"], "check logs")
+        output = buf.getvalue()
+        self.assertIn("kaboom", output)
+        self.assertIn("check logs", output)
 
 
 class TestAnsiWindowsEnablement(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,7 +75,7 @@ class TestInfoDispatch(unittest.TestCase):
         """info subcommand calls info.main()."""
         original_argv = sys.argv[:]
         try:
-            with patch("sys.argv", ["nanvix-zutil", "info", "--json"]):
+            with patch("sys.argv", ["nanvix-zutil", "info"]):
                 main()
         except SystemExit:
             pass

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,7 +7,6 @@ import os
 import unittest
 from unittest.mock import patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil import paths
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.manifest import load_manifest, is_local_path
@@ -18,12 +17,6 @@ from tests.testutils import make_toml
 class TestLoadManifestFileNotFound(unittest.TestCase):
     """load_manifest exits 3 when the file does not exist."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_missing_file_exits_3(self) -> None:
         with self.assertRaises(SystemExit) as ctx:
             load_manifest()
@@ -33,12 +26,6 @@ class TestLoadManifestFileNotFound(unittest.TestCase):
 
 class TestLoadManifestBasic(unittest.TestCase):
     """load_manifest parses a well-formed nanvix.toml."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_single_dependency_commitish(self) -> None:
         path = paths.manifest_path()
@@ -142,12 +129,6 @@ class TestLoadManifestBasic(unittest.TestCase):
 
 class TestLoadManifestInvalidVersion(unittest.TestCase):
     """Invalid version specs are rejected."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_empty_string_nanvix_version_exits_2(self) -> None:
         path = paths.manifest_path()
@@ -277,12 +258,6 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
 class TestLoadManifestLatestWarning(unittest.TestCase):
     """'latest' emits a warning but is accepted for dependencies."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_latest_dep_version_warns(self) -> None:
         path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"latest"'}))
@@ -296,12 +271,6 @@ class TestLoadManifestLatestWarning(unittest.TestCase):
 
 class TestLoadManifestPackageValidation(unittest.TestCase):
     """Required [package] keys are validated."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_missing_package_section_exits_2(self) -> None:
         path = paths.manifest_path()
@@ -352,12 +321,6 @@ class TestLoadManifestPackageValidation(unittest.TestCase):
 class TestLoadManifestMalformedToml(unittest.TestCase):
     """Invalid TOML syntax is rejected."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_invalid_toml_exits_2(self) -> None:
         path = paths.manifest_path()
         path.write_text("this is not valid toml [[[")
@@ -370,12 +333,6 @@ class TestLoadManifestMalformedToml(unittest.TestCase):
 
 class TestLoadManifestEnvOverride(unittest.TestCase):
     """Environment variables override manifest versions."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_nanvix_version_overrides_sysroot(self) -> None:
         path = paths.manifest_path()
@@ -447,12 +404,6 @@ class TestLoadManifestEnvOverride(unittest.TestCase):
 class TestLoadManifestAutoSuffix(unittest.TestCase):
     """Only VERSION refs are auto-suffixed with the nanvix version."""
 
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_version_string_dep_suffixed(self) -> None:
         path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="1.0.0", deps={"zlib": '"4.5.6"'}))
@@ -504,10 +455,8 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
         path = paths.manifest_path()
         path.write_text(make_toml(deps={"zlib": '"b7a6a3c-nanvix-fa06b88"'}))
 
-        log_mod.set_json_mode(True)
         with self.assertRaises(SystemExit) as ctx:
             load_manifest()
-        log_mod.set_json_mode(False)
 
         self.assertEqual(ctx.exception.code, 2)
 
@@ -538,12 +487,6 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
 
 class TestLoadManifestSystemDependencies(unittest.TestCase):
     """[system-dependencies] are parsed correctly."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_system_deps_parsed(self) -> None:
         path = paths.manifest_path()
@@ -581,12 +524,6 @@ class TestLoadManifestSystemDependencies(unittest.TestCase):
 
 class TestLoadManifestTypeValidation(unittest.TestCase):
     """Non-string/non-table dependency values and non-table sections are rejected."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_integer_dependency_value_exits_2(self) -> None:
         path = paths.manifest_path()
@@ -679,12 +616,6 @@ class TestIsLocalPath(unittest.TestCase):
 
 class TestLoadManifestLocalRef(unittest.TestCase):
     """Env var overrides with filesystem paths produce RefKind.LOCAL."""
-
-    def setUp(self) -> None:
-        log_mod.set_json_mode(False)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_dep_env_unix_path_produces_local(self) -> None:
         path = paths.manifest_path()

--- a/tests/test_resolve_cmd.py
+++ b/tests/test_resolve_cmd.py
@@ -3,7 +3,6 @@
 
 """Tests for nanvix_zutil.commands.resolve."""
 
-import json
 import os
 import sys
 import unittest
@@ -108,37 +107,6 @@ class TestDefaultOutput(unittest.TestCase):
         self.assertIn(f"nanvix_version={_TAG.lstrip('v')}", output)
         self.assertIn(f"package_name={_NAME}", output)
         self.assertIn(f"package_version={_VERSION}", output)
-
-
-class TestJsonOutput(unittest.TestCase):
-    """``--json`` emits a JSON object."""
-
-    @patch("nanvix_zutil.commands.resolve.resolve")
-    @patch("nanvix_zutil.commands.resolve.load_manifest")
-    def test_json_output(self, mock_load: MagicMock, mock_resolve: MagicMock) -> None:
-        mock_load.return_value = _make_manifest()
-        mock_resolve.return_value = _make_lockfile()
-
-        _write_manifest()
-
-        buf = StringIO()
-        sys.stdout = buf
-        try:
-            with (
-                patch("sys.argv", ["nanvix-zutil resolve", "--json"]),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                main()
-        finally:
-            sys.stdout = sys.__stdout__
-
-        self.assertEqual(ctx.exception.code, 0)
-        obj = json.loads(buf.getvalue().strip())
-        self.assertEqual(obj["nanvix_tag"], _TAG)
-        self.assertEqual(obj["nanvix_sha"], _SHA[:7])
-        self.assertEqual(obj["nanvix_version"], _TAG.lstrip("v"))
-        self.assertEqual(obj["package_name"], _NAME)
-        self.assertEqual(obj["package_version"], _VERSION)
 
 
 class TestShallowFlag(unittest.TestCase):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -9,7 +9,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil import paths
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.lockfile import (
@@ -79,10 +78,6 @@ class TestResolveSysrootOnly(unittest.TestCase):
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\nnanvix-version = "0.1.0"\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_sysroot_only(
         self,
@@ -125,10 +120,6 @@ class TestResolveDirectDep(unittest.TestCase):
             "[dependencies]\n"
             'zlib = { tag = "v1.0.0" }\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_one_direct_dep(
         self,
@@ -180,10 +171,6 @@ class TestResolveTransitive(unittest.TestCase):
             "[dependencies]\n"
             'libfoo = { tag = "v1.0.0" }\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_transitive_discovery(
         self,
@@ -267,10 +254,6 @@ class TestResolveShallow(unittest.TestCase):
             "[dependencies]\n"
             'libfoo = { tag = "v1.0.0" }\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_shallow_skips_transitive(
         self,
@@ -311,10 +294,6 @@ class TestCycleDetection(unittest.TestCase):
             "[dependencies]\n"
             'liba = { tag = "v1.0.0" }\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_cycle_detected(
         self,
@@ -392,10 +371,6 @@ class TestVersionConflict(unittest.TestCase):
             'libfoo = { tag = "v1.0.0" }\n'
             'zlib = { tag = "v1.0.0" }\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_conflict_exits_2(
         self,
@@ -492,10 +467,6 @@ class TestResolveLatestSysroot(unittest.TestCase):
             "[dependencies]\n"
             'zlib = "1.3.1"\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_latest_sysroot_deferred_suffix(
         self,
@@ -562,10 +533,6 @@ class TestAssetFiltering(unittest.TestCase):
         self._manifest_path.write_text(
             '[package]\nname = "test"\nversion = "0.1.0"\nnanvix-version = "0.1.0"\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_filters_non_tar_bz2(
         self,
@@ -647,10 +614,6 @@ class TestResolveVersionFallback(unittest.TestCase):
             "[dependencies]\n"
             'zlib = "1.3.1"\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_fallback_downgrades_sysroot(
         self,
@@ -817,10 +780,6 @@ class TestNoFallbackWhenPinned(unittest.TestCase):
             "[dependencies]\n"
             'zlib = "1.3.1"\n'
         )
-        log_mod.set_json_mode(True)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_no_fallback_when_pinned(
         self,

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -4,7 +4,6 @@
 # pyright: reportPrivateUsage=false
 """Tests for nanvix_zutil.script (ZScript)."""
 
-import json
 import os
 import subprocess as sp
 import sys
@@ -13,7 +12,6 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil import helpers, paths
 from nanvix_zutil.buildroot import RefKind
 from nanvix_zutil.docker import (
@@ -74,13 +72,9 @@ class TestZScriptInit(unittest.TestCase):
     def test_missing_manifest_exits_3(self) -> None:
         # Autouse fixture wrote a manifest in setUp; remove it.
         (paths.manifest_path()).unlink()
-        log_mod.set_json_mode(True)
-        try:
-            with self.assertRaises(SystemExit) as ctx:
-                ZScript()
-            self.assertEqual(ctx.exception.code, 3)
-        finally:
-            log_mod.set_json_mode(False)
+        with self.assertRaises(SystemExit) as ctx:
+            ZScript()
+        self.assertEqual(ctx.exception.code, 3)
 
 
 class TestZScriptAutoSetup(unittest.TestCase):
@@ -211,21 +205,17 @@ class TestZScriptSetupLatestSysroot(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
         fake_sysroot.tag = ""
 
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch(
-                    "nanvix_zutil.script.Sysroot.download",
-                    return_value=fake_sysroot,
-                ),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                script = ZScript()
-                script.setup()
+        with (
+            patch(
+                "nanvix_zutil.script.Sysroot.download",
+                return_value=fake_sysroot,
+            ),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            script = ZScript()
+            script.setup()
 
-            self.assertEqual(ctx.exception.code, 3)
-        finally:
-            log_mod.set_json_mode(False)
+        self.assertEqual(ctx.exception.code, 3)
 
 
 class TestZScriptSyncConfigs(unittest.TestCase):
@@ -393,25 +383,6 @@ class TestZScriptReleaseDefault(unittest.TestCase):
         self.assertIn("Packaged 2 archive(s) for 'test'", output)
         self.assertIn(str(paths.dist_dir()), output)
 
-    def test_emits_success_message_json(self) -> None:
-        """In JSON mode, success is emitted as a structured record."""
-        self._populate_release_dir()
-
-        buf = StringIO()
-        original_stderr = sys.stderr
-        log_mod.set_json_mode(True)
-        sys.stderr = buf
-        try:
-            ZScript().release()
-        finally:
-            sys.stderr = original_stderr
-            log_mod.set_json_mode(False)
-
-        records = [json.loads(line) for line in buf.getvalue().splitlines() if line]
-        success_records = [r for r in records if r.get("level") == "success"]
-        self.assertEqual(len(success_records), 1)
-        self.assertIn("Packaged 2 archive(s) for 'test'", success_records[0]["message"])
-
     def test_fails_when_release_dir_missing(self) -> None:
         """Missing ``.nanvix/out/release`` aborts with EXIT_GENERAL_ERROR."""
         from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
@@ -518,24 +489,14 @@ class TestHelpersRun(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
 
     def test_run_failure_exits(self) -> None:
-        log_mod.set_json_mode(True)
-        try:
-            with self.assertRaises(SystemExit) as ctx:
-                helpers.run(sys.executable, "-c", "raise SystemExit(1)")
-            self.assertEqual(ctx.exception.code, EXIT_BUILD_FAILURE)
-        finally:
-            log_mod.set_json_mode(False)
+        with self.assertRaises(SystemExit) as ctx:
+            helpers.run(sys.executable, "-c", "raise SystemExit(1)")
+        self.assertEqual(ctx.exception.code, EXIT_BUILD_FAILURE)
 
     def test_run_timeout_exits(self) -> None:
-        log_mod.set_json_mode(True)
-        try:
-            with self.assertRaises(SystemExit) as ctx:
-                helpers.run(
-                    sys.executable, "-c", "import time; time.sleep(10)", timeout=1
-                )
-            self.assertEqual(ctx.exception.code, EXIT_BUILD_FAILURE)
-        finally:
-            log_mod.set_json_mode(False)
+        with self.assertRaises(SystemExit) as ctx:
+            helpers.run(sys.executable, "-c", "import time; time.sleep(10)", timeout=1)
+        self.assertEqual(ctx.exception.code, EXIT_BUILD_FAILURE)
 
     def test_run_without_docker_uses_args_directly(self) -> None:
         """Without a docker config, run() executes the command as-is."""
@@ -1175,34 +1136,21 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
         ]
         self.assertTrue(success_calls, "Expected a success log on clean setup")
 
-    def test_main_json_fatal_includes_degraded_code(self) -> None:
-        """main() emits a fatal JSON object with code on degraded setup."""
+    def test_main_fatal_exits_with_degraded_code(self) -> None:
+        """main() exits with EXIT_DEGRADED_SETUP when setup() returns True."""
         from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
 
-        buf = StringIO()
-        original_stderr = sys.stderr
-        log_mod.set_json_mode(True)
-        sys.stderr = buf
-        try:
-            with (
-                patch(
-                    "sys.argv",
-                    ["z.py", "--json", "setup", "--with-docker", "test/image:tag"],
-                ),
-                patch.object(ZScript, "setup", return_value=True),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                ZScript.main()
-        finally:
-            sys.stderr = original_stderr
-            log_mod.set_json_mode(False)
+        with (
+            patch(
+                "sys.argv",
+                ["z.py", "setup", "--with-docker", "test/image:tag"],
+            ),
+            patch.object(ZScript, "setup", return_value=True),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            ZScript.main()
 
         self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
-        json_lines = [ln for ln in buf.getvalue().splitlines() if ln.startswith("{")]
-        self.assertTrue(json_lines, "Expected JSON output on stderr")
-        obj = json.loads(json_lines[-1])
-        self.assertEqual(obj["level"], "error")
-        self.assertEqual(obj["code"], EXIT_DEGRADED_SETUP)
 
 
 class TestZScriptSetupWithNanvix(unittest.TestCase):
@@ -1282,9 +1230,6 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
 
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
-
     def test_local_sysroot_skips_github(self) -> None:
         """When sysroot ref is LOCAL, Sysroot.from_local is used."""
         repo_root = paths.repo_root()
@@ -1332,9 +1277,6 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
     def setUp(self) -> None:
         for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_local_dep_uses_install_local_nanvix(self) -> None:
         """LOCAL deps call install_local_nanvix instead of GitHub."""
@@ -1400,7 +1342,6 @@ class TestZScriptSetupLocalDep(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
         fake_sysroot.tag = "v0.1.0"
 
-        log_mod.set_json_mode(True)
         with (
             patch.dict(os.environ, {"NANVIX_VERSION_ZLIB": str(local_dep_path)}),
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
@@ -1610,13 +1551,9 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         """Exits with EXIT_MISSING_DEP when sysroot is None and config lacks one."""
         script = ZScript()
         script.sysroot = None
-        log_mod.set_json_mode(True)
-        try:
-            with self.assertRaises(SystemExit) as ctx:
-                helpers.make_initrd(script, "my-app.elf", test=False, args=InitRdArgs())
-            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-        finally:
-            log_mod.set_json_mode(False)
+        with self.assertRaises(SystemExit) as ctx:
+            helpers.make_initrd(script, "my-app.elf", test=False, args=InitRdArgs())
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_app_stem_derived_from_filename(self, _mock: object) -> None:
@@ -1641,15 +1578,11 @@ class TestHelpersMakeInitrd(unittest.TestCase):
     def test_app_with_path_separator_exits(self) -> None:
         """Exits with EXIT_MISSING_DEP when app contains path separators."""
         script = self._make_script()
-        log_mod.set_json_mode(True)
-        try:
-            with self.assertRaises(SystemExit) as ctx:
-                helpers.make_initrd(
-                    script, "build/hello.elf", test=False, args=InitRdArgs()
-                )
-            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-        finally:
-            log_mod.set_json_mode(False)
+        with self.assertRaises(SystemExit) as ctx:
+            helpers.make_initrd(
+                script, "build/hello.elf", test=False, args=InitRdArgs()
+            )
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_mkimage_not_found_exits(self, _mock: object) -> None:
@@ -1661,13 +1594,9 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         fake_sysroot = MagicMock()
         fake_sysroot.path = paths.sysroot()
         script.sysroot = fake_sysroot
-        log_mod.set_json_mode(True)
-        try:
-            with self.assertRaises(SystemExit) as ctx:
-                helpers.make_initrd(script, "my-app.elf", test=False, args=InitRdArgs())
-            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-        finally:
-            log_mod.set_json_mode(False)
+        with self.assertRaises(SystemExit) as ctx:
+            helpers.make_initrd(script, "my-app.elf", test=False, args=InitRdArgs())
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_app_env(self, _mock: object) -> None:
@@ -1867,17 +1796,13 @@ class TestHelpersCheckDocker(unittest.TestCase):
     def test_missing_docker_binary_exits_fatal(self) -> None:
         """No `docker` on PATH -> fatal EXIT_MISSING_DEP, no subprocess calls."""
         mock_run = MagicMock()
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch("nanvix_zutil.helpers.shutil.which", return_value=None),
-                patch("nanvix_zutil.helpers.subprocess.run", mock_run),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                helpers.check_docker("test/image:tag")
-            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-        finally:
-            log_mod.set_json_mode(False)
+        with (
+            patch("nanvix_zutil.helpers.shutil.which", return_value=None),
+            patch("nanvix_zutil.helpers.subprocess.run", mock_run),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            helpers.check_docker("test/image:tag")
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         mock_run.assert_not_called()
 
     def test_image_present_skips_pull(self) -> None:
@@ -1935,21 +1860,16 @@ class TestHelpersCheckDocker(unittest.TestCase):
                 args=cmd, returncode=next(returncodes), stdout="", stderr=""
             )
 
-        log_mod.set_json_mode(True)
-        try:
-            with (
-                patch(
-                    "nanvix_zutil.helpers.shutil.which",
-                    return_value="/usr/bin/docker",
-                ),
-                patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
-                self.assertRaises(SystemExit) as ctx,
-            ):
-                helpers.check_docker(image)
-            self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-        finally:
-            log_mod.set_json_mode(False)
-
+        with (
+            patch(
+                "nanvix_zutil.helpers.shutil.which",
+                return_value="/usr/bin/docker",
+            ),
+            patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            helpers.check_docker(image)
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[0], ["docker", "image", "inspect", image])
         self.assertEqual(calls[1], ["docker", "pull", image])
@@ -1967,9 +1887,6 @@ class TestOfflineMode(unittest.TestCase):
             "WITH_NANVIX",
         ):
             os.environ.pop(key, None)
-
-    def tearDown(self) -> None:
-        log_mod.set_json_mode(False)
 
     def test_offline_default_false(self) -> None:
         """Offline mode defaults to False."""
@@ -2017,7 +1934,6 @@ class TestOfflineMode(unittest.TestCase):
         script = ZScript()
         script._offline = True
 
-        log_mod.set_json_mode(True)
         with self.assertRaises(SystemExit) as ctx:
             script.setup()
 
@@ -2037,7 +1953,6 @@ class TestOfflineMode(unittest.TestCase):
         fake_sysroot.path = sysroot_dir
         fake_sysroot.tag = ""
 
-        log_mod.set_json_mode(True)
         with (
             patch(
                 "nanvix_zutil.script.Sysroot.from_local",

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -11,7 +11,6 @@ import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
-import nanvix_zutil.log as log_mod
 from nanvix_zutil.config import DEFAULT_TARGET, Config
 from nanvix_zutil.sysroot import WINDOWS_HOST_BINARIES, Sysroot
 
@@ -55,11 +54,9 @@ class TestSysrootDownloadSkipsIfExists(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_skips_download_when_dest_exists(self) -> None:
         dest = Path(self._tmpdir.name) / "sysroot"
@@ -95,11 +92,9 @@ class TestSysrootDownloadStaleDetection(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_redownloads_when_tag_mismatches(self) -> None:
         """If sysroot exists but cached tag != requested tag, re-download."""
@@ -229,11 +224,9 @@ class TestWindowsBinariesStaleDetection(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_redownloads_when_tag_changes(self) -> None:
         """If Windows binaries exist but persisted tag differs, re-download."""
@@ -301,7 +294,6 @@ class TestSysrootDownloadFetches(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
         self._resolve_patcher = patch(
             "nanvix_zutil.github.resolve_release",
             return_value={"target_commitish": "abc1234def5678"},
@@ -311,7 +303,6 @@ class TestSysrootDownloadFetches(unittest.TestCase):
     def tearDown(self) -> None:
         self._resolve_patcher.stop()
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_downloads_and_extracts(self) -> None:
         dest = Path(self._tmpdir.name) / "sysroot"
@@ -402,11 +393,9 @@ class TestSysrootVerify(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(True)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_verify_passes_when_files_present(self) -> None:
         sysroot_dir = Path(self._tmpdir.name) / "sysroot"
@@ -444,11 +433,9 @@ class TestSysrootOverlayLocal(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_overlay_copies_bin_files(self) -> None:
         sysroot_dir = Path(self._tmpdir.name) / "sysroot"
@@ -510,7 +497,6 @@ class TestSysrootOverlayLocal(unittest.TestCase):
     def test_overlay_nonexistent_path_exits(self) -> None:
         sysroot_dir = Path(self._tmpdir.name) / "sysroot"
         sysroot_dir.mkdir()
-        log_mod.set_json_mode(True)
 
         sysroot = Sysroot(sysroot_dir)
         with self.assertRaises(SystemExit) as ctx:
@@ -523,11 +509,9 @@ class TestSysrootFromLocal(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
 
     def tearDown(self) -> None:
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_returns_sysroot_pointing_at_path(self) -> None:
         sysroot_dir = Path(self._tmpdir.name) / "my-sysroot"
@@ -549,7 +533,6 @@ class TestSysrootFromLocal(unittest.TestCase):
                 mock_dl.assert_not_called()
 
     def test_exits_if_path_not_directory(self) -> None:
-        log_mod.set_json_mode(True)
         bad_path = Path(self._tmpdir.name) / "nonexistent"
 
         with self.assertRaises(SystemExit) as ctx:
@@ -557,7 +540,6 @@ class TestSysrootFromLocal(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 3)
 
     def test_exits_if_path_is_file(self) -> None:
-        log_mod.set_json_mode(True)
         file_path = Path(self._tmpdir.name) / "a-file"
         file_path.write_text("not a dir")
 
@@ -571,7 +553,6 @@ class TestSysrootDownloadZip(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
-        log_mod.set_json_mode(False)
         self._resolve_patcher = patch(
             "nanvix_zutil.github.resolve_release",
             return_value={"target_commitish": "abc1234def5678"},
@@ -581,7 +562,6 @@ class TestSysrootDownloadZip(unittest.TestCase):
     def tearDown(self) -> None:
         self._resolve_patcher.stop()
         self._tmpdir.cleanup()
-        log_mod.set_json_mode(False)
 
     def test_downloads_and_extracts_zip(self) -> None:
         dest = Path(self._tmpdir.name) / "sysroot"


### PR DESCRIPTION
The `--json` log/output mode is not consumed by any downstream tooling. Drop it everywhere to reduce the API surface:

- Remove the top-level `--json` flag from `build_parser()` and the pre-parser in `ZScript.main()`.
- Remove the per-command `--json` flag from `nanvix-info` and `nanvix-zutil resolve`; both now always emit key=value lines.
- Drop `log.set_json_mode` / `log.is_json_mode` / `_json_mode` state from the log module; all helpers emit plain colored text. `warning()` no longer accepts a 'code' kwarg (unused).
- Update tests: remove defensive `set_json_mode` `setUp`/`tearDown` calls, drop JSON-specific test cases, and adapt the degraded-setup test.

Closes #230