### PR TITLE
[zutils] F: Remove WITH_NANVIX env var

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -56,7 +56,6 @@ development of `nanvix-zutil` itself:
 | `NANVIX_DEPLOYMENT_MODE` | `standalone` | Deployment mode |
 | `NANVIX_MEMORY_SIZE` | `256mb` | Memory size for artifact naming |
 | `NANVIX_SYSROOT` | *(set by setup)* | Path to runtime sysroot |
-| `WITH_NANVIX` | *(unset)* | Path to local build dir for dep overlay |
 | `GH_TOKEN` | *(none)* | GitHub token for API rate limits |
 
 ## Project Layout

--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -21,8 +21,8 @@ etc.) without publishing a release.
 The `--offline` flag skips the dependency resolver entirely and requires
 all artifacts to be available locally via `--with-nanvix`.  In offline mode:
 
-- `--with-nanvix` (or `WITH_NANVIX`) is **required** — a fatal error is
-  raised if neither is provided.
+- `--with-nanvix PATH` is **required** — a fatal error is raised if it
+  is not provided.
 - **All** dependencies (not just `nanvix/`-owned) are resolved from
   `PATH/deps/<name>/`.
 - Missing individual dependencies produce a warning rather than a fatal
@@ -74,8 +74,9 @@ cd /path/to/consumer   # e.g. usr/lib/zlib
 
 # Clean sysroot and re-run with local override
 rm -rf .nanvix/sysroot .nanvix/env.json
-WITH_NANVIX=~/src/nanvix/nanvix .nanvix/venv/bin/nanvix-zutil setup \
-    --with-docker nanvix/toolchain:latest-minimal
+.nanvix/venv/bin/nanvix-zutil setup \
+    --with-docker nanvix/toolchain:latest-minimal \
+    --with-nanvix ~/src/nanvix/nanvix
 
 # Verify
 cmp .nanvix/sysroot/bin/nanvixd.elf ~/src/nanvix/nanvix/bin/nanvixd.elf
@@ -92,8 +93,6 @@ When building ports in a dependency chain without network access:
 cd /path/to/consumer
 
 # All deps pre-built, sysroot at build/sysroot/, deps at build/deps/
-NANVIX_VERSION=~/nanvix/build/sysroot \
-WITH_NANVIX=~/nanvix/build \
 PYTHONPATH=~/nanvix/usr/lib/zutils/src \
   python3 -m nanvix_zutil setup \
     --offline \
@@ -102,15 +101,14 @@ PYTHONPATH=~/nanvix/usr/lib/zutils/src \
     --sysroot-path ~/nanvix/build/sysroot
 
 # Then build
-WITH_NANVIX=~/nanvix/build \
 PYTHONPATH=~/nanvix/usr/lib/zutils/src \
   python3 -m nanvix_zutil build
 ```
 
 ## Using the Shell Wrapper
 
-The `z.sh` and `z.ps1` wrappers support `--with-nanvix` natively. Pass
-the flag directly:
+The `z.sh` and `z.ps1` wrappers forward `--with-nanvix` directly to
+`nanvix-zutil`. Pass the flag to any subcommand that accepts it:
 
 ```bash
 ./z setup --with-docker nanvix/toolchain:latest-minimal \
@@ -118,8 +116,8 @@ the flag directly:
 ./z build
 ```
 
-The wrapper resolves the path to an absolute directory and exports it as
-`WITH_NANVIX` before invoking `nanvix-zutil`.
+The CLI canonicalises the path to an absolute directory. Relative paths
+and `~` are accepted; the path must exist and be a directory.
 
 ## Local Dependency Override
 
@@ -136,14 +134,14 @@ under `PATH/deps/<name>/`:
             └── zlib.h
 ```
 
-When `WITH_NANVIX` is set and `deps/<name>/` exists, the dependency
+When `--with-nanvix` is set and `deps/<name>/` exists, the dependency
 is installed from the local directory and the GitHub download is skipped.
 
 ## Notes
 
 - The overlay copies **all** files from `bin/` and `lib/` — not only the
   ones required by the sysroot verification.  Extra files are harmless.
