### PR TITLE
[zutils] Remove NANVIX_VERSION env var

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -61,25 +61,8 @@ newest release matching `1.2.3-nanvix-*` and uses it instead (e.g.
 `TAG`, `COMMITISH`, `ID`, and `LOCAL` refs are never suffixed — they
 resolve exactly as written.
 
-When the sysroot ref is `LOCAL` (i.e. `NANVIX_VERSION` is a filesystem
-path), the auto-suffix step is skipped entirely — `VERSION` deps keep
-their bare version string.
-
 Refs that already contain `-nanvix-` are rejected to prevent accidental
 double-suffixing.
-
-## Environment variable overrides
-
-| Variable | Overrides |
-|---|---|
-| `NANVIX_VERSION` | `nanvix-version` (sysroot ref value) |
-
-Overrides replace the **value** but keep the `RefKind` from the
-manifest — **unless** the override value looks like a filesystem path
-(absolute Unix path, Windows drive path, or relative `./`/`../` path),
-in which case the `RefKind` is changed to `LOCAL`.
-`NANVIX_VERSION` bypasses semver validation (intended for development
-use).
 
 ## Full example
 

--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -27,17 +27,13 @@ all artifacts to be available locally via `--with-nanvix`.  In offline mode:
   `PATH/deps/<name>/`.
 - Missing individual dependencies produce a warning rather than a fatal
   error, allowing the port's own build logic to handle fallbacks.
-- A local sysroot must be provided via `--sysroot-path` or by setting
-  `NANVIX_VERSION` to an absolute directory path.
+- A local sysroot must be provided via `--sysroot-path`.
 
 ## Sysroot Path Override
 
-The `--sysroot-path PATH` flag (or setting `NANVIX_VERSION` to an absolute
-directory path) provides an explicit local sysroot directory, bypassing the
-GitHub download entirely.  This takes precedence over version-based resolution.
-`NANVIX_VERSION` is only interpreted as a path when it is absolute (starts
-with `/`) and points to an existing directory — otherwise it is treated as a
-version string.
+The `--sysroot-path PATH` flag provides an explicit local sysroot
+directory, bypassing the GitHub download entirely.  This takes
+precedence over version-based resolution.
 
 ## Prerequisites
 
@@ -160,9 +156,3 @@ nanvix-zutil install --output /path/to/output
 
 This creates `<output>/{lib,include,bin}/` subdirectories with the port's
 artifacts from `.nanvix/output/`.
-
-## Environment Variables
-
-| Variable | Purpose |
-| --- | --- |
-| `NANVIX_VERSION` | When set to a directory path, used as local sysroot |

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -189,8 +189,10 @@ def build_parser(
                 type=str,
                 metavar="PATH",
                 dest="sysroot_path",
-                help="Explicit path to a local sysroot directory."
-                " Alternative to setting NANVIX_VERSION to a path.",
+                help="Explicit path to a local sysroot directory,"
+                " bypassing sysroot download/version resolution."
+                " The manifest's nanvix-version is still used for"
+                " dependency tag suffixing.",
             )
         if name == "install":
             sub.add_argument(

--- a/src/nanvix_zutil/config.py
+++ b/src/nanvix_zutil/config.py
@@ -58,7 +58,7 @@ CFG_DOCKER_IMAGE: str = "NANVIX_DOCKER_IMAGE"
 #: Curated mapping of the most common environment variables recognised by
 #: nanvix-zutil to human-readable descriptions.  Rendered in the ``--help``
 #: epilog.  Not exhaustive — consumers and other modules may honour additional
-#: ``NANVIX_*`` variables (e.g. ``NANVIX_VERSION`` in ``manifest.py``).
+#: ``NANVIX_*`` variables recognised by manifest/script modules.
 ENV_VARS: dict[str, str] = {
     "NANVIX_TARGET": f"Target architecture (default: {DEFAULT_TARGET})",
     "NANVIX_MACHINE": f"Target machine (default: {DEFAULT_MACHINE})",

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -9,9 +9,6 @@ or the literal ``"latest"``.  Dependency version fields accept a plain
 string (``version`` specifier), or a table with one of ``version``,
 ``tag``, ``commitish``, or ``id``.
 
-The environment variable ``NANVIX_VERSION`` (for the sysroot) overrides
-the version declared in the manifest.
-
 Only ``version`` specifier refs (plain string or ``{ version = "..." }``)
 are auto-suffixed with ``-nanvix-{sysroot_version}``.  ``tag``,
 ``commitish``, and ``id`` specifiers are exact-match and never suffixed.
@@ -22,7 +19,6 @@ deferred to the resolver (which resolves the actual version first).
 
 from __future__ import annotations
 
-import os
 import re
 import tomllib
 from dataclasses import dataclass, field
@@ -289,9 +285,6 @@ def load_manifest() -> Manifest:
     ``{ version }``, ``{ tag }``, ``{ commitish }``, ``{ id }``), and
     auto-suffixes ``version`` refs with ``-nanvix-{sysroot_version}``.
 
-    Environment variable ``NANVIX_VERSION`` (sysroot) overrides the
-    manifest value.
-
     Returns:
         A :class:`Manifest` instance.
 
@@ -352,15 +345,6 @@ def load_manifest() -> Manifest:
         )
 
     sysroot_ref = _parse_nanvix_version(raw_nanvix_version)
-    env_sysroot = os.environ.get("NANVIX_VERSION")
-    if env_sysroot is not None:
-        # NOTE: NANVIX_VERSION intentionally bypasses semver validation.
-        # This is a development escape hatch — CI may pass with a non-semver
-        # sysroot version if this env var is set.
-        if is_local_path(env_sysroot):
-            sysroot_ref = Ref(kind=RefKind.LOCAL, value=env_sysroot)
-        else:
-            sysroot_ref = Ref(kind=sysroot_ref.kind, value=env_sysroot)
 
     # --- [dependencies] (optional) ---
     deps_raw: object = data.get("dependencies", {})

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -302,18 +302,8 @@ class ZScript:
         """
         self._used_fallback = False
 
-        # Resolve sysroot: --sysroot-path / NANVIX_VERSION (path) take precedence.
-        # NANVIX_VERSION is only treated as a path when it is absolute AND
-        # points to an existing directory — this avoids accidentally matching
-        # a version string like "3" against a relative directory.
-        _env_version = os.environ.get("NANVIX_VERSION")
-        sysroot_path = self._cli_sysroot_path or (
-            _env_version
-            if _env_version
-            and Path(_env_version).is_absolute()
-            and Path(_env_version).is_dir()
-            else None
-        )
+        # Resolve sysroot: --sysroot-path takes precedence.
+        sysroot_path = self._cli_sysroot_path
 
         if sysroot_path:
             self.sysroot = Sysroot.from_local(
@@ -328,7 +318,7 @@ class ZScript:
         elif self._offline:
             log.fatal(
                 "Offline mode requires a local sysroot."
-                " Set --sysroot-path or NANVIX_VERSION to a directory.",
+                " Set --sysroot-path to a directory.",
                 code=EXIT_MISSING_DEP,
             )
         else:

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -81,7 +81,7 @@ class Sysroot:
             log.fatal(
                 f"Local sysroot path is not a directory: {local_path}",
                 code=EXIT_MISSING_DEP,
-                hint="Set NANVIX_VERSION to a valid sysroot directory path.",
+                hint="Pass --sysroot-path with a valid sysroot directory.",
             )
         log.info(f"Using local sysroot at {resolved}")
         if config is not None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,14 +3,12 @@
 
 """Tests for nanvix_zutil.manifest."""
 
-import os
 import unittest
 from unittest.mock import patch
 
 from nanvix_zutil import paths
 from nanvix_zutil.buildroot import RefKind
-from nanvix_zutil.manifest import load_manifest, is_local_path
-
+from nanvix_zutil.manifest import is_local_path, load_manifest
 from tests.testutils import make_toml
 
 
@@ -176,16 +174,6 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
         # Dep should NOT be suffixed — deferred to resolver
         self.assertEqual(m.dependencies[0].ref.value, "1.3.1")
 
-    def test_latest_sysroot_env_override_suffixes_normally(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(nanvix_version="latest", deps={"zlib": '"1.3.1"'}))
-
-        with patch.dict("os.environ", {"NANVIX_VERSION": "0.12.258"}):
-            m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.value, "0.12.258")
-        self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-0.12.258")
-
     def test_nanvix_version_table_exits_2(self) -> None:
         path = paths.manifest_path()
         path.write_text(
@@ -329,31 +317,6 @@ class TestLoadManifestMalformedToml(unittest.TestCase):
             load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
-
-
-class TestLoadManifestEnvOverride(unittest.TestCase):
-    """Environment variables override manifest versions."""
-
-    def test_nanvix_version_overrides_sysroot(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '"1.0.0"'}))
-
-        with patch.dict(os.environ, {"NANVIX_VERSION": "override_sha"}):
-            m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.value, "override_sha")
-        self.assertEqual(m.dependencies[0].ref.value, "1.0.0-nanvix-override_sha")
-
-    def test_nanvix_version_v_prefix_stripped_in_suffix(self) -> None:
-        """NANVIX_VERSION with 'v' prefix must strip it for dep suffix."""
-        path = paths.manifest_path()
-        path.write_text(make_toml(nanvix_version="latest", deps={"zlib": '"1.3.1"'}))
-
-        with patch.dict(os.environ, {"NANVIX_VERSION": "v0.12.291"}):
-            m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.value, "v0.12.291")
-        self.assertEqual(m.dependencies[0].ref.value, "1.3.1-nanvix-0.12.291")
 
 
 class TestLoadManifestAutoSuffix(unittest.TestCase):
@@ -567,54 +530,6 @@ class TestIsLocalPath(unittest.TestCase):
 
     def test_empty_not_path(self) -> None:
         self.assertFalse(is_local_path(""))
-
-
-class TestLoadManifestLocalRef(unittest.TestCase):
-    """Env var overrides with filesystem paths produce RefKind.LOCAL."""
-
-    def test_sysroot_env_unix_path_produces_local(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml())
-
-        with patch.dict(os.environ, {"NANVIX_VERSION": "/path/to/sysroot"}):
-            m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
-        self.assertEqual(m.sysroot_ref.value, "/path/to/sysroot")
-
-    def test_sysroot_env_windows_path_produces_local(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml())
-
-        with patch.dict(os.environ, {"NANVIX_VERSION": "C:\\nanvix\\sysroot"}):
-            m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
-        self.assertEqual(m.sysroot_ref.value, "C:\\nanvix\\sysroot")
-
-    def test_sysroot_env_version_still_works(self) -> None:
-        # make_toml default nanvix-version is a semver string, which
-        # _parse_nanvix_version maps to RefKind.TAG.  The env override
-        # keeps the manifest RefKind (TAG) and only replaces the value.
-        path = paths.manifest_path()
-        path.write_text(make_toml(nanvix_version="0.12.257"))
-
-        with patch.dict(os.environ, {"NANVIX_VERSION": "0.12.258"}):
-            m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
-
-    def test_local_sysroot_skips_dep_suffix(self) -> None:
-        """When sysroot is LOCAL, VERSION deps must NOT be auto-suffixed."""
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '"1.3.1"'}))
-
-        with patch.dict(os.environ, {"NANVIX_VERSION": "/path/to/sysroot"}):
-            m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.kind, RefKind.LOCAL)
-        # Dep should NOT be suffixed — sysroot is local.
-        self.assertEqual(m.dependencies[0].ref.value, "1.3.1")
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1233,11 +1233,11 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
 
         write_manifest()
 
-        with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
-            script = ZScript()
+        script = ZScript()
+        # Simulate a manifest with a LOCAL sysroot ref.
+        from nanvix_zutil.buildroot import Ref
 
-        # Verify manifest parsed as LOCAL.
-        self.assertEqual(script.manifest.sysroot_ref.kind, RefKind.LOCAL)
+        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(local_sysroot))
 
         with (
             patch("nanvix_zutil.script.Sysroot.download") as mock_download,
@@ -1250,19 +1250,27 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
             mock_download.assert_not_called()
             mock_from_local.assert_called_once()
 
-    def test_local_sysroot_no_dep_suffix(self) -> None:
-        """When sysroot is LOCAL, VERSION deps are not suffixed."""
+    def test_local_sysroot_via_cli_sysroot_path(self) -> None:
+        """When --sysroot-path is provided, Sysroot.from_local is used."""
         repo_root = paths.repo_root()
         local_sysroot = repo_root / "my-sysroot"
         local_sysroot.mkdir()
 
-        write_manifest(MANIFEST_WITH_DEPS)
+        write_manifest()
 
-        with patch.dict(os.environ, {"NANVIX_VERSION": str(local_sysroot)}):
-            script = ZScript()
+        script = ZScript()
+        script._cli_sysroot_path = str(local_sysroot)
 
-        # VERSION dep should NOT be suffixed (sysroot is LOCAL).
-        self.assertEqual(script.manifest.dependencies[0].ref.value, "1.0")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download") as mock_download,
+            patch(
+                "nanvix_zutil.script.Sysroot.from_local",
+                return_value=MagicMock(path=local_sysroot, tag=""),
+            ) as mock_from_local,
+        ):
+            script.setup()
+            mock_download.assert_not_called()
+            mock_from_local.assert_called_once()
 
 
 class TestHelpersMakeInitrd(unittest.TestCase):


### PR DESCRIPTION
The NANVIX_VERSION env var let users override the sysroot version declared in nanvix.toml, optionally substituting an absolute filesystem path to bypass the GitHub download. It was a development escape hatch that bypassed semver validation and is unused in practice; the --sysroot-path CLI flag covers the local-directory case explicitly. Drop the env lookups from manifest.py and script.py, refresh docs and error hints, and convert the affected tests to construct LOCAL sysroot refs / set _cli_sysroot_path directly.

Closes: https://github.com/nanvix/zutils/issues/199

STACKED ON https://github.com/nanvix/zutils/pull/255