### PR TITLE
fix(main): source ZScript impl only from z.py

### DIFF
--- a/src/nanvix_zutil/__main__.py
+++ b/src/nanvix_zutil/__main__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 
@@ -75,8 +76,20 @@ def discover_script_class() -> type[ZScript]:
             hint=f"Import error: {exc}",
         )
 
+    # Only match classes whose `class` statement lives in z.py itself,
+    # so mixin bases imported from other files are not picked up ahead
+    # of the real implementor.
+    z_py_resolved = z_py.resolve()
     for attr in vars(module).values():
-        if isinstance(attr, type) and issubclass(attr, ZScript) and attr is not ZScript:
+        if not (
+            isinstance(attr, type) and issubclass(attr, ZScript) and attr is not ZScript
+        ):
+            continue
+        try:
+            src = Path(inspect.getfile(attr)).resolve()
+        except (TypeError, OSError):
+            continue
+        if src == z_py_resolved:
             return attr
 
     log.fatal(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -210,6 +210,29 @@ class TestConsumerCommandWithZPy(unittest.TestCase):
         )
         self.assertEqual(cls.__name__, "MyBuild")
 
+    def test_discover_ignores_imported_mixin(self) -> None:
+        """Imported ZScript subclasses (mixins) are not picked up."""
+        from nanvix_zutil.__main__ import (
+            discover_script_class,
+        )
+
+        # Put a mixin module next to z.py so it can be imported by it.
+        (z_py_path().parent / "mixins.py").write_text(textwrap.dedent("""\
+            from nanvix_zutil.script import ZScript
+
+            class BuildMixin(ZScript):
+                def build(self):
+                    pass
+            """))
+        z_py_path().write_text(textwrap.dedent("""\
+            from mixins import BuildMixin
+
+            class MyBuild(BuildMixin):
+                pass
+            """))
+        cls = discover_script_class()
+        self.assertEqual(cls.__name__, "MyBuild")
+
     def test_no_subclass_exits(self) -> None:
         """discover_script_class exits with error if no subclass found."""
         from nanvix_zutil.__main__ import (


### PR DESCRIPTION
discover_script_class walked vars(module) and returned the first ZScript subclass, which snags imported mixin bases too. Filter by inspect.getfile == z.py so only the class defined in z.py wins.

Closes #269