### PR TITLE
[zutils] Add multi-release mode

### DIFF
--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -45,6 +45,7 @@ class Manifest:
         sysroot_ref: Nanvix sysroot version reference.
         dependencies: Build-time dependencies as :class:`Dependency` objects.
         system_dependencies: Runtime dependencies as :class:`Dependency` objects.
+        multi_release_mode: See field description
     """
 
     name: str
@@ -52,6 +53,22 @@ class Manifest:
     sysroot_ref: Ref
     dependencies: list[Dependency] = field(default_factory=lambda: [])
     system_dependencies: list[Dependency] = field(default_factory=lambda: [])
+    multi_release_mode: bool = False
+    """
+    Whether the release() target will map from subdirectories to release
+    artifacts.
+
+    Leaving this variable unset (= False) will result in a single release
+    artifact which wraps everything in ``paths.release_dir()``.
+
+    Example:
+        Suppose we're porting 'mytool', which has multi-release mode enabled.
+        Then the following map holds:
+        ```
+            .nanvix/out/release/bin -> .nanvix/out/dist/mytool-bin.tar.gz
+            .nanvix/out/release/lib -> .nanvix/out/dist/mytool-lib.tar.gz
+        ```
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -327,6 +344,20 @@ def load_manifest() -> Manifest:
             code=EXIT_INVALID_ARGS,
             hint="Add 'name = \"...\"' under [package].",
         )
+    # Validate name is a safe, non-empty filename
+    if not pkg_name.strip():
+        log.fatal(
+            f"Invalid package name '{pkg_name}': must be a non-empty filename",
+            code=EXIT_INVALID_ARGS,
+            hint="Provide a proper basename like 'mylib-v1.0'.",
+        )
+    # Validate name has no path separators or parent traversal
+    if "/" in pkg_name or "\\" in pkg_name or ".." in pkg_name:
+        log.fatal(
+            f"Invalid package name '{pkg_name}': must be a plain filename without path separators or '..'",
+            code=EXIT_INVALID_ARGS,
+            hint="Use a simple basename like 'mylib-v1.0' instead of paths like '../evil' or 'dir/name'.",
+        )
 
     pkg_version: object = pkg.get("version")
     if not isinstance(pkg_version, str) or not pkg_version:
@@ -345,6 +376,15 @@ def load_manifest() -> Manifest:
         )
 
     sysroot_ref = _parse_nanvix_version(raw_nanvix_version)
+
+    # optional
+    multi_release_mode: object = pkg.get("multi-release-mode", False)
+    if not isinstance(multi_release_mode, bool):
+        log.fatal(
+            "multi-release-mode must be a boolean value.",
+            code=EXIT_INVALID_ARGS,
+            hint="Use a boolean value.",
+        )
 
     # --- [dependencies] (optional) ---
     deps_raw: object = data.get("dependencies", {})
@@ -394,4 +434,5 @@ def load_manifest() -> Manifest:
         sysroot_ref=sysroot_ref,
         dependencies=dependencies,
         system_dependencies=system_dependencies,
+        multi_release_mode=multi_release_mode,
     )

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -1,36 +1,20 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-"""Release artifact packaging.
-
-Produces release archives in multiple formats (``.tar.gz``, ``.tar.bz2``,
-``.zip``) from a source directory.  Consumer repositories call
-:func:`package` from their :meth:`~nanvix_zutil.ZScript.release` hook to
-generate distribution archives::
-
-    from nanvix_zutil.release import ArchiveFormat, package
-
-    archives = package(
-        sources=[Path("build/output")],
-        dest=Path("dist"),
-        name="mylib-microvm-standalone-256mb",
-    )
-"""
+"""Release artifact packaging."""
 
 from __future__ import annotations
 
 import os
-import shutil
 import tarfile
 import zipfile
-from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
-from tempfile import mkdtemp
-from typing import Literal, Sequence
+from shutil import rmtree
+from typing import Literal
 
-from nanvix_zutil import log
-from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR, EXIT_INVALID_ARGS
+from nanvix_zutil import EXIT_MISSING_DEP, load_manifest, log, paths
+from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
 
 # ---------------------------------------------------------------------------
 # Archive format enum
