### PR TITLE
[zutils] F: Make release standalone

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -103,7 +103,7 @@ Zutils has a multi-phase lifecycle similar to other build tools. Most lifecycle 
 | Setup     | `./z setup --with-docker nanvix/toolchain:latest-minimal` | ❌          | ❌           | See below.                                                              |
 | Build     | `./z build`                                               | ❌          | ✅           | See below.                                                              |
 | Test      | `./z test`                                                | ❌          | ✅           | Runs project-specific test suites. Should _not_ create build artefacts. |
-| Release   | `./z release`                                             | ❌          | ❌           | Packages build artefacts into tarballs and zip files for distribution.  |
+| Release   | `./z release`                                             | ✅          | ❌           | Packages build artefacts into tarballs and zip files for distribution. Honours a `release_targets()` override on the consumer's `ZScript` subclass when present. |
 | Benchmark | `./z benchmark`                                           | ❌          | ✅           | Runs benchmarks.                                                        |
 | Clean     | `./z clean`                                               | ❌          | ✅           | Cleans up build files.                                                  |
 | Distclean | `./z distclean`                                           | ✅          | ❌           | Removes all transient nanvix artefacts. Also runs clean if available.   |
@@ -143,17 +143,20 @@ Certain lifecycle stages will only be available if the implementor class overrid
 | Verb      | Requires override |
 | --------- | ----------------- |
 | setup     | ❌                |
+| release   | ❌                |
 | distclean | ❌                |
 | lint      | ❌                |
 | format    | ❌                |
+| info      | ❌                |
 | build     | ✅                |
 | test      | ✅                |
 | benchmark | ✅                |
-| release   | ✅                |
 | clean     | ✅                |
 
-Automatically available verbs are listed in the `AUTO_HOOKS` list, while opt-in
-verbs are listed in the `CONSUMER_HOOKS` array.
+Automatically available verbs are either standalone commands
+(``distclean``, ``format``, ``info``, ``lint``, ``release``) or listed in
+the ``AUTO_HOOKS`` list on ``ZScript`` (``setup``); opt-in verbs are
+listed in the ``CONSUMER_HOOKS`` array.
 
 ### Environment variables
 

--- a/src/nanvix_zutil/__main__.py
+++ b/src/nanvix_zutil/__main__.py
@@ -17,6 +17,7 @@ from nanvix_zutil.commands import (
     format,
     info,
     lint,
+    release,
     resolve,
 )
 from nanvix_zutil.config import ENV_VARS
@@ -35,6 +36,7 @@ _STANDALONE_HELP: dict[str, str] = {
     "format": format.HELP,
     "info": info.HELP,
     "lint": lint.HELP,
+    "release": release.HELP,
     "resolve": resolve.HELP,
 }
 
@@ -179,6 +181,13 @@ def main() -> None:
 
         sys.argv = ["nanvix-zutil format", *remaining]
         format_main()
