### PR TITLE
[zutils] F: Multi-release

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -162,23 +163,21 @@ class ZScript:
         {"setup", "build", "release", "clean"}
     )
 
+    #: Consumer-provided release targets.
+    #: By default, `./z release` will wrap everything in the `release_dir()`.
+    #: Specify this value to override.
+    #: This value maps from subdirectory names to release artifacts.
+    #:
+    #: Example usage:
+    #: ```python
+    #: RELEASE_TARGETS = {
+    #:     # release_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+    #:     "sysroot-pkg": f"{name}-{toolchain}",
+    #:     # release_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+    #:     "buildroot-pkg": f"{name}-{toolchain}-buildroot",
+    #: }
+    #: ```
     RELEASE_TARGETS: dict[str, str] = {}
-    """
-    Consumer-provided release targets.
-    By default, `./z release` will wrap everything in the `release_dir()`.
-    Specify this value to override.
-    This value maps from subdirectory names to release artifacts.
-
-    Example usage:
-    ```python
-    RELEASE_TARGETS = {
-        # release_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
-        "sysroot-pkg": f"{name}-{toolchain}",
-        # release_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
-        "buildroot-pkg": f"{name}-{toolchain}-buildroot",
-    }
-    ```
-    """
 
     def sysroot_required_files(self) -> list[str]:
         """Return the sysroot files required for the current platform and mode.
@@ -475,10 +474,22 @@ class ZScript:
         manifest package name.
         """
         manifest = load_manifest()
+
+        def check_target(target: str):
+            allowlist = re.compile(r"^[A-Za-z0-9_.-]+$")
+            if not allowlist.match(target) and target not in (".", ".."):
+                log.fatal(
+                    f"Invalid release target '{target}'."
+                    "Characters must be alphanumeric, underscore, hyphen, or dot.",
+                    code=EXIT_INVALID_ARGS,
+                )
+
         if self.RELEASE_TARGETS == {}:
             package([release_dir()], dist_dir(), manifest.name)
         else:
             for input, output in self.RELEASE_TARGETS.items():
+                check_target(input)
+                check_target(output)
                 package([release_dir() / input], dist_dir(), output)
 
     def install_artifacts(self, output: str) -> None:

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -162,6 +162,24 @@ class ZScript:
         {"setup", "build", "release", "clean"}
     )
 
+    RELEASE_TARGETS: dict[str, str] = {}
+    """
+    Consumer-provided release targets.
+    By default, `./z release` will wrap everything in the `release_dir()`.
+    Specify this value to override.
+    This value maps from subdirectory names to release artifacts.
+
+    Example usage:
+    ```python
+    RELEASE_TARGETS = {
+        # release_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+        "sysroot-pkg": f"{name}-{toolchain}",
+        # release_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+        "buildroot-pkg": f"{name}-{toolchain}-buildroot",
+    }
+    ```
+    """
+
     def sysroot_required_files(self) -> list[str]:
         """Return the sysroot files required for the current platform and mode.
 
@@ -457,7 +475,11 @@ class ZScript:
         manifest package name.
         """
         manifest = load_manifest()
-        package([release_dir()], dist_dir(), manifest.name)
+        if self.RELEASE_TARGETS == {}:
+            package([release_dir()], dist_dir(), manifest.name)
+        else:
+            for input, output in self.RELEASE_TARGETS.items():
+                package([release_dir() / input], dist_dir(), output)
 
     def install_artifacts(self, output: str) -> None:
         """Export build artifacts to a target directory.

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -416,6 +416,64 @@ class TestZScriptReleaseDefault(unittest.TestCase):
         self.assertIn("release", output)
 
 
+class TestZScriptReleaseMulti(unittest.TestCase):
+    """``ZScript.RELEASE_TARGETS`` drives multi-release packaging.
+
+    Wiring only: archive contents are covered by ``tests/test_release.py``.
+    We just check that ``release()`` issues one ``package()`` call per
+    target, with the right source subdir and output name.
+    """
+
+    def setUp(self) -> None:
+        write_manifest()
+
+    def _populate(self, *subdirs: str) -> None:
+        for sub in subdirs:
+            d = paths.release_dir() / sub
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "artifact.bin").write_bytes(b"payload")
+
+    def test_dispatches_one_package_call_per_target(self) -> None:
+        self._populate("sysroot-pkg", "buildroot-pkg")
+
+        class MultiScript(ZScript):
+            RELEASE_TARGETS = {
+                "sysroot-pkg": "test-sysroot",
+                "buildroot-pkg": "test-buildroot",
+            }
+
+        with patch("nanvix_zutil.script.package") as mock_pkg:
+            MultiScript().release()
+
+        rel = paths.release_dir()
+        dist = paths.dist_dir()
+        self.assertEqual(mock_pkg.call_count, 2)
+        seen = {(tuple(c.args[0]), c.args[2]) for c in mock_pkg.call_args_list}
+        self.assertEqual(
+            seen,
+            {
+                ((rel / "sysroot-pkg",), "test-sysroot"),
+                ((rel / "buildroot-pkg",), "test-buildroot"),
+            },
+        )
+        for c in mock_pkg.call_args_list:
+            self.assertEqual(c.args[1], dist)
+
+    def test_empty_targets_falls_back_to_default(self) -> None:
+        """``RELEASE_TARGETS = {}`` keeps the single-archive default."""
+        rel = paths.release_dir()
+        rel.mkdir(parents=True, exist_ok=True)
+        (rel / "artifact.bin").write_bytes(b"payload")
+
+        with patch("nanvix_zutil.script.package") as mock_pkg:
+            ZScript().release()
+
+        mock_pkg.assert_called_once()
+        args, _ = mock_pkg.call_args
+        self.assertEqual(args[0], [rel])
+        self.assertEqual(args[2], "test")  # manifest name
+
+
 class TestZScriptAvailableSubcommands(unittest.TestCase):
     """available_subcommands() reflects hook overrides."""
 


### PR DESCRIPTION
Add RELEASE_TARGETS to support multiple release artifacts with arbitrary input subdirectories and output names. Closes #259.

Verified against all downstream default branches with editable install.