### PR TITLE
[zutils] B: Parameterize make_initrd paths

### DIFF
--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -28,7 +28,7 @@ from nanvix_zutil import (
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE
 from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
-from nanvix_zutil.paths import nanvix_root, repo_root
+from nanvix_zutil.paths import bin_out, nanvix_root, repo_root
 
 
 class BinHello(ZScript):
@@ -113,7 +113,12 @@ class BinHello(ZScript):
         # For standalone deployment mode, produce an initrd image
         # containing the system daemons and the application binary.
         if self.config.deployment_mode == "standalone":
-            make_initrd(self, "hello.elf", test=False, args=InitRdArgs())
+            make_initrd(
+                self,
+                repo_root() / "hello.elf",
+                bin_out(),
+                args=InitRdArgs(),
+            )
 
     def test(self) -> None:
         _test.Test(self).test()

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -15,7 +15,7 @@ from nanvix_zutil import log
 from nanvix_zutil.config import CFG_SYSROOT
 from nanvix_zutil.docker import DockerConfig, is_windows
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
-from nanvix_zutil.paths import bin_out, nanvix_root, repo_root, test_out
+from nanvix_zutil.paths import nanvix_root
 
 if TYPE_CHECKING:
     from nanvix_zutil.script import ZScript
@@ -165,7 +165,11 @@ class InitRdArgs:
 
 
 def make_initrd(
-    instance: "ZScript", app: str, *, test: bool, args: InitRdArgs | None = None
+    instance: "ZScript",
+    input_path: Path,
+    out_dir: Path,
+    *,
+    args: InitRdArgs | None = None,
 ) -> Path:
     """Build a standalone initrd image for *app*.
 
@@ -179,11 +183,8 @@ def make_initrd(
     ``run-linux.md`` for the full protocol).
 
     Args:
-        app: A bare application binary filename (e.g. ``"my-app.elf"``).
-            Must include the extension and must not contain path
-            separators (``/`` or ``\\``).
-        test: Controls the output directory. Is this for test, or release?
-            If true, outputs to ``test_out()``, else ``bin_out()``
+        input_path: Path to the application to be placed in the initrd image.
+        out_dir: Path to place the compiled image. The name is determined by the input_path.
         args: Additional arguments controlling the image generation.
 
     Returns:
@@ -193,12 +194,6 @@ def make_initrd(
         SystemExit: If *app* contains path separators, the sysroot
             is unavailable, or ``mkimage`` is missing.
     """
-    # Validate that app is a bare filename — no directory components.
-    if "/" in app or "\\" in app:
-        log.fatal(
-            f"app must be a bare filename without path separators, got: {app!r}",
-            code=EXIT_MISSING_DEP,
-        )
 
     if args is None:
         args = InitRdArgs()
@@ -229,8 +224,7 @@ def make_initrd(
             hint="Ensure the sysroot contains mkimage by running ./z setup.",
         )
 
-    app_stem = Path(app).stem
-    out_dir = test_out() if test else bin_out()
+    app_stem = input_path.stem
     out_dir.mkdir(parents=True, exist_ok=True)
     output = out_dir / f"{app_stem}.img"
 
@@ -267,7 +261,7 @@ def make_initrd(
             ),
             _entry(args.bin_dir / "memd.elf", "memd", args.memd_args, args.memd_env),
             _entry(args.bin_dir / "vfsd.elf", "vfsd", args.vfsd_args, args.vfsd_env),
-            _entry(repo_root() / app, app, args.app_args, args.app_env),
+            _entry(input_path, app_stem, args.app_args, args.app_env),
         ]
     )
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1375,7 +1375,10 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             result = helpers.make_initrd(
-                script, "my-app.elf", test=False, args=InitRdArgs()
+                script,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
+                args=InitRdArgs(),
             )
 
         self.assertEqual(result, paths.bin_out() / "my-app.img")
@@ -1387,7 +1390,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         self.assertEqual(cmd[3], f"{bin_dir / 'procd.elf'};procd")
         self.assertEqual(cmd[4], f"{bin_dir / 'memd.elf'};memd")
         self.assertEqual(cmd[5], f"{bin_dir / 'vfsd.elf'};vfsd")
-        self.assertEqual(cmd[6], f"{paths.repo_root() / 'my-app.elf'};my-app.elf")
+        self.assertEqual(cmd[6], f"{paths.repo_root() / 'my-app.elf'};my-app")
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=True)
     def test_basic_invocation_windows(self, _mock: object) -> None:
@@ -1400,7 +1403,12 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
-            helpers.make_initrd(script, "my-app.elf", test=False, args=InitRdArgs())
+            helpers.make_initrd(
+                script,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
+                args=InitRdArgs(),
+            )
 
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
         self.assertEqual(captured[0][0], str(bin_dir / "mkimage.exe"))
@@ -1418,15 +1426,15 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(app_args=["--verbose", "--port=8080"]),
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{paths.repo_root() / 'my-app.elf'};my-app.elf --verbose --port=8080",
+            f"{paths.repo_root() / 'my-app.elf'};my-app --verbose --port=8080",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1442,8 +1450,8 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(
                     procd_args=["--debug"],
                     memd_args=["--heap=64m"],
@@ -1469,8 +1477,8 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(kernel_args=["console=ttyS0", "debug"]),
             )
 
@@ -1491,12 +1499,15 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
-                script, "my-app.elf", test=False, args=InitRdArgs(app_args=["--sep=;"])
+                script,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
+                args=InitRdArgs(app_args=["--sep=;"]),
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
-            app_entry, f"{paths.repo_root() / 'my-app.elf'};my-app.elf --sep=\\;"
+            app_entry, f"{paths.repo_root() / 'my-app.elf'};my-app --sep=\\;"
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1511,7 +1522,10 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
-                script, "my-app.elf", test=False, args=InitRdArgs(kernel_args=["a;b"])
+                script,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
+                args=InitRdArgs(kernel_args=["a;b"]),
             )
 
         cmd = captured[0]
@@ -1533,7 +1547,10 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
-                script, "my-app.elf", test=False, args=InitRdArgs(bin_dir=custom_bin)
+                script,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
+                args=InitRdArgs(bin_dir=custom_bin),
             )
 
         self.assertEqual(captured[0][0], str(custom_bin / "mkimage.elf"))
@@ -1544,12 +1561,17 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         script = ZScript()
         script.sysroot = None
         with self.assertRaises(SystemExit) as ctx:
-            helpers.make_initrd(script, "my-app.elf", test=False, args=InitRdArgs())
+            helpers.make_initrd(
+                script,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
+                args=InitRdArgs(),
+            )
         self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_app_stem_derived_from_filename(self, _mock: object) -> None:
-        """The output .img uses the stem; argv0 uses the full filename."""
+        """The output .img uses the stem of input_path; argv0 also uses the stem."""
         script = self._make_script()
         captured: list[list[str]] = []
 
@@ -1559,22 +1581,36 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             result = helpers.make_initrd(
-                script, "hello-world.elf", test=False, args=InitRdArgs()
+                script,
+                paths.repo_root() / "hello-world.elf",
+                paths.bin_out(),
+                args=InitRdArgs(),
             )
 
         self.assertEqual(result, paths.bin_out() / "hello-world.img")
         self.assertEqual(
-            captured[0][6], f"{paths.repo_root() / 'hello-world.elf'};hello-world.elf"
+            captured[0][6], f"{paths.repo_root() / 'hello-world.elf'};hello-world"
         )
 
-    def test_app_with_path_separator_exits(self) -> None:
-        """Exits with EXIT_MISSING_DEP when app contains path separators."""
+    @patch("nanvix_zutil.helpers.is_windows", return_value=False)
+    def test_input_path_with_directory_components(self, _mock: object) -> None:
+        """input_path may include directory components; they are preserved
+        verbatim in the entry, while the .img name is taken from the stem."""
         script = self._make_script()
-        with self.assertRaises(SystemExit) as ctx:
-            helpers.make_initrd(
-                script, "build/hello.elf", test=False, args=InitRdArgs()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:
+            captured.append(cmd)
+            return sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        input_path = paths.repo_root() / "build" / "hello.elf"
+        with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
+            result = helpers.make_initrd(
+                script, input_path, paths.bin_out(), args=InitRdArgs()
             )
-        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+
+        self.assertEqual(result, paths.bin_out() / "hello.img")
+        self.assertEqual(captured[0][6], f"{input_path};hello")
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
     def test_mkimage_not_found_exits(self, _mock: object) -> None:
@@ -1587,7 +1623,12 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         fake_sysroot.path = paths.sysroot()
         script.sysroot = fake_sysroot
         with self.assertRaises(SystemExit) as ctx:
-            helpers.make_initrd(script, "my-app.elf", test=False, args=InitRdArgs())
+            helpers.make_initrd(
+                script,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
+                args=InitRdArgs(),
+            )
         self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1603,15 +1644,15 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(app_env=["VAR1=foo", "VAR2=bar"]),
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{paths.repo_root() / 'my-app.elf'};my-app.elf;VAR1=foo VAR2=bar",
+            f"{paths.repo_root() / 'my-app.elf'};my-app;VAR1=foo VAR2=bar",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1627,15 +1668,15 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(app_args=["--verbose"], app_env=["DEBUG=1"]),
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{paths.repo_root() / 'my-app.elf'};my-app.elf --verbose;DEBUG=1",
+            f"{paths.repo_root() / 'my-app.elf'};my-app --verbose;DEBUG=1",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1651,8 +1692,8 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(
                     procd_env=["LOG=debug"],
                     memd_env=["HEAP=64m"],
@@ -1678,15 +1719,15 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(app_env=["PATH=/a;/b"]),
             )
 
         app_entry = captured[0][6]
         self.assertEqual(
             app_entry,
-            f"{paths.repo_root() / 'my-app.elf'};my-app.elf;PATH=/a\\;/b",
+            f"{paths.repo_root() / 'my-app.elf'};my-app;PATH=/a\\;/b",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1702,8 +1743,8 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(
                     procd_args=["--log-level", "trace"], procd_env=["LOG=debug"]
                 ),
@@ -1728,8 +1769,8 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             helpers.make_initrd(
                 script,
-                "my-app.elf",
-                test=False,
+                paths.repo_root() / "my-app.elf",
+                paths.bin_out(),
                 args=InitRdArgs(
                     app_args=["--verbose"], app_env=["DEBUG=1"], procd_env=["LOG=debug"]
                 ),
@@ -1740,14 +1781,13 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         self.assertEqual(captured[0][3], f"{bin_dir / 'procd.elf'};procd;LOG=debug")
         self.assertEqual(
             captured[0][6],
-            f"{paths.repo_root() / 'my-app.elf'};my-app.elf --verbose;DEBUG=1",
+            f"{paths.repo_root() / 'my-app.elf'};my-app --verbose;DEBUG=1",
         )
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
-    def test_output_location_depends_on_test_flag(self, _mock: object) -> None:
-        """Output directory is ``test_out()`` when ``test=True`` and
-        ``bin_out()`` when ``test=False``; in both cases the directory is
-        created automatically if it does not already exist."""
+    def test_out_dir_used_verbatim_and_created(self, _mock: object) -> None:
+        """The caller-supplied ``out_dir`` controls where the .img is written
+        and is created automatically if it does not already exist."""
         script = self._make_script()
         captured: list[list[str]] = []
 
@@ -1760,12 +1800,13 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         self.assertFalse(paths.bin_out().exists())
         self.assertFalse(paths.test_out().exists())
 
+        input_path = paths.repo_root() / "my-app.elf"
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             release = helpers.make_initrd(
-                script, "my-app.elf", test=False, args=InitRdArgs()
+                script, input_path, paths.bin_out(), args=InitRdArgs()
             )
             test_img = helpers.make_initrd(
-                script, "my-app.elf", test=True, args=InitRdArgs()
+                script, input_path, paths.test_out(), args=InitRdArgs()
             )
 
         self.assertEqual(release, paths.bin_out() / "my-app.img")


### PR DESCRIPTION
This PR aims to parameterize the make_initrd input and output paths so that downstreams have full control over their usage.

THIS IS A BREAKING CHANGE. Please cut a release in sync with https://github.com/nanvix/workflows/pull/97

Closes #273 