+        return
+
+    if subcmd == "release":
+        from nanvix_zutil.commands.release import main as release_main
+
+        sys.argv = ["nanvix-zutil release", *remaining]
+        release_main()
         return
 
     if subcmd == "help":

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -55,7 +55,6 @@ SUBCOMMANDS: tuple[str, ...] = (
     "build",
     "test",
     "benchmark",
-    "release",
     "clean",
     "lock",
     "install",
@@ -65,8 +64,8 @@ SUBCOMMANDS: tuple[str, ...] = (
 #: Subcommands that accept the ``--with-docker`` flag.
 #:
 #: ``--with-docker IMAGE`` is required on ``setup`` to specify the Docker
-#: image.  ``build``, ``release``, and ``clean`` load the image from
-#: persisted config (set during ``setup``).
+#: image.  ``build`` and ``clean`` load the image from persisted config
+#: (set during ``setup``).
 DOCKER_SUBCOMMANDS: tuple[str, ...] = ("setup",)
 
 #: Human-readable descriptions for each subcommand.
@@ -75,7 +74,6 @@ SUBCOMMAND_HELP: dict[str, str] = {
     "build": "Build the project",
     "test": "Run tests",
     "benchmark": "Run benchmarks",
-    "release": "Package a release",
     "clean": "Remove build artifacts",
     "lock": "Resolve dependencies and write nanvix.lock",
     "install": "Export build artifacts to a target directory",
@@ -163,7 +161,7 @@ def build_parser(
                 dest="with_docker",
                 help="Docker image to use for containerised builds."
                 " The image is persisted to .nanvix/env.json so that"
-                " subsequent build/release/clean commands use it"
+                " subsequent build/clean commands use it"
                 " automatically. test and benchmark always run on"
                 " the host.",
             )

--- a/src/nanvix_zutil/commands/release.py
+++ b/src/nanvix_zutil/commands/release.py
@@ -1,0 +1,115 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""``nanvix-zutil release`` — package release archives from ``.nanvix/out/release``.
+
+Standalone command (per issue #191): does not require a ``ZScript``
+subclass, but honours a consumer-defined ``release_targets()`` override
+on ``.nanvix/z.py`` when present.
+
+Archives are written to ``.nanvix/out/dist`` under the manifest package
+name.  With no override, a single archive is produced covering the
+entire release directory.  With an override, one archive per entry is
+produced from the named subdirectory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+from nanvix_zutil import log
+from nanvix_zutil.config import Config
+from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_SUCCESS
+from nanvix_zutil.manifest import load_manifest
+from nanvix_zutil.paths import dist_dir, nanvix_root, release_dir
+from nanvix_zutil.release import package
+
+HELP: str = "Package release archives from .nanvix/out/release into .nanvix/out/dist"
+"""One-line description surfaced in ``nanvix-zutil --help``."""
+
+_TARGET_ALLOWLIST = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the argument parser for ``nanvix-zutil release``.
+
+    Returns:
+        Configured :class:`argparse.ArgumentParser`.
+    """
+    return argparse.ArgumentParser(
+        prog="nanvix-zutil release",
+        description=(
+            "Package release archives from .nanvix/out/release into"
+            " .nanvix/out/dist. If .nanvix/z.py defines a release_targets()"
+            " override, one archive is produced per entry; otherwise a"
+            " single archive covers the whole release directory."
+        ),
+    )
+
+
+def _check_target(target: str) -> None:
+    """Reject release-target names that are not filename-safe."""
+    if not _TARGET_ALLOWLIST.match(target) and target not in (".", ".."):
+        log.fatal(
+            f"Invalid release target '{target}'."
+            " Characters must be alphanumeric, underscore, hyphen, or dot.",
+            code=EXIT_INVALID_ARGS,
+        )
+
+
+def consumer_release_targets() -> dict[str, str]:
+    """Return ``release_targets()`` from ``.nanvix/z.py`` if it defines one.
+
+    Returns ``{}`` when ``z.py`` is absent or defines no ``release_targets``
+    override.  Import errors on ``z.py`` propagate — a broken consumer
+    script must fail loudly rather than silently ship a default archive.
+    """
+    z_py = nanvix_root() / "z.py"
+    if not z_py.exists():
+        return {}
+
+    # Lazy import: ``__main__`` imports this module at top level for HELP.
+    from nanvix_zutil.__main__ import discover_script_class
+
+    script_cls = discover_script_class()
+    instance = script_cls()
+
+    targets_fn = getattr(instance, "release_targets", None)
+    if not callable(targets_fn):
+        return {}
+    result = targets_fn()
+    if not isinstance(result, dict):
+        return {}
+    return {str(k): str(v) for k, v in result.items()}  # type: ignore[reportUnknownVariableType]
+
+
+def release() -> None:
+    """Package release archives from ``.nanvix/out/release``."""
+    manifest = load_manifest()
+    config = Config()
+
+    targets = consumer_release_targets()
+    if not targets:
+        name = (
+            f"{manifest.name}"
+            f"-{config.machine}"
+            f"-{config.deployment_mode}"
+            f"-{config.memory_size}"
+        )
+        package([release_dir()], dist_dir(), name)
+        return
+
+    for input, output in targets.items():
+        _check_target(input)
+        _check_target(output)
+        package([release_dir() / input], dist_dir(), output)
+
+
+def main() -> None:
+    """Entry point for ``nanvix-zutil release``."""
+    parser = _build_parser()
+    _args = parser.parse_args()
+    release()
+    sys.exit(EXIT_SUCCESS)

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -4,9 +4,9 @@
 """Release artifact packaging.
 
 Produces release archives in multiple formats (``.tar.gz``, ``.tar.bz2``,
-``.zip``) from a source directory.  Consumer repositories call
-:func:`package` from their :meth:`~nanvix_zutil.ZScript.release` hook to
-generate distribution archives::
+``.zip``) from a source directory.  The standalone ``nanvix-zutil release``
+command (:mod:`nanvix_zutil.commands.release`) is the primary caller;
+consumers may also invoke :func:`package` directly for custom staging::
 
     from nanvix_zutil.release import ArchiveFormat, package
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import re
 import shutil
 import sys
 from pathlib import Path
@@ -64,9 +63,8 @@ from nanvix_zutil.helpers import (
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.paths import buildroot as _buildroot_dir
-from nanvix_zutil.paths import dist_dir, nanvix_root, out_dir, release_dir, repo_root
+from nanvix_zutil.paths import nanvix_root, out_dir, repo_root
 from nanvix_zutil.paths import sysroot as _sysroot_dir
-from nanvix_zutil.release import package
 from nanvix_zutil.resolver import is_stale, resolve
 from nanvix_zutil.sysroot import Sysroot
 
@@ -80,8 +78,8 @@ class ZScript:
 
     The :meth:`setup` and :meth:`lock` hooks are *auto-implemented* in
     the base class and are always available in the CLI.
-    The remaining hooks (``build``, ``test``, ``benchmark``, ``release``,
-    ``clean``) only appear in the help menu when the subclass overrides them.
+    The remaining hooks (``build``, ``test``, ``benchmark``, ``clean``)
+    only appear in the help menu when the subclass overrides them.
 
     Attributes:
         SYSROOT_REQUIRED_FILES: Files that must exist in the sysroot
@@ -146,7 +144,6 @@ class ZScript:
         "lock",
         "install",
         "help",
-        "release",
     )
 
     #: Consumer-defined hooks that appear in the CLI only when the
@@ -159,16 +156,15 @@ class ZScript:
     )
 
     # Subcommands that always run inside Docker.
-    DOCKER_COMMANDS: frozenset[str | None] = frozenset(
-        {"setup", "build", "release", "clean"}
-    )
+    DOCKER_COMMANDS: frozenset[str | None] = frozenset({"setup", "build", "clean"})
 
     def release_targets(self) -> dict[str, str]:
         """
-        Consumer-provided release targets.
-        By default, `./z release` will wrap everything in the `release_dir()`.
-        Specify this value to override.
-        This value maps from subdirectory names to release artifacts.
+        Consumer-provided release targets, consumed by the standalone
+        ``nanvix-zutil release`` command.
+        By default, ``release`` will wrap everything in ``release_dir()``.
+        Override to produce one archive per subdirectory.
+        This value maps from subdirectory names to release artifact names.
 
         Example usage:
         ```python
@@ -471,37 +467,6 @@ class ZScript:
         sync_configs()
         return self._used_fallback
 
-    def release(self) -> None:
-        """Package release archives from ``.nanvix/out/release``.
-
-        The resulting archives are written to ``.nanvix/out/dist`` under the
-        manifest package name.
-        """
-        manifest = load_manifest()
-
-        def check_target(target: str):
-            allowlist = re.compile(r"^[A-Za-z0-9_.-]+$")
-            if not allowlist.match(target) and target not in (".", ".."):
-                log.fatal(
-                    f"Invalid release target '{target}'."
-                    "Characters must be alphanumeric, underscore, hyphen, or dot.",
-                    code=EXIT_INVALID_ARGS,
-                )
-
-        if self.release_targets() == {}:
-            name = (
-                f"{manifest.name}"
-                f"-{self.config.machine}"
-                f"-{self.config.deployment_mode}"
-                f"-{self.config.memory_size}"
-            )
-            package([release_dir()], dist_dir(), name)
-        else:
-            for input, output in self.release_targets().items():
-                check_target(input)
-                check_target(output)
-                package([release_dir() / input], dist_dir(), output)
-
     def install_artifacts(self, output: str) -> None:
         """Export build artifacts to a target directory.
 
@@ -753,7 +718,6 @@ class ZScript:
             "build": instance.build,
             "test": instance.test,
             "benchmark": instance.benchmark,
-            "release": instance.release,
             "clean": instance.clean,
         }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,11 +112,11 @@ class TestDockerFlags(unittest.TestCase):
             parser.parse_args(["build", "--with-docker"])
         self.assertEqual(ctx.exception.code, 2)
 
-    def test_docker_flags_rejected_on_release(self) -> None:
-        """release subcommand does not accept Docker flags (moved to setup)."""
+    def test_release_subcommand_removed(self) -> None:
+        """release is no longer a consumer subcommand (moved to standalone)."""
         parser = build_parser()
         with self.assertRaises(SystemExit) as ctx:
-            parser.parse_args(["release", "--with-docker"])
+            parser.parse_args(["release"])
         self.assertEqual(ctx.exception.code, 2)
 
     def test_docker_flags_rejected_on_test(self) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,10 +47,6 @@ class _MockConsumer(ZScript):
         """Record benchmark hook invocation."""
         self.called.append("benchmark")
 
-    def release(self) -> None:
-        """Record release hook invocation."""
-        self.called.append("release")
-
     def clean(self) -> None:
         """Record clean hook invocation."""
         self.called.append("clean")
@@ -79,8 +75,8 @@ class TestIntegrationLifecycle(unittest.TestCase):
         if subcommand == "setup" and "--with-docker" not in argv:
             argv += ["--with-docker", "test/image:tag"]
 
-        # build/release/clean need a persisted Docker image.
-        _DOCKER_COMMANDS = {"build", "release", "clean"}
+        # build/clean need a persisted Docker image.
+        _DOCKER_COMMANDS = {"build", "clean"}
         if subcommand in _DOCKER_COMMANDS:
             nanvix_dir = nanvix_root()
             env_json = nanvix_dir / "env.json"
@@ -117,10 +113,6 @@ class TestIntegrationLifecycle(unittest.TestCase):
     def test_benchmark_hook_called(self) -> None:
         instance = self._run_main("benchmark")
         self.assertIn("benchmark", instance.called)
-
-    def test_release_hook_called(self) -> None:
-        instance = self._run_main("release")
-        self.assertIn("release", instance.called)
 
     def test_clean_hook_called(self) -> None:
         instance = self._run_main("clean")

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -1,0 +1,191 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Tests for the standalone ``nanvix-zutil release`` command."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from typing import override
+from unittest.mock import patch
+
+from nanvix_zutil import paths
+from nanvix_zutil.commands import release as release_cmd
+from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
+from nanvix_zutil.script import ZScript
+from tests.testutils import write_manifest
+
+
+class TestReleaseDefault(unittest.TestCase):
+    """Default packaging path — no ``.nanvix/z.py`` override.
+
+    Content coverage lives in ``tests/test_release.py``. These tests only
+    verify wiring: the release directory is picked up, archives land in the
+    dist directory under the manifest name, and a missing release directory
+    fails cleanly.
+    """
+
+    def setUp(self) -> None:
+        write_manifest()  # manifest name = "test"
+
+    def _populate_release_dir(self) -> Path:
+        rel = paths.release_dir()
+        rel.mkdir(parents=True, exist_ok=True)
+        (rel / "artifact.bin").write_bytes(b"payload")
+        return rel
+
+    def test_packages_when_release_dir_exists(self) -> None:
+        self._populate_release_dir()
+
+        release_cmd.release()
+
+        dist = paths.dist_dir()
+        produced = {p.name for p in dist.iterdir()}
+        self.assertEqual(
+            produced,
+            {
+                "test-microvm-standalone-256mb.tar.gz",
+                "test-microvm-standalone-256mb.zip",
+            },
+        )
+        for p in dist.iterdir():
+            self.assertGreater(p.stat().st_size, 0, f"empty archive: {p}")
+
+    def test_emits_success_message(self) -> None:
+        self._populate_release_dir()
+
+        buf = StringIO()
+        original_stderr = sys.stderr
+        sys.stderr = buf
+        try:
+            release_cmd.release()
+        finally:
+            sys.stderr = original_stderr
+
+        output = buf.getvalue()
+        self.assertIn("success:", output)
+        self.assertIn(
+            "Packaged 2 archive(s) for 'test-microvm-standalone-256mb'", output
+        )
+        self.assertIn(str(paths.dist_dir()), output)
+
+    def test_fails_when_release_dir_missing(self) -> None:
+        self.assertFalse(paths.release_dir().exists())
+
+        with self.assertRaises(SystemExit) as ctx:
+            release_cmd.release()
+        self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
+
+        dist = paths.dist_dir()
+        if dist.exists():
+            self.assertEqual(list(dist.iterdir()), [])
+
+    def test_failure_emits_error_with_hint(self) -> None:
+        buf = StringIO()
+        original_stderr = sys.stderr
+        sys.stderr = buf
+        try:
+            with self.assertRaises(SystemExit):
+                release_cmd.release()
+        finally:
+            sys.stderr = original_stderr
+
+        output = buf.getvalue()
+        self.assertIn("error:", output)
+        self.assertIn(str(paths.release_dir()), output)
+        self.assertIn("hint:", output)
+        self.assertIn("release", output)
+
+
+class TestReleaseTargetsOverride(unittest.TestCase):
+    """A ``release_targets()`` override on ``.nanvix/z.py`` drives multi-archive packaging.
+
+    We patch ``consumer_release_targets`` to simulate a consumer override
+    without materialising a fake ``z.py`` module on disk.
+    """
+
+    def setUp(self) -> None:
+        write_manifest()
+
+    def _populate(self, *subdirs: str) -> None:
+        for sub in subdirs:
+            d = paths.release_dir() / sub
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "artifact.bin").write_bytes(b"payload")
+
+    def test_dispatches_one_package_call_per_target(self) -> None:
+        self._populate("sysroot-pkg", "buildroot-pkg")
+
+        targets = {
+            "sysroot-pkg": "test-sysroot",
+            "buildroot-pkg": "test-buildroot",
+        }
+        with (
+            patch(
+                "nanvix_zutil.commands.release.consumer_release_targets",
+                return_value=targets,
+            ),
+            patch("nanvix_zutil.commands.release.package") as mock_pkg,
+        ):
+            release_cmd.release()
+
+        rel = paths.release_dir()
+        dist = paths.dist_dir()
+        self.assertEqual(mock_pkg.call_count, 2)
+        seen = {(tuple(c.args[0]), c.args[2]) for c in mock_pkg.call_args_list}
+        self.assertEqual(
+            seen,
+            {
+                ((rel / "sysroot-pkg",), "test-sysroot"),
+                ((rel / "buildroot-pkg",), "test-buildroot"),
+            },
+        )
+        for c in mock_pkg.call_args_list:
+            self.assertEqual(c.args[1], dist)
+
+    def test_empty_targets_falls_back_to_default(self) -> None:
+        rel = paths.release_dir()
+        rel.mkdir(parents=True, exist_ok=True)
+        (rel / "artifact.bin").write_bytes(b"payload")
+
+        with patch("nanvix_zutil.commands.release.package") as mock_pkg:
+            release_cmd.release()
+
+        mock_pkg.assert_called_once()
+        args, _ = mock_pkg.call_args
+        self.assertEqual(args[0], [rel])
+        self.assertEqual(args[2], "test-microvm-standalone-256mb")
+
+
+class TestConsumerReleaseTargets(unittest.TestCase):
+    """``consumer_release_targets()`` picks up overrides from ``.nanvix/z.py``."""
+
+    def setUp(self) -> None:
+        write_manifest()
+
+    def test_no_z_py_returns_empty(self) -> None:
+        self.assertFalse((paths.nanvix_root() / "z.py").exists())
+        self.assertEqual(release_cmd.consumer_release_targets(), {})
+
+    def test_override_returned(self) -> None:
+        class _Sub(ZScript):
+            @override
+            def release_targets(self) -> dict[str, str]:
+                return {"sysroot-pkg": "test-sysroot"}
+
+        # Create a placeholder z.py so the presence check passes; the
+        # discover step is patched to return _Sub directly.
+        (paths.nanvix_root() / "z.py").write_text("# placeholder\n")
+
+        with patch("nanvix_zutil.__main__.discover_script_class", return_value=_Sub):
+            self.assertEqual(
+                release_cmd.consumer_release_targets(),
+                {"sysroot-pkg": "test-sysroot"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -8,9 +8,7 @@ import os
 import subprocess as sp
 import sys
 import unittest
-from io import StringIO
 from pathlib import Path
-from typing import override
 from unittest.mock import MagicMock, patch
 
 from nanvix_zutil import helpers, paths
@@ -334,160 +332,6 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
         self._make_script().clean()
 
 
-class TestZScriptReleaseDefault(unittest.TestCase):
-    """Default ``ZScript.release()`` packages ``.nanvix/out/release``.
-
-    The hook is a thin wrapper around :func:`nanvix_zutil.release.package`;
-    exhaustive coverage of archive contents, format handling, and input
-    validation lives in ``tests/test_release.py``. These tests only verify
-    the wiring: the release directory is picked up, archives land in the
-    dist directory under the manifest name, and a missing release directory
-    fails cleanly.
-    """
-
-    def setUp(self) -> None:
-        write_manifest()  # manifest name = "test"
-
-    def _populate_release_dir(self) -> Path:
-        rel = paths.release_dir()
-        rel.mkdir(parents=True, exist_ok=True)
-        (rel / "artifact.bin").write_bytes(b"payload")
-        return rel
-
-    def test_packages_when_release_dir_exists(self) -> None:
-        """With a populated release dir, archives appear in dist_dir()."""
-        self._populate_release_dir()
-
-        ZScript().release()
-
-        dist = paths.dist_dir()
-        produced = {p.name for p in dist.iterdir()}
-        # Manifest name is "test"; DEFAULT_FORMATS = tar.gz + zip.
-        # Default release name suffixes manifest name with machine/mode/memory.
-        self.assertEqual(
-            produced,
-            {
-                "test-microvm-standalone-256mb.tar.gz",
-                "test-microvm-standalone-256mb.zip",
-            },
-        )
-        for p in dist.iterdir():
-            self.assertGreater(p.stat().st_size, 0, f"empty archive: {p}")
-
-    def test_emits_success_message(self) -> None:
-        """A human-readable success line is written to stderr."""
-        self._populate_release_dir()
-
-        buf = StringIO()
-        original_stderr = sys.stderr
-        sys.stderr = buf
-        try:
-            ZScript().release()
-        finally:
-            sys.stderr = original_stderr
-
-        output = buf.getvalue()
-        self.assertIn("success:", output)
-        self.assertIn(
-            "Packaged 2 archive(s) for 'test-microvm-standalone-256mb'", output
-        )
-        self.assertIn(str(paths.dist_dir()), output)
-
-    def test_fails_when_release_dir_missing(self) -> None:
-        """Missing ``.nanvix/out/release`` aborts with EXIT_GENERAL_ERROR."""
-        from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
-
-        self.assertFalse(paths.release_dir().exists())
-
-        with self.assertRaises(SystemExit) as ctx:
-            ZScript().release()
-        self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
-
-        # Nothing should have been produced in dist/.
-        dist = paths.dist_dir()
-        if dist.exists():
-            self.assertEqual(list(dist.iterdir()), [])
-
-    def test_failure_emits_error_with_hint(self) -> None:
-        """The failure path surfaces a recognizable error + hint on stderr."""
-        buf = StringIO()
-        original_stderr = sys.stderr
-        sys.stderr = buf
-        try:
-            with self.assertRaises(SystemExit):
-                ZScript().release()
-        finally:
-            sys.stderr = original_stderr
-
-        output = buf.getvalue()
-        self.assertIn("error:", output)
-        self.assertIn(str(paths.release_dir()), output)
-        self.assertIn("hint:", output)
-        self.assertIn("release", output)
-
-
-class TestZScriptReleaseMulti(unittest.TestCase):
-    """``ZScript.RELEASE_TARGETS`` drives multi-release packaging.
-
-    Wiring only: archive contents are covered by ``tests/test_release.py``.
-    We just check that ``release()`` issues one ``package()`` call per
-    target, with the right source subdir and output name.
-    """
-
-    def setUp(self) -> None:
-        write_manifest()
-
-    def _populate(self, *subdirs: str) -> None:
-        for sub in subdirs:
-            d = paths.release_dir() / sub
-            d.mkdir(parents=True, exist_ok=True)
-            (d / "artifact.bin").write_bytes(b"payload")
-
-    def test_dispatches_one_package_call_per_target(self) -> None:
-        self._populate("sysroot-pkg", "buildroot-pkg")
-
-        class MultiScript(ZScript):
-            @override
-            def release_targets(self) -> dict[str, str]:
-                return {
-                    "sysroot-pkg": "test-sysroot",
-                    "buildroot-pkg": "test-buildroot",
-                }
-
-        with patch("nanvix_zutil.script.package") as mock_pkg:
-            MultiScript().release()
-
-        rel = paths.release_dir()
-        dist = paths.dist_dir()
-        self.assertEqual(mock_pkg.call_count, 2)
-        seen = {(tuple(c.args[0]), c.args[2]) for c in mock_pkg.call_args_list}
-        self.assertEqual(
-            seen,
-            {
-                ((rel / "sysroot-pkg",), "test-sysroot"),
-                ((rel / "buildroot-pkg",), "test-buildroot"),
-            },
-        )
-        for c in mock_pkg.call_args_list:
-            self.assertEqual(c.args[1], dist)
-
-    def test_empty_targets_falls_back_to_default(self) -> None:
-        """``RELEASE_TARGETS = {}`` keeps the single-archive default."""
-        rel = paths.release_dir()
-        rel.mkdir(parents=True, exist_ok=True)
-        (rel / "artifact.bin").write_bytes(b"payload")
-
-        with patch("nanvix_zutil.script.package") as mock_pkg:
-            ZScript().release()
-
-        mock_pkg.assert_called_once()
-        args, _ = mock_pkg.call_args
-        self.assertEqual(args[0], [rel])
-        self.assertEqual(
-            args[2], "test-microvm-standalone-256mb"
-        )  # manifest name + config suffix
-
-
 class TestZScriptAvailableSubcommands(unittest.TestCase):
     """available_subcommands() reflects hook overrides."""
 
@@ -536,9 +380,6 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
                 pass
 
             def benchmark(self) -> None:
-                pass
-
-            def release(self) -> None:
                 pass
 
             def clean(self) -> None:


### PR DESCRIPTION
In this commit, the release function moves from an overridable ZScript function to a standalone utility.

Verified against all downstreams; none are currently overriding release().

 Closes #191 

Note: the diff is fairly large in number, but functionally quite small. 