-- `WITH_NANVIX` has no effect on `build`, `test`, or other
+- `--with-nanvix` has no effect on `build`, `test`, or other
   subcommands — it only modifies behavior during `setup`.
 - To return to the normal (release-based) workflow, simply omit
   `--with-nanvix` and delete `.nanvix/sysroot` before re-running setup.
@@ -167,5 +165,4 @@ artifacts from `.nanvix/output/`.
 
 | Variable | Purpose |
 | --- | --- |
-| `WITH_NANVIX` | Path to local build dir (same as `--with-nanvix`) |
 | `NANVIX_VERSION` | When set to a directory path, used as local sysroot |

--- a/examples/bin-hello/z.ps1
+++ b/examples/bin-hello/z.ps1
@@ -57,8 +57,7 @@ catch {
     $null
 }
 
-# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
-# nanvix-zutil.
+# Extract --with-zutils PATH before forwarding to nanvix-zutil.
 #
 # --with-zutils PATH (optional): install nanvix-zutil from a local source
 # tree (editable) instead of fetching the pinned wheel from GitHub Releases.
@@ -83,25 +82,6 @@ while ($i -lt $ZArgs.Count) {
     }
     elseif ($ZArgs[$i] -match '^--with-zutils=(.+)$') {
         $withZutils = $Matches[1]
-        $i++
-    }
-    elseif ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i += 2
-    }
-    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
-        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
         $i++
     }
     else {

--- a/examples/bin-hello/z.sh
+++ b/examples/bin-hello/z.sh
@@ -53,9 +53,9 @@ function _resolve_venv_paths() {
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
-# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
-# nanvix-zutil.  The nanvix-zutil CLI inspects positional args to find the
-# subcommand; either flag's PATH argument would be mistaken for a subcommand.
+# Extract --with-zutils PATH before forwarding to nanvix-zutil.  The
+# nanvix-zutil CLI inspects positional args to find the subcommand; the
+# flag's PATH argument would otherwise be mistaken for a subcommand.
 #
 # --with-zutils PATH (optional): install nanvix-zutil from a local source
 # tree (editable) instead of fetching the pinned wheel from GitHub Releases.
@@ -67,8 +67,6 @@ ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 # The path must point at a nanvix-zutil source checkout (a directory
 # containing pyproject.toml).  The venv version-match check is bypassed; the
 # editable install is rebuilt only when the recorded source path changes.
-#
-# --with-nanvix PATH is forwarded to z.py via the WITH_NANVIX env var.
 WITH_ZUTILS=""
 _resolve_zutils_path() {
     local raw="$1"
@@ -90,15 +88,6 @@ _resolve_zutils_path() {
     fi
 }
 
-_resolve_nanvix_path() {
-    local raw="$1"
-    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
-        exit 1
-    fi
-    export WITH_NANVIX
-}
-
 ARGS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -112,18 +101,6 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             _resolve_zutils_path "$2"
-            shift 2
-            ;;
-        --with-nanvix=*)
-            _resolve_nanvix_path "${1#--with-nanvix=}"
-            shift
-            ;;
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            _resolve_nanvix_path "$2"
             shift 2
             ;;
         *)

--- a/examples/lib-hello/z.ps1
+++ b/examples/lib-hello/z.ps1
@@ -57,8 +57,7 @@ catch {
     $null
 }
 
-# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
-# nanvix-zutil.
+# Extract --with-zutils PATH before forwarding to nanvix-zutil.
 #
 # --with-zutils PATH (optional): install nanvix-zutil from a local source
 # tree (editable) instead of fetching the pinned wheel from GitHub Releases.
@@ -83,25 +82,6 @@ while ($i -lt $ZArgs.Count) {
     }
     elseif ($ZArgs[$i] -match '^--with-zutils=(.+)$') {
         $withZutils = $Matches[1]
-        $i++
-    }
-    elseif ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i += 2
-    }
-    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
-        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
         $i++
     }
     else {

--- a/examples/lib-hello/z.sh
+++ b/examples/lib-hello/z.sh
@@ -53,9 +53,9 @@ function _resolve_venv_paths() {
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
-# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
-# nanvix-zutil.  The nanvix-zutil CLI inspects positional args to find the
-# subcommand; either flag's PATH argument would be mistaken for a subcommand.
+# Extract --with-zutils PATH before forwarding to nanvix-zutil.  The
+# nanvix-zutil CLI inspects positional args to find the subcommand; the
+# flag's PATH argument would otherwise be mistaken for a subcommand.
 #
 # --with-zutils PATH (optional): install nanvix-zutil from a local source
 # tree (editable) instead of fetching the pinned wheel from GitHub Releases.
@@ -67,8 +67,6 @@ ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 # The path must point at a nanvix-zutil source checkout (a directory
 # containing pyproject.toml).  The venv version-match check is bypassed; the
 # editable install is rebuilt only when the recorded source path changes.
-#
-# --with-nanvix PATH is forwarded to z.py via the WITH_NANVIX env var.
 WITH_ZUTILS=""
 _resolve_zutils_path() {
     local raw="$1"
@@ -90,15 +88,6 @@ _resolve_zutils_path() {
     fi
 }
 
-_resolve_nanvix_path() {
-    local raw="$1"
-    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
-        exit 1
-    fi
-    export WITH_NANVIX
-}
-
 ARGS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -112,18 +101,6 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             _resolve_zutils_path "$2"
-            shift 2
-            ;;
-        --with-nanvix=*)
-            _resolve_nanvix_path "${1#--with-nanvix=}"
-            shift
-            ;;
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            _resolve_nanvix_path "$2"
             shift 2
             ;;
         *)

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -17,6 +17,35 @@ from pathlib import Path
 from nanvix_zutil.lockfile import get_zutil_version
 
 # ---------------------------------------------------------------------------
+# argparse type helpers
+# ---------------------------------------------------------------------------
+
+
+def _abs_dir(raw: str) -> str:
+    """argparse ``type=`` callable: resolve ``raw`` to an absolute directory.
+
+    Expands ``~``, resolves symlinks, and requires the target to exist and
+    be a directory.  Returns the canonicalised absolute path as a string
+    so downstream consumers (``ZScript._with_nanvix_path``) receive a
+    fully-resolved value regardless of the caller's CWD.
+    """
+    if not raw:
+        raise argparse.ArgumentTypeError("path is empty")
+    p = Path(raw).expanduser()
+    try:
+        resolved = p.resolve(strict=True)
+    except (OSError, RuntimeError) as e:
+        raise argparse.ArgumentTypeError(
+            f"path does not exist: {raw}",
+        ) from e
+    if not resolved.is_dir():
+        raise argparse.ArgumentTypeError(
+            f"path is not a directory: {raw}",
+        )
+    return str(resolved)
+
+
+# ---------------------------------------------------------------------------
 # Parser factory
 # ---------------------------------------------------------------------------
 
@@ -147,12 +176,13 @@ def build_parser(
             )
             sub.add_argument(
                 "--with-nanvix",
-                type=str,
+                type=_abs_dir,
                 metavar="PATH",
                 dest="with_nanvix",
                 help="Path to a local build directory containing"
                 " deps/<name>/{lib,include}/ artifacts."
-                " Overrides the WITH_NANVIX environment variable.",
+                " Relative paths and ~ are accepted; the path is"
+                " canonicalised to an absolute directory.",
             )
             sub.add_argument(
                 "--sysroot-path",

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -196,7 +196,7 @@ class ZScript:
         self.docker: DockerConfig | None = None
         self._used_fallback: bool = False
         self._offline: bool = False
-        self._with_nanvix_path: str | None = os.environ.get("WITH_NANVIX")
+        self._with_nanvix_path: str | None = None
         self._cli_sysroot_path: str | None = None
 
     # ------------------------------------------------------------------
@@ -358,13 +358,10 @@ class ZScript:
         # When --with-nanvix PATH is passed, overlay local build artifacts
         # (nanvixd.elf, mkramfs.elf, uservm.elf, libposix.a, etc.) on top
         # of the downloaded sysroot before verification.
-        # Re-read WITH_NANVIX here in case the env var was set after __init__
-        # (e.g., by a parent orchestrator between construction and setup()).
-        nanvix_local = self._with_nanvix_path or os.environ.get("WITH_NANVIX")
+        nanvix_local = self._with_nanvix_path
         if self._offline and not nanvix_local:
             log.fatal(
-                "Offline mode requires --with-nanvix or WITH_NANVIX to"
-                " provide local artifacts.",
+                "Offline mode requires --with-nanvix to" " provide local artifacts.",
                 code=EXIT_MISSING_DEP,
             )
         if nanvix_local:

--- a/templates/z.ps1
+++ b/templates/z.ps1
@@ -57,8 +57,7 @@ catch {
     $null
 }
 
-# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
-# nanvix-zutil.
+# Extract --with-zutils PATH before forwarding to nanvix-zutil.
 #
 # --with-zutils PATH (optional): install nanvix-zutil from a local source
 # tree (editable) instead of fetching the pinned wheel from GitHub Releases.
@@ -83,25 +82,6 @@ while ($i -lt $ZArgs.Count) {
     }
     elseif ($ZArgs[$i] -match '^--with-zutils=(.+)$') {
         $withZutils = $Matches[1]
-        $i++
-    }
-    elseif ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $item = Get-Item -LiteralPath $ZArgs[$i + 1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($ZArgs[$i + 1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
-        $i += 2
-    }
-    elseif ($ZArgs[$i] -match '^--with-nanvix=(.+)$') {
-        $item = Get-Item -LiteralPath $Matches[1] -ErrorAction Stop
-        if (-not $item.PSIsContainer) {
-            throw "ERROR: --with-nanvix path is not a directory: $($Matches[1])"
-        }
-        $env:WITH_NANVIX = $item.FullName
         $i++
     }
     else {

--- a/templates/z.sh
+++ b/templates/z.sh
@@ -53,9 +53,9 @@ function _resolve_venv_paths() {
 _resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
-# Extract --with-zutils PATH and --with-nanvix PATH before forwarding to
-# nanvix-zutil.  The nanvix-zutil CLI inspects positional args to find the
-# subcommand; either flag's PATH argument would be mistaken for a subcommand.
+# Extract --with-zutils PATH before forwarding to nanvix-zutil.  The
+# nanvix-zutil CLI inspects positional args to find the subcommand; the
+# flag's PATH argument would otherwise be mistaken for a subcommand.
 #
 # --with-zutils PATH (optional): install nanvix-zutil from a local source
 # tree (editable) instead of fetching the pinned wheel from GitHub Releases.
@@ -67,8 +67,6 @@ ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 # The path must point at a nanvix-zutil source checkout (a directory
 # containing pyproject.toml).  The venv version-match check is bypassed; the
 # editable install is rebuilt only when the recorded source path changes.
-#
-# --with-nanvix PATH is forwarded to z.py via the WITH_NANVIX env var.
 WITH_ZUTILS=""
 _resolve_zutils_path() {
     local raw="$1"
@@ -90,15 +88,6 @@ _resolve_zutils_path() {
     fi
 }
 
-_resolve_nanvix_path() {
-    local raw="$1"
-    if ! WITH_NANVIX="$(cd -- "$raw" 2>/dev/null && pwd -P)"; then
-        echo "ERROR: --with-nanvix path does not exist or is not a directory: $raw" >&2
-        exit 1
-    fi
-    export WITH_NANVIX
-}
-
 ARGS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -112,18 +101,6 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             _resolve_zutils_path "$2"
-            shift 2
-            ;;
-        --with-nanvix=*)
-            _resolve_nanvix_path "${1#--with-nanvix=}"
-            shift
-            ;;
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            _resolve_nanvix_path "$2"
             shift 2
             ;;
         *)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,10 @@
 
 """Tests for nanvix_zutil.cli."""
 
+import os
+import tempfile
 import unittest
+from pathlib import Path
 
 from nanvix_zutil.cli import SUBCOMMANDS, build_parser
 
@@ -157,15 +160,73 @@ class TestWithNanvixFlag(unittest.TestCase):
 
     def test_with_nanvix_parsed(self) -> None:
         parser = build_parser()
-        args = parser.parse_args(
-            ["setup", "--with-docker", "img:t", "--with-nanvix", "/some/path"]
-        )
-        self.assertEqual(args.with_nanvix, "/some/path")
+        with tempfile.TemporaryDirectory() as tmp:
+            args = parser.parse_args(
+                ["setup", "--with-docker", "img:t", "--with-nanvix", tmp]
+            )
+            self.assertEqual(args.with_nanvix, str(Path(tmp).resolve(strict=True)))
+
+    def test_with_nanvix_canonicalised_to_absolute(self) -> None:
+        """Relative paths are resolved to absolute by the argparse type."""
+        parser = build_parser()
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                Path("sub").mkdir()
+                args = parser.parse_args(
+                    ["setup", "--with-docker", "img:t", "--with-nanvix", "sub"]
+                )
+            finally:
+                os.chdir(cwd)
+            self.assertTrue(Path(args.with_nanvix).is_absolute())
+            self.assertEqual(
+                Path(args.with_nanvix).name,
+                "sub",
+            )
 
     def test_with_nanvix_default_none(self) -> None:
         parser = build_parser()
         args = parser.parse_args(["setup", "--with-docker", "img:t"])
         self.assertIsNone(args.with_nanvix)
+
+    def test_with_nanvix_rejects_missing_path(self) -> None:
+        """Non-existent paths are rejected at parse time."""
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(
+                [
+                    "setup",
+                    "--with-docker",
+                    "img:t",
+                    "--with-nanvix",
+                    "/definitely/does/not/exist/xyzzy",
+                ]
+            )
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_with_nanvix_rejects_file(self) -> None:
+        """A path that exists but is a file (not a directory) is rejected."""
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as tmp:
+            with self.assertRaises(SystemExit) as ctx:
+                parser.parse_args(
+                    [
+                        "setup",
+                        "--with-docker",
+                        "img:t",
+                        "--with-nanvix",
+                        tmp.name,
+                    ]
+                )
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_with_nanvix_rejects_empty_string(self) -> None:
+        """Empty path is rejected (would otherwise resolve to CWD)."""
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["setup", "--with-docker", "img:t", "--with-nanvix", ""])
+        self.assertEqual(ctx.exception.code, 2)
 
     def test_with_nanvix_rejected_on_build(self) -> None:
         """--with-nanvix is only accepted on setup, not build."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1154,7 +1154,7 @@ class TestZScriptMainDegradedExit(unittest.TestCase):
 
 
 class TestZScriptSetupWithNanvix(unittest.TestCase):
-    """setup() with WITH_NANVIX overlays local artifacts."""
+    """setup() with --with-nanvix overlays local artifacts."""
 
     def setUp(self) -> None:
         write_manifest()
@@ -1162,32 +1162,27 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
             "NANVIX_MACHINE",
             "NANVIX_DEPLOYMENT_MODE",
             "NANVIX_MEMORY_SIZE",
-            "WITH_NANVIX",
         ):
             os.environ.pop(key, None)
 
-    def tearDown(self) -> None:
-        os.environ.pop("WITH_NANVIX", None)
-
-    def test_setup_calls_overlay_when_env_set(self) -> None:
-        """setup() calls sysroot.overlay_local_nanvix when WITH_NANVIX is set."""
+    def test_setup_calls_overlay_when_path_set(self) -> None:
+        """setup() calls sysroot.overlay_local_nanvix when --with-nanvix is set."""
         local_dir = Path.cwd() / "local-nanvix"
         local_dir.mkdir()
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
 
-        os.environ["WITH_NANVIX"] = str(local_dir)
-
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
             script = ZScript()
+            script._with_nanvix_path = str(local_dir)
             script.setup()
 
         fake_sysroot.overlay_local_nanvix.assert_called_once_with(local_dir)
         fake_sysroot.verify.assert_called_once()
 
-    def test_setup_no_overlay_without_env(self) -> None:
-        """setup() does not call overlay_local_nanvix when WITH_NANVIX is unset."""
+    def test_setup_no_overlay_without_path(self) -> None:
+        """setup() does not call overlay_local_nanvix when --with-nanvix is unset."""
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
 
@@ -1209,13 +1204,12 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
         fake_sysroot.tag = "v0.1.0"
 
-        os.environ["WITH_NANVIX"] = str(local_dir)
-
         with (
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             patch("nanvix_zutil.script.resolve_release_with_fallback") as mock_resolve,
         ):
             script = ZScript()
+            script._with_nanvix_path = str(local_dir)
             script.setup()
 
         # The dependency was satisfied locally so GitHub resolve should not
@@ -1884,7 +1878,6 @@ class TestOfflineMode(unittest.TestCase):
             "NANVIX_MACHINE",
             "NANVIX_DEPLOYMENT_MODE",
             "NANVIX_MEMORY_SIZE",
-            "WITH_NANVIX",
         ):
             os.environ.pop(key, None)
 
@@ -1893,11 +1886,10 @@ class TestOfflineMode(unittest.TestCase):
         script = ZScript()
         self.assertFalse(script._offline)
 
-    def test_with_nanvix_env_sets_path(self) -> None:
-        """WITH_NANVIX env sets _with_nanvix_path."""
-        with patch.dict(os.environ, {"WITH_NANVIX": "/some/build"}):
-            script = ZScript()
-        self.assertEqual(script._with_nanvix_path, "/some/build")
+    def test_with_nanvix_path_initially_none(self) -> None:
+        """_with_nanvix_path starts as None."""
+        script = ZScript()
+        self.assertIsNone(script._with_nanvix_path)
 
     def test_cli_sysroot_path_initially_none(self) -> None:
         """_cli_sysroot_path starts as None."""
@@ -1912,6 +1904,7 @@ class TestOfflineMode(unittest.TestCase):
         script = ZScript()
         script._offline = True
         script._cli_sysroot_path = str(sysroot_dir)
+        script._with_nanvix_path = str(paths.repo_root())
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = sysroot_dir
@@ -1923,7 +1916,6 @@ class TestOfflineMode(unittest.TestCase):
                 "nanvix_zutil.script.Sysroot.from_local",
                 return_value=fake_sysroot,
             ) as mock_from_local,
-            patch.dict(os.environ, {"WITH_NANVIX": str(paths.repo_root())}),
         ):
             script.setup()
             mock_download.assert_not_called()
@@ -1969,25 +1961,22 @@ class TestOfflineMode(unittest.TestCase):
         repo_root = paths.repo_root()
         sysroot_dir = repo_root / "my-sysroot"
         sysroot_dir.mkdir()
-        # Create WITH_NANVIX dir without deps
+        # Create --with-nanvix dir without deps
         build_dir = repo_root / "build"
         build_dir.mkdir()
 
-        with patch.dict(os.environ, {"WITH_NANVIX": str(build_dir)}):
-            script = ZScript()
+        script = ZScript()
         script._offline = True
         script._cli_sysroot_path = str(sysroot_dir)
+        script._with_nanvix_path = str(build_dir)
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = sysroot_dir
         fake_sysroot.tag = ""
 
-        with (
-            patch(
-                "nanvix_zutil.script.Sysroot.from_local",
-                return_value=fake_sysroot,
-            ),
-            patch.dict(os.environ, {"WITH_NANVIX": str(build_dir)}),
+        with patch(
+            "nanvix_zutil.script.Sysroot.from_local",
+            return_value=fake_sysroot,
         ):
             # Should NOT raise SystemExit — just warn
             script.setup()
@@ -2001,10 +1990,10 @@ class TestOfflineMode(unittest.TestCase):
         (build_dir / "deps" / "zlib" / "lib").mkdir(parents=True)
         (build_dir / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
 
-        with patch.dict(os.environ, {"WITH_NANVIX": str(build_dir)}):
-            script = ZScript()
+        script = ZScript()
         script._offline = True
         script._cli_sysroot_path = str(sysroot_dir)
+        script._with_nanvix_path = str(build_dir)
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = sysroot_dir
@@ -2016,7 +2005,6 @@ class TestOfflineMode(unittest.TestCase):
                 return_value=fake_sysroot,
             ),
             patch("nanvix_zutil.script.resolve_release") as mock_resolve,
-            patch.dict(os.environ, {"WITH_NANVIX": str(build_dir)}),
         ):
             script.setup()
 


### PR DESCRIPTION
WITH_NANVIX was the wrapper-internal channel for passing `./z --with-nanvix PATH` through z.sh/z.ps1 into nanvix-zutil because `--with-nanvix` is registered as a per-subcommand argparse flag and so cannot be parsed by the CLI when placed before the subcommand. Replace the env-var hand-off with explicit argv mutation: the wrappers still strip `--with-nanvix` from the user's argv and resolve it to an absolute path, but now append a canonicalised `--with-nanvix=<abs>` token to the forwarded arguments. Drop the env lookups in script.py, update the CLI help, docs, and tests to match. Examples regenerated from templates.

Closes: https://github.com/nanvix/zutils/issues/198