@@ -173,110 +157,58 @@ def _build_zip(source: Path, dest: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def package(
-    sources: list[Path],
-    dest: Path,
-    name: str,
-    formats: Sequence[ArchiveFormat] = DEFAULT_FORMATS,
-    staging: Path | None = None,
-) -> list[Path]:
+def package():
     """Package one or more sources into release archives.
 
-    Creates one archive per requested format.  The output file names are
-    formed as ``<name><extension>`` (e.g. ``mylib-v1.0.tar.gz``,
-    ``mylib-v1.0.zip``).
+    Creates one archive per ``DEFAULT_FORMATS``.  The output file names are
+    formed as ``<name><postfix?><extension>`` (e.g. ``mylib-v1.0.tar.gz``,
+    ``mylib-v1.0.zip``, ``mytool-v0.5-bin.tar.bz``).
 
-    Args:
-        sources: Items to archive.  Each entry may be a file or a directory.
-            Directory contents are merged flat into the staging root;
-            individual files are placed at the staging root by their basename.
-            Duplicate items are clobbered.
-            Symlinks in *sources* and symlinks encountered inside source
-            directories are silently skipped.
-        dest: Output directory for archives.  Created if it does not exist.
-        name: Base name for the archives (without extension). Must be a plain
-            filename without path separators or parent directory traversal.
-        formats: Archive formats to produce.  Defaults to
-            :data:`DEFAULT_FORMATS` (tar.gz + zip).
-        staging: Directory to use as the staging area.  When supplied, sources
-            are copied directly into this directory (which must already exist)
-            and the caller is responsible for its lifetime.  When omitted, a
-            fresh temporary directory is created and removed automatically on
-            return.
-
-    Returns:
-        List of absolute paths to created archives, one per format, in
-        the same order as *formats*.
+    May release multiple archives if ``multi_release_mode: true`` is specified in nanvix.toml.
+    By default releases only one, containing the full contents of ``paths.release_dir()``
 
     Raises:
-        SystemExit: With :data:`~nanvix_zutil.exitcodes.EXIT_GENERAL_ERROR`
-            if any entry in *sources* does not exist, if staging or copying
-            fails, or if archive creation fails.  With
-            :data:`~nanvix_zutil.exitcodes.EXIT_INVALID_ARGS` if *name* is
-            empty, whitespace-only, or contains path separators or parent
-            directory traversal, or if an unknown format is encountered,
-            or if *sources* is empty.
+        SystemExit:
+            - With :data:`~nanvix_zutil.exitcodes.EXIT_GENERAL_ERROR`
+                if ``paths.release_dir()`` does not exist, if staging or copying
+                fails, or if archive creation fails.
+            - with :data:`~nanvix_zutil.exitcodes.EXIT_MISSING_DEP` if the
+                release source directory is missing or not a directory.
     """
-    if not sources:
+    formats = DEFAULT_FORMATS
+    manifest = load_manifest()
+    name = manifest.name
+    multi_release = manifest.multi_release_mode
+    sources = paths.release_dir()
+    if sources.is_dir() and not sources.is_symlink():
+        if multi_release:
+            _sources: list[Path] = []
+            for s in sources.iterdir():
+                if s.is_dir() and not s.is_symlink():
+                    _sources.append(s)
+                else:
+                    log.warning(f"Skipping non-directory item {s}")
+            sources = _sources
+            if len(sources) == 0:
+                log.fatal(
+                    "No release content found.",
+                    code=EXIT_MISSING_DEP,
+                    hint="Run ./z build first.",
+                )
+        else:
+            sources = [sources]
+    else:
         log.fatal(
-            "package() requires at least one source item.",
-            code=EXIT_INVALID_ARGS,
-            hint="Pass one or more file or directory paths in the 'sources' list.",
-        )
-    for item in sources:
-        if not item.exists():
-            log.fatal(
-                f"Release source '{item}' does not exist.",
-                code=EXIT_GENERAL_ERROR,
-                hint="Ensure the build step has run and produced output in the"
-                " expected directory before calling 'release'.",
-            )
-
-    # Validate name is a safe, non-empty filename
-    if not name or not name.strip():
-        log.fatal(
-            f"Invalid archive name '{name}': must be a non-empty filename",
-            code=EXIT_INVALID_ARGS,
-            hint="Provide a proper basename like 'mylib-v1.0'.",
-        )
-
-    # Validate name has no path separators or parent traversal
-    if "/" in name or "\\" in name or ".." in name:
-        log.fatal(
-            f"Invalid archive name '{name}': must be a plain filename without path separators or '..'",
-            code=EXIT_INVALID_ARGS,
-            hint="Use a simple basename like 'mylib-v1.0' instead of paths like '../evil' or 'dir/name'.",
+            f"Release source {sources} is not a directory.",
+            code=EXIT_MISSING_DEP,
+            hint="Run ./z build first.",
         )
 
-    if formats is None:  # type: ignore[redundant-expr]
-        log.fatal(
-            "Invalid formats parameter: cannot be None",
-            code=EXIT_INVALID_ARGS,
-            hint="Provide a sequence of ArchiveFormat values, e.g., (ArchiveFormat.TAR_GZ, ArchiveFormat.ZIP).",
-        )
-    if isinstance(formats, (str, bytes)):
-        log.fatal(
-            f"Invalid formats parameter: {type(formats).__name__!r} is not a valid sequence",
-            code=EXIT_INVALID_ARGS,
-            hint="Provide a sequence of ArchiveFormat values, not a string or bytes object.",
-        )
-    if not isinstance(formats, Iterable):  # type: ignore[redundant-expr]
-        log.fatal(
-            f"Invalid formats parameter: {type(formats).__name__!r} is not iterable",
-            code=EXIT_INVALID_ARGS,
-            hint="Provide a sequence of ArchiveFormat values, e.g., (ArchiveFormat.TAR_GZ, ArchiveFormat.ZIP).",
-        )
+    dest = paths.dist_dir()
 
-    # Create destination directory with proper error handling
     try:
+        rmtree(dest, ignore_errors=True)
         dest.mkdir(parents=True, exist_ok=True)
-        # Verify it's actually a directory (not a file with the same name)
-        if not dest.is_dir():
-            log.fatal(
-                f"Destination path exists but is not a directory: {dest}",
-                code=EXIT_GENERAL_ERROR,
-                hint="Choose a different destination path or remove the conflicting file.",
-            )
     except (OSError, PermissionError) as e:
         log.fatal(
             f"Cannot create destination directory '{dest}': {e}",
@@ -284,65 +216,18 @@ def package(
             hint="Check parent directory permissions and available disk space.",
         )
 
-    _cleanup_staging = staging is None
-    if staging is not None:
-        if not staging.exists():
-            log.fatal(
-                f"Staging directory '{staging}' does not exist.",
-                code=EXIT_INVALID_ARGS,
-                hint="Create the directory before passing it as 'staging', or omit the argument to use a temporary directory.",
-            )
-        if not staging.is_dir():
-            log.fatal(
-                f"Staging path '{staging}' exists but is not a directory.",
-                code=EXIT_INVALID_ARGS,
-                hint="Pass a directory path for 'staging', or omit the argument to use a temporary directory.",
-            )
-    staging = staging if staging else Path(mkdtemp())
-
-    def package_sources() -> list[Path]:
-        created: list[Path] = []
-        try:
-            for item in sources:
-                if item.is_dir():
-                    shutil.copytree(item, staging, dirs_exist_ok=True, symlinks=True)
-                else:
-                    if item.is_symlink():
-                        log.warning(f"Skipping symlink source '{item}'.")
-                        continue
-                    shutil.copy2(item, staging / item.name)
-        except (OSError, shutil.Error) as e:
-            log.fatal(
-                f"Failed to stage sources into '{staging}': {e}",
-                code=EXIT_GENERAL_ERROR,
-                hint="Check source file permissions and available disk space.",
-            )
-
+    for subdir in sources:
         for fmt in formats:
-            # Runtime validation: users could pass invalid types despite type hints
-            if not isinstance(fmt, ArchiveFormat):  # type: ignore[redundant-expr]
-                log.fatal(
-                    f"Invalid archive format: {fmt!r} (expected ArchiveFormat)",
-                    code=EXIT_INVALID_ARGS,
-                    hint="Use one of the supported ArchiveFormat enum values (TAR_GZ, TAR_BZ2, ZIP).",
-                )
-
-            out = dest / f"{name}{fmt.extension}"
-
+            postfix = f"-{subdir.name}" if multi_release else ""
+            out = dest / f"{name}{postfix}{fmt.extension}"
             try:
-                if fmt is ArchiveFormat.TAR_GZ:
-                    _build_tarball(staging, out, "gz")
-                elif fmt is ArchiveFormat.TAR_BZ2:
-                    _build_tarball(staging, out, "bz2")
-                elif fmt is ArchiveFormat.ZIP:
-                    _build_zip(staging, out)
-                else:
-                    # This should never happen with a proper ArchiveFormat enum value
-                    log.fatal(
-                        f"Unknown archive format: {fmt}",
-                        code=EXIT_INVALID_ARGS,
-                        hint="Use one of the supported ArchiveFormat enum values.",
-                    )
+                match fmt:
+                    case ArchiveFormat.TAR_GZ:
+                        _build_tarball(subdir, out, "gz")
+                    case ArchiveFormat.TAR_BZ2:
+                        _build_tarball(subdir, out, "bz2")
+                    case ArchiveFormat.ZIP:
+                        _build_zip(subdir, out)
             except Exception as e:
                 log.fatal(
                     f"Failed to create {fmt.name} archive: {e}",
@@ -359,13 +244,3 @@ def package(
                 )
 
             log.info(f"Created {out}")
-            created.append(out.resolve())
-
-        log.success(f"Packaged {len(created)} archive(s) for '{name}' into {dest}")
-        return created
-
-    try:
-        return package_sources()
-    finally:
-        if _cleanup_staging:
-            shutil.rmtree(staging, ignore_errors=True)

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -63,7 +63,7 @@ from nanvix_zutil.helpers import (
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.paths import buildroot as _buildroot_dir
-from nanvix_zutil.paths import dist_dir, nanvix_root, out_dir, release_dir, repo_root
+from nanvix_zutil.paths import nanvix_root, out_dir, repo_root
 from nanvix_zutil.paths import sysroot as _sysroot_dir
 from nanvix_zutil.release import package
 from nanvix_zutil.resolver import is_stale, resolve
@@ -456,8 +456,7 @@ class ZScript:
         The resulting archives are written to ``.nanvix/out/dist`` under the
         manifest package name.
         """
-        manifest = load_manifest()
-        package([release_dir()], dist_dir(), manifest.name)
+        package()
 
     def install_artifacts(self, output: str) -> None:
         """Export build artifacts to a target directory.

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -9,13 +9,9 @@ import unittest
 import zipfile
 from pathlib import Path
 
-from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR, EXIT_INVALID_ARGS
 from nanvix_zutil.release import (
-    DEFAULT_FORMATS,
-    ArchiveFormat,
     _build_tarball,  # pyright: ignore[reportPrivateUsage]
     _build_zip,  # pyright: ignore[reportPrivateUsage]
-    package,
 )
 
 
@@ -34,44 +30,6 @@ def _make_source_tree(root: Path) -> None:
     sub = root / "sub"
     sub.mkdir()
     (sub / "data.bin").write_bytes(b"\x00\x01\x02\x03")
-
-
-class TestArchiveFormat(unittest.TestCase):
-    """Tests for the ArchiveFormat enum."""
-
-    def test_extension_tar_gz(self) -> None:
-        self.assertEqual(ArchiveFormat.TAR_GZ.extension, ".tar.gz")
-
-    def test_extension_tar_bz2(self) -> None:
-        self.assertEqual(ArchiveFormat.TAR_BZ2.extension, ".tar.bz2")
-
-    def test_extension_zip(self) -> None:
-        self.assertEqual(ArchiveFormat.ZIP.extension, ".zip")
-
-    def test_value_tar_gz(self) -> None:
-        self.assertEqual(ArchiveFormat.TAR_GZ.value, "tar.gz")
-
-    def test_value_tar_bz2(self) -> None:
-        self.assertEqual(ArchiveFormat.TAR_BZ2.value, "tar.bz2")
-
-    def test_value_zip(self) -> None:
-        self.assertEqual(ArchiveFormat.ZIP.value, "zip")
-
-
-class TestDefaultFormats(unittest.TestCase):
-    """Tests for DEFAULT_FORMATS."""
-
-    def test_contains_tar_gz(self) -> None:
-        self.assertIn(ArchiveFormat.TAR_GZ, DEFAULT_FORMATS)
-
-    def test_contains_zip(self) -> None:
-        self.assertIn(ArchiveFormat.ZIP, DEFAULT_FORMATS)
-
-    def test_does_not_contain_tar_bz2(self) -> None:
-        self.assertNotIn(ArchiveFormat.TAR_BZ2, DEFAULT_FORMATS)
-
-    def test_is_tuple(self) -> None:
-        self.assertIsInstance(DEFAULT_FORMATS, tuple)
 
 
 class TestBuildTarball(unittest.TestCase):
@@ -156,338 +114,105 @@ class TestBuildZip(unittest.TestCase):
                 self.assertEqual(zf.read("sub/data.bin"), b"\x00\x01\x02\x03")
 
 
-class TestPackage(unittest.TestCase):
-    """Tests for the public package() function."""
+class TestBuilderSymlinkSecurity(unittest.TestCase):
+    """Symlink handling in the internal archive builders."""
 
-    def test_default_formats(self) -> None:
-        """package() with default formats produces .tar.gz and .zip."""
+    def _make_external_payload(self, tmp: Path) -> tuple[Path, Path]:
+        """Create an external directory tree with sensitive content."""
+        external_dir = tmp / "external"
+        external_dir.mkdir()
+        (external_dir / "secret.txt").write_text("THIS SHOULD NOT BE IN ARCHIVES")
+        nested = external_dir / "nested"
+        nested.mkdir()
+        (nested / "nested_secret.txt").write_text("NESTED SECRET DATA")
+        external_file = tmp / "external.txt"
+        external_file.write_text("sensitive data")
+        return external_dir, external_file
+
+    def test_tarball_excludes_file_symlinks(self) -> None:
+        """_build_tarball does not archive symlinks pointing outside source."""
         with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
+            tmp_path = Path(tmp)
+            src = tmp_path / "src"
             _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            result = package([src], dest, "mylib-v1.0")
-            self.assertEqual(len(result), 2)
-            names = [p.name for p in result]
-            self.assertIn("mylib-v1.0.tar.gz", names)
-            self.assertIn("mylib-v1.0.zip", names)
+            _external_dir, external_file = self._make_external_payload(tmp_path)
 
-    def test_single_format_tar_bz2(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            result = package([src], dest, "pkg", formats=(ArchiveFormat.TAR_BZ2,))
-            self.assertEqual(len(result), 1)
-            self.assertEqual(result[0].name, "pkg.tar.bz2")
-
-    def test_all_three_formats(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            all_fmts = (ArchiveFormat.TAR_GZ, ArchiveFormat.TAR_BZ2, ArchiveFormat.ZIP)
-            result = package([src], dest, "all", formats=all_fmts)
-            self.assertEqual(len(result), 3)
-            names = {p.name for p in result}
-            self.assertEqual(names, {"all.tar.gz", "all.tar.bz2", "all.zip"})
-
-    def test_creates_dest_directory(self) -> None:
-        """package() creates the destination directory if it doesn't exist."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "nested" / "output" / "dist"
-            self.assertFalse(dest.exists())
-            package([src], dest, "test")
-            self.assertTrue(dest.exists())
-
-    def test_returns_absolute_paths(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            result = package([src], dest, "abs")
-            for p in result:
-                self.assertTrue(p.is_absolute(), f"expected absolute: {p}")
-
-    def test_empty_sources_exits(self) -> None:
-        """package() with an empty sources list exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([], dest, "empty")
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
-
-    def test_missing_source_exits(self) -> None:
-        """package() calls log.fatal when source doesn't exist."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "nonexistent"
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "fail")
-            self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
-
-    def test_source_is_file_packaged(self) -> None:
-        """package() accepts individual files (not just directories)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "afile.txt"
-            src.write_text("not a directory")
-            dest = Path(tmp) / "dist"
-            result = package([src], dest, "file-pkg")
-            self.assertEqual(len(result), 2)
-            names = [p.name for p in result]
-            self.assertIn("file-pkg.tar.gz", names)
-            self.assertIn("file-pkg.zip", names)
-
-            tar_path = next(p for p in result if p.name.endswith(".tar.gz"))
-            zip_path = next(p for p in result if p.name.endswith(".zip"))
-
-            with tarfile.open(tar_path, "r:gz") as tf:
-                self.assertIn("afile.txt", tf.getnames())
-                member = tf.extractfile("afile.txt")
-                assert member is not None
-                self.assertEqual(member.read().decode(), "not a directory")
-
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                self.assertIn("afile.txt", zf.namelist())
-                self.assertEqual(zf.read("afile.txt").decode(), "not a directory")
-
-    def test_zip_and_tarball_have_same_file_set(self) -> None:
-        """Both archive types should contain the same set of files."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            result = package([src], dest, "match")
-
-            tar_path = [p for p in result if p.name.endswith(".tar.gz")][0]
-            zip_path = [p for p in result if p.name.endswith(".zip")][0]
-
-            with tarfile.open(tar_path, "r:gz") as tf:
-                tar_files = {n for n in tf.getnames() if not tf.getmember(n).isdir()}
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                zip_files = set(zf.namelist())
-
-            self.assertEqual(tar_files, zip_files)
-
-    def test_order_matches_formats(self) -> None:
-        """Returned paths should be in the same order as the formats tuple."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            fmts = (ArchiveFormat.ZIP, ArchiveFormat.TAR_BZ2, ArchiveFormat.TAR_GZ)
-            result = package([src], dest, "order", formats=fmts)
-            self.assertEqual(result[0].name, "order.zip")
-            self.assertEqual(result[1].name, "order.tar.bz2")
-            self.assertEqual(result[2].name, "order.tar.gz")
-
-    def test_name_with_slash_exits(self) -> None:
-        """package() with name containing forward slash exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "bad/name")
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
-
-    def test_name_with_backslash_exits(self) -> None:
-        """package() with name containing backslash exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "bad\\name")
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
-
-    def test_name_with_parent_traversal_exits(self) -> None:
-        """package() with name containing '..' exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "../evil")
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
-
-    def test_empty_name_exits(self) -> None:
-        """package() with empty name exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "")
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
-
-    def test_whitespace_only_name_exits(self) -> None:
-        """package() with whitespace-only name exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "   ")
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
-
-    def test_symlinks_excluded_from_archives(self) -> None:
-        """Symlinks are excluded from both tar and zip archives for security."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-
-            # Create a symlink to a file outside the source tree (security risk)
-            external_file = Path(tmp) / "external.txt"
-            external_file.write_text("sensitive data")
-            symlink_path = src / "dangerous_link"
+            link = src / "dangerous_link"
             try:
-                symlink_path.symlink_to(external_file)
+                link.symlink_to(external_file)
             except (OSError, NotImplementedError):
-                # Skip test if symlinks not supported (e.g. Windows without dev mode)
                 self.skipTest("Symlinks not supported on this platform")
 
-            dest = Path(tmp) / "dist"
-            result = package([src], dest, "test")
+            out = tmp_path / "out.tar.gz"
+            _build_tarball(src, out, "gz")
+            with tarfile.open(out, "r:gz") as tf:
+                names = set(tf.getnames())
+            self.assertNotIn("dangerous_link", names)
 
-            # Check that symlinks are not included in either archive
-            tar_path = [p for p in result if p.name.endswith(".tar.gz")][0]
-            with tarfile.open(tar_path, "r:gz") as tf:
-                tar_names = set(tf.getnames())
-                self.assertNotIn("dangerous_link", tar_names)
-
-            zip_path = [p for p in result if p.name.endswith(".zip")][0]
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                zip_names = set(zf.namelist())
-                self.assertNotIn("dangerous_link", zip_names)
-
-    def test_invalid_format_type_exits(self) -> None:
-        """package() with non-ArchiveFormat in formats exits with error."""
+    def test_tarball_does_not_traverse_symlinked_dirs(self) -> None:
+        """_build_tarball does not descend into symlinked directories."""
         with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
+            tmp_path = Path(tmp)
+            src = tmp_path / "src"
             _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            # Use a string instead of ArchiveFormat enum
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "test", formats=("invalid_format",))  # type: ignore
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
+            external_dir, _external_file = self._make_external_payload(tmp_path)
 
-    def test_invalid_format_mixed_tuple_exits(self) -> None:
-        """package() with mixed valid/invalid formats exits on first invalid."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            # Mix valid ArchiveFormat with invalid type
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "test", formats=(ArchiveFormat.ZIP, "bad_format"))  # type: ignore
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
-
-    def test_symlinked_directory_not_traversed(self) -> None:
-        """Symlinked directories are not traversed to prevent directory escape attacks."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-
-            # Create an external directory with sensitive content
-            external_dir = Path(tmp) / "external"
-            external_dir.mkdir()
-            sensitive_file = external_dir / "secret.txt"
-            sensitive_file.write_text("THIS SHOULD NOT BE IN ARCHIVES")
-
-            # Create a nested directory in external
-            nested_external = external_dir / "nested"
-            nested_external.mkdir()
-            nested_sensitive = nested_external / "nested_secret.txt"
-            nested_sensitive.write_text("NESTED SECRET DATA")
-
-            # Create a symlinked directory inside src pointing to the external directory
-            symlink_dir = src / "evil_link"
+            link = src / "evil_link"
             try:
-                symlink_dir.symlink_to(external_dir)
+                link.symlink_to(external_dir)
             except (OSError, NotImplementedError):
-                # Skip test if symlinks not supported (e.g. Windows without dev mode)
                 self.skipTest("Symlinks not supported on this platform")
 
-            dest = Path(tmp) / "dist"
-            result = package([src], dest, "test")
+            out = tmp_path / "out.tar.gz"
+            _build_tarball(src, out, "gz")
+            with tarfile.open(out, "r:gz") as tf:
+                names = set(tf.getnames())
+            self.assertNotIn("evil_link", names)
+            self.assertNotIn("evil_link/secret.txt", names)
+            self.assertNotIn("evil_link/nested/nested_secret.txt", names)
 
-            # Verify external files are NOT included in either archive format
-            tar_path = [p for p in result if p.name.endswith(".tar.gz")][0]
-            with tarfile.open(tar_path, "r:gz") as tf:
-                tar_names = set(tf.getnames())
-                # Should not contain any files from the symlinked directory
-                self.assertNotIn("evil_link/secret.txt", tar_names)
-                self.assertNotIn("evil_link/nested/nested_secret.txt", tar_names)
-                # Should not contain the symlinked directory itself
-                self.assertNotIn("evil_link", tar_names)
-
-            zip_path = [p for p in result if p.name.endswith(".zip")][0]
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                zip_names = set(zf.namelist())
-                # Should not contain any files from the symlinked directory
-                self.assertNotIn("evil_link/secret.txt", zip_names)
-                self.assertNotIn("evil_link/nested/nested_secret.txt", zip_names)
-                # Should not contain the symlinked directory itself
-                self.assertNotIn("evil_link/", zip_names)
-                self.assertNotIn("evil_link", zip_names)
-
-    def test_multi_source_directories_merged(self) -> None:
-        """package() merges multiple source directories into a single archive."""
+    def test_zip_excludes_file_symlinks(self) -> None:
+        """_build_zip does not archive symlinks pointing outside source."""
         with tempfile.TemporaryDirectory() as tmp:
-            src_a = Path(tmp) / "a"
-            src_a.mkdir()
-            (src_a / "from_a.txt").write_bytes(b"alpha")
-
-            src_b = Path(tmp) / "b"
-            src_b.mkdir()
-            (src_b / "from_b.txt").write_bytes(b"beta")
-
-            dest = Path(tmp) / "dist"
-            result = package([src_a, src_b], dest, "merged")
-
-            tar_path = next(p for p in result if p.name.endswith(".tar.gz"))
-            zip_path = next(p for p in result if p.name.endswith(".zip"))
-
-            with tarfile.open(tar_path, "r:gz") as tf:
-                tar_files = {n for n in tf.getnames() if not tf.getmember(n).isdir()}
-            with zipfile.ZipFile(zip_path, "r") as zf:
-                zip_files = set(zf.namelist())
-
-            for names in (tar_files, zip_files):
-                self.assertIn("from_a.txt", names)
-                self.assertIn("from_b.txt", names)
-
-    def test_formats_none_exits(self) -> None:
-        """package() with None formats parameter exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
+            tmp_path = Path(tmp)
+            src = tmp_path / "src"
             _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "test", formats=None)  # type: ignore
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
+            _external_dir, external_file = self._make_external_payload(tmp_path)
 
-    def test_formats_string_exits(self) -> None:
-        """package() with string formats parameter exits with error."""
-        with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
-            _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "test", formats="invalid")  # type: ignore
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
+            link = src / "dangerous_link"
+            try:
+                link.symlink_to(external_file)
+            except (OSError, NotImplementedError):
+                self.skipTest("Symlinks not supported on this platform")
 
-    def test_formats_non_iterable_exits(self) -> None:
-        """package() with non-iterable formats parameter exits with error."""
+            out = tmp_path / "out.zip"
+            _build_zip(src, out)
+            with zipfile.ZipFile(out, "r") as zf:
+                names = set(zf.namelist())
+            self.assertNotIn("dangerous_link", names)
+
+    def test_zip_does_not_traverse_symlinked_dirs(self) -> None:
+        """_build_zip does not descend into symlinked directories."""
         with tempfile.TemporaryDirectory() as tmp:
-            src = Path(tmp) / "src"
+            tmp_path = Path(tmp)
+            src = tmp_path / "src"
             _make_source_tree(src)
-            dest = Path(tmp) / "dist"
-            with self.assertRaises(SystemExit) as ctx:
-                package([src], dest, "test", formats=42)  # type: ignore
-            self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
+            external_dir, _external_file = self._make_external_payload(tmp_path)
+
+            link = src / "evil_link"
+            try:
+                link.symlink_to(external_dir)
+            except (OSError, NotImplementedError):
+                self.skipTest("Symlinks not supported on this platform")
+
+            out = tmp_path / "out.zip"
+            _build_zip(src, out)
+            with zipfile.ZipFile(out, "r") as zf:
+                names = set(zf.namelist())
+            self.assertNotIn("evil_link", names)
+            self.assertNotIn("evil_link/", names)
+            self.assertNotIn("evil_link/secret.txt", names)
+            self.assertNotIn("evil_link/nested/nested_secret.txt", names)
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -20,7 +20,10 @@ from nanvix_zutil.docker import (
     DockerConfig,
     Mount,
 )
-from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
+from nanvix_zutil.exitcodes import (
+    EXIT_BUILD_FAILURE,
+    EXIT_MISSING_DEP,
+)
 from nanvix_zutil.helpers import InitRdArgs
 from nanvix_zutil.script import ZScript
 from tests.testutils import (
@@ -334,15 +337,7 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
 
 
 class TestZScriptReleaseDefault(unittest.TestCase):
-    """Default ``ZScript.release()`` packages ``.nanvix/out/release``.
-
-    The hook is a thin wrapper around :func:`nanvix_zutil.release.package`;
-    exhaustive coverage of archive contents, format handling, and input
-    validation lives in ``tests/test_release.py``. These tests only verify
-    the wiring: the release directory is picked up, archives land in the
-    dist directory under the manifest name, and a missing release directory
-    fails cleanly.
-    """
+    """Default ``ZScript.release()`` packages ``.nanvix/out/release``."""
 
     def setUp(self) -> None:
         write_manifest()  # manifest name = "test"
@@ -379,41 +374,90 @@ class TestZScriptReleaseDefault(unittest.TestCase):
             sys.stderr = original_stderr
 
         output = buf.getvalue()
-        self.assertIn("success:", output)
-        self.assertIn("Packaged 2 archive(s) for 'test'", output)
+        self.assertIn("Created", output)
+        self.assertEqual(output.count("Created"), 2)
+        self.assertIn("info:", output)
+        self.assertIn("test.tar.gz", output)
+        self.assertIn("test.zip", output)
         self.assertIn(str(paths.dist_dir()), output)
 
-    def test_fails_when_release_dir_missing(self) -> None:
-        """Missing ``.nanvix/out/release`` aborts with EXIT_GENERAL_ERROR."""
-        from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
 
+class TestZScriptReleaseMultiMode(unittest.TestCase):
+    """``ZScript.release()`` in multi-release mode.
+
+    With ``multi_release_mode = true`` in the manifest, each child of
+    ``paths.release_dir()`` is packaged into its own pair of archives,
+    with the child's stem appended to the manifest name.
+    """
+
+    MULTI_RELEASE_MANIFEST = (
+        "[package]\n"
+        'name = "test"\n'
+        'version = "0.1.0"\n'
+        'nanvix-version = "0.1.0"\n'
+        "multi-release-mode = true\n"
+    )
+
+    def setUp(self) -> None:
+        write_manifest(self.MULTI_RELEASE_MANIFEST)
+
+    def test_packages_each_subdirectory_separately(self) -> None:
+        import tarfile
+        import zipfile
+
+        rel = paths.release_dir()
+        rel.mkdir(parents=True, exist_ok=True)
+        (rel / "a").mkdir()
+        (rel / "a" / "file_a.bin").write_bytes(b"alpha")
+        (rel / "b").mkdir()
+        (rel / "b" / "file_b.bin").write_bytes(b"beta")
+
+        ZScript().release()
+
+        dist = paths.dist_dir()
+        produced = {p.name for p in dist.iterdir()}
+        # name="test" + "-" + item.stem ("a"/"b") + DEFAULT_FORMATS (tar.gz, zip).
+        self.assertEqual(
+            produced,
+            {"test-a.tar.gz", "test-a.zip", "test-b.tar.gz", "test-b.zip"},
+        )
+        for p in dist.iterdir():
+            self.assertGreater(p.stat().st_size, 0, f"empty archive: {p}")
+
+        # Each archive must contain ONLY its own subdir's file — not the
+        # union of both. This is the headline contract of multi-release mode.
+        def _tar_files(name: str) -> set[str]:
+            with tarfile.open(dist / name, "r:gz") as tf:
+                return {n for n in tf.getnames() if not tf.getmember(n).isdir()}
+
+        def _zip_files(name: str) -> set[str]:
+            with zipfile.ZipFile(dist / name, "r") as zf:
+                return set(zf.namelist())
+
+        self.assertEqual(_tar_files("test-a.tar.gz"), {"file_a.bin"})
+        self.assertEqual(_zip_files("test-a.zip"), {"file_a.bin"})
+        self.assertEqual(_tar_files("test-b.tar.gz"), {"file_b.bin"})
+        self.assertEqual(_zip_files("test-b.zip"), {"file_b.bin"})
+
+    def test_fails_when_release_dir_is_file(self) -> None:
+        """In multi-release mode, a non-directory release path is fatal."""
+        rel = paths.release_dir()
+        rel.parent.mkdir(parents=True, exist_ok=True)
+        rel.write_bytes(b"not a directory")
+
+        with self.assertRaises(SystemExit) as ctx:
+            ZScript().release()
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+
+    def test_fails_when_release_dir_missing(self) -> None:
+        """In multi-release mode, a missing release path is also fatal
+        (same ``not sources.is_dir()`` branch as the is-a-file case).
+        """
         self.assertFalse(paths.release_dir().exists())
 
         with self.assertRaises(SystemExit) as ctx:
             ZScript().release()
-        self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
-
-        # Nothing should have been produced in dist/.
-        dist = paths.dist_dir()
-        if dist.exists():
-            self.assertEqual(list(dist.iterdir()), [])
-
-    def test_failure_emits_error_with_hint(self) -> None:
-        """The failure path surfaces a recognizable error + hint on stderr."""
-        buf = StringIO()
-        original_stderr = sys.stderr
-        sys.stderr = buf
-        try:
-            with self.assertRaises(SystemExit):
-                ZScript().release()
-        finally:
-            sys.stderr = original_stderr
-
-        output = buf.getvalue()
-        self.assertIn("error:", output)
-        self.assertIn(str(paths.release_dir()), output)
-        self.assertIn("hint:", output)
-        self.assertIn("release", output)
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
 
 class TestZScriptAvailableSubcommands(unittest.TestCase):


### PR DESCRIPTION
Adds a multi-release boolean flag to the manifest which allows the package() function to iterate the release_dir() and find multiple packages to wrap. Also cleans up the package() API.

Closes #259 