### PR TITLE
[zutils] B: Ensure tool paths fix

### DIFF
--- a/src/nanvix_zutil/commands/format.py
+++ b/src/nanvix_zutil/commands/format.py
@@ -50,10 +50,10 @@ def format(check: bool = False) -> None:
     if not py_files:
         log.warning(f"No .py files found in {nanvix_root()} — nothing to format")
         return
-    ensure_tool_installed("black")
+    cmd = ensure_tool_installed("black")
     str_files = [str(f) for f in py_files]
     black_cfg = str(nanvix_root() / "black.toml")
-    cmd = [sys.executable, "-m", "black", "--config", black_cfg]
+    cmd.extend(["--config", black_cfg])
     if check:
         cmd.append("--check")
     cmd.extend(str_files)

--- a/src/nanvix_zutil/commands/lint.py
+++ b/src/nanvix_zutil/commands/lint.py
@@ -15,6 +15,7 @@ import argparse
 import sys
 
 from nanvix_zutil import log
+from nanvix_zutil.commands.format import format
 from nanvix_zutil.exitcodes import EXIT_SUCCESS
 from nanvix_zutil.helpers import ensure_tool_installed, run
 from nanvix_zutil.paths import nanvix_root
@@ -46,29 +47,13 @@ def lint() -> None:
     if not py_files:
         log.warning(f"No .py files found in {nanvix_root()} — nothing to lint")
         return
-    for tool in ("black", "pyright"):
-        ensure_tool_installed(tool)
+    cmd = ensure_tool_installed("pyright")
 
     str_files = [str(f) for f in py_files]
-    black_cfg = str(nanvix_root() / "black.toml")
     pyright_cfg = str(nanvix_root() / "pyrightconfig.json")
-    run(
-        sys.executable,
-        "-m",
-        "black",
-        "--config",
-        black_cfg,
-        "--check",
-        *str_files,
-    )
-    run(
-        sys.executable,
-        "-m",
-        "pyright",
-        "--project",
-        pyright_cfg,
-        *str_files,
-    )
+    cmd.extend(["--project", pyright_cfg, *str_files])
+    run(*cmd)
+    format(check=True)
 
 
 def main() -> None:

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -7,6 +7,7 @@ import importlib.resources
 import importlib.util
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -98,12 +99,20 @@ def check_docker(image: str) -> None:
             )
 
 
-def ensure_tool_installed(name: str):
-    if importlib.util.find_spec(name) is None:
+def ensure_tool_installed(name: str) -> list[str]:
+    """
+    Check that `name` can either be imported or is on path.
+    Will prefer the imported path.
+    """
+    if importlib.util.find_spec(name):
+        return [sys.executable, "-m", name]
+    elif shutil.which(name):
+        return [name]
+    else:
         log.fatal(
             f"{name} is not installed.",
             code=EXIT_MISSING_DEP,
-            hint="Run ./z setup before using this command.",
+            hint="Run ./z setup or manually install the executable before using this command.",
         )
 
 

--- a/tests/test_format_cmd.py
+++ b/tests/test_format_cmd.py
@@ -101,6 +101,7 @@ class TestFormatCmd(unittest.TestCase):
 
         with (
             patch("importlib.util.find_spec", return_value=None),
+            patch("nanvix_zutil.helpers.shutil.which", return_value=None),
             self.assertRaises(SystemExit) as ctx,
         ):
             format()

--- a/tests/test_lint_cmd.py
+++ b/tests/test_lint_cmd.py
@@ -19,7 +19,7 @@ class TestLintCmd(unittest.TestCase):
         self.nanvix_dir = paths.nanvix_root()
 
     def test_runs_black_and_pyright(self) -> None:
-        """``lint`` invokes black --check then pyright on .nanvix/*.py."""
+        """``lint`` invokes pyright then black --check on .nanvix/*.py."""
         (self.nanvix_dir / "z.py").write_text("x = 1\n")
 
         calls: list[list[str]] = []
@@ -39,12 +39,12 @@ class TestLintCmd(unittest.TestCase):
 
         self.assertEqual(len(calls), 2)
         self.assertIn("-m", calls[0])
-        self.assertIn("black", calls[0])
-        self.assertIn("--config", calls[0])
-        self.assertIn("--check", calls[0])
+        self.assertIn("pyright", calls[0])
+        self.assertIn("--project", calls[0])
         self.assertIn("-m", calls[1])
-        self.assertIn("pyright", calls[1])
-        self.assertIn("--project", calls[1])
+        self.assertIn("black", calls[1])
+        self.assertIn("--config", calls[1])
+        self.assertIn("--check", calls[1])
 
     def test_no_py_files_warns(self) -> None:
         """Warns and returns when no .py files exist."""
@@ -78,6 +78,7 @@ class TestLintCmd(unittest.TestCase):
 
         with (
             patch("importlib.util.find_spec", return_value=None),
+            patch("nanvix_zutil.helpers.shutil.which", return_value=None),
             self.assertRaises(SystemExit) as ctx,
         ):
             lint()


### PR DESCRIPTION
Closes #276.

Ensure that tools exist by checking both the installed zutils directory (if not installed globally), or on path (if installed globally). (I am implying a branch that does not exist, but those are the use cases.)