### PR TITLE
Add out/ to sync'd gitignore

### DIFF
--- a/src/nanvix_zutil/configs/.gitignore
+++ b/src/nanvix_zutil/configs/.gitignore
@@ -3,6 +3,7 @@ venv
 cache
 sysroot
 buildroot
+out
 .yamllint.yml
 black.toml
 env.json


### PR DESCRIPTION
Downstreams need to ignore the out/ directory. The issue is that the downstream .gitignores are overridden when we synchronize, so we need to do it here.