### PR TITLE
[zutils] B: release targets as fn

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -163,21 +163,25 @@ class ZScript:
         {"setup", "build", "release", "clean"}
     )
 
-    #: Consumer-provided release targets.
-    #: By default, `./z release` will wrap everything in the `release_dir()`.
-    #: Specify this value to override.
-    #: This value maps from subdirectory names to release artifacts.
-    #:
-    #: Example usage:
-    #: ```python
-    #: RELEASE_TARGETS = {
-    #:     # release_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
-    #:     "sysroot-pkg": f"{name}-{toolchain}",
-    #:     # release_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
-    #:     "buildroot-pkg": f"{name}-{toolchain}-buildroot",
-    #: }
-    #: ```
-    RELEASE_TARGETS: dict[str, str] = {}
+    def release_targets(self) -> dict[str, str]:
+        """
+        Consumer-provided release targets.
+        By default, `./z release` will wrap everything in the `release_dir()`.
+        Specify this value to override.
+        This value maps from subdirectory names to release artifacts.
+
+        Example usage:
+        ```python
+        def release_targets() -> dict[str,str]:
+            return {
+                # release_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+                "sysroot-pkg": f"{name}-{toolchain}",
+                # release_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+                "buildroot-pkg": f"{name}-{toolchain}-buildroot",
+            }
+        ```
+        """
+        return {}
 
     def sysroot_required_files(self) -> list[str]:
         """Return the sysroot files required for the current platform and mode.
@@ -484,7 +488,7 @@ class ZScript:
                     code=EXIT_INVALID_ARGS,
                 )
 
-        if self.RELEASE_TARGETS == {}:
+        if self.release_targets() == {}:
             name = (
                 f"{manifest.name}"
                 f"-{self.config.machine}"
@@ -493,7 +497,7 @@ class ZScript:
             )
             package([release_dir()], dist_dir(), name)
         else:
-            for input, output in self.RELEASE_TARGETS.items():
+            for input, output in self.release_targets().items():
                 check_target(input)
                 check_target(output)
                 package([release_dir() / input], dist_dir(), output)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -10,6 +10,7 @@ import sys
 import unittest
 from io import StringIO
 from pathlib import Path
+from typing import override
 from unittest.mock import MagicMock, patch
 
 from nanvix_zutil import helpers, paths
@@ -446,10 +447,12 @@ class TestZScriptReleaseMulti(unittest.TestCase):
         self._populate("sysroot-pkg", "buildroot-pkg")
 
         class MultiScript(ZScript):
-            RELEASE_TARGETS = {
-                "sysroot-pkg": "test-sysroot",
-                "buildroot-pkg": "test-buildroot",
-            }
+            @override
+            def release_targets(self) -> dict[str, str]:
+                return {
+                    "sysroot-pkg": "test-sysroot",
+                    "buildroot-pkg": "test-buildroot",
+                }
 
         with patch("nanvix_zutil.script.package") as mock_pkg:
             MultiScript().release()


### PR DESCRIPTION
Use a function instead of a constnat. This allows taking the self parameter (e.g. calling  in cpython).

Example downstream usage (cpython):

```python
    @override
    def release_targets(self) -> dict[str, str]:
        name = (
            f"{self.manifest.name}"
            f"-{self.config.machine}"
            f"-{self.config.deployment_mode}"
            f"-{self.config.memory_size}"
        )
        return {
            config.PKG_SYSROOT: f"{name}",
            config.PKG_BUILDROOT: f"{name}-buildroot",
        }
```

Blocks https://github.com/nanvix/cpython/pull/771