### PR TITLE
 [zutils] E: Drop CFG_SYSROOT

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,7 +101,6 @@ nanvix/<project>/
 | `NANVIX_MACHINE` | `microvm` | Target machine |
 | `NANVIX_DEPLOYMENT_MODE` | `standalone` | Deployment mode (`single-process`, `multi-process`, `standalone`) |
 | `NANVIX_MEMORY_SIZE` | `256mb` | Memory size for artifact naming |
-| `NANVIX_SYSROOT` | *(set by setup)* | Path to runtime sysroot |
 | `NANVIX_TOOLCHAIN` | *(set by setup)* | Path to cross-compilation toolchain |
 | `NANVIX_DOCKER_IMAGE` | *(set by setup)* | Docker image (set by `setup --with-docker`) |
 | `GH_TOKEN` | *(none)* | GitHub token for API rate limits |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -55,7 +55,6 @@ development of `nanvix-zutil` itself:
 | `NANVIX_MACHINE` | `microvm` | Target machine |
 | `NANVIX_DEPLOYMENT_MODE` | `standalone` | Deployment mode |
 | `NANVIX_MEMORY_SIZE` | `256mb` | Memory size for artifact naming |
-| `NANVIX_SYSROOT` | *(set by setup)* | Path to runtime sysroot |
 | `GH_TOKEN` | *(none)* | GitHub token for API rate limits |
 
 ## Project Layout

--- a/examples/bin-hello/.nanvix/_test.py
+++ b/examples/bin-hello/.nanvix/_test.py
@@ -6,14 +6,12 @@ import sys
 from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import (
-    CFG_SYSROOT,
-    EXIT_BUILD_FAILURE,
     ZScript,
     log,
 )
 from nanvix_zutil.exitcodes import EXIT_TEST_FAILURE
 from nanvix_zutil.helpers import run
-from nanvix_zutil.paths import repo_root
+from nanvix_zutil.paths import repo_root, sysroot
 
 
 class Test:
@@ -69,14 +67,11 @@ class Test:
 
     def _sysroot(self) -> PurePosixPath | Path:
         """Return the sysroot path, translated for Docker if active."""
-        sysroot_str = self.script.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
-            log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_BUILD_FAILURE,
-            )
-        host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.script.docker.translate_path(host) if self.script.docker else host
+        return (
+            self.script.docker.translate_path(sysroot())
+            if self.script.docker
+            else sysroot()
+        )
 
     def _test_functional_docker(self, binary: Path) -> None:
         """Run functional tests inside a Docker container (Linux)."""
@@ -101,14 +96,7 @@ class Test:
     def _test_functional_windows(self, binary: Path) -> None:
         """Run functional tests natively on Windows using nanvixd.exe."""
         log.info("=== bin-hello functional tests (Windows) ===")
-        sysroot_str = self.script.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
-            log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_TEST_FAILURE,
-            )
-        sysroot = Path(sysroot_str)  # type: ignore[arg-type]
-        nanvixd = sysroot / "bin" / "nanvixd.exe"
+        nanvixd = sysroot() / "bin" / "nanvixd.exe"
         if not nanvixd.exists():
             log.fatal(
                 f"{nanvixd} not found — run 'nanvix-zutil setup' to download it.",

--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -20,15 +20,12 @@ import _test
 
 from nanvix_zutil import (
     BUILDROOT_CONTAINER_PATH,
-    CFG_SYSROOT,
     TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
-    log,
 )
-from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE
 from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
-from nanvix_zutil.paths import bin_out, nanvix_root, repo_root
+from nanvix_zutil.paths import bin_out, nanvix_root, repo_root, sysroot
 
 
 class BinHello(ZScript):
@@ -49,14 +46,7 @@ class BinHello(ZScript):
 
     def _sysroot(self) -> PurePosixPath | Path:
         """Return the sysroot path, translated for Docker if active."""
-        sysroot_str = self.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
-            log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_BUILD_FAILURE,
-            )
-        host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.docker.translate_path(host) if self.docker else host
+        return self.docker.translate_path(sysroot()) if self.docker else sysroot()
 
     def _buildroot_path(self) -> PurePosixPath | Path:
         """Return the effective buildroot path (translated for Docker if active)."""

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -17,7 +17,6 @@ import dataclasses
 from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import (
-    CFG_SYSROOT,
     TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
@@ -25,7 +24,7 @@ from nanvix_zutil import (
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
 from nanvix_zutil.helpers import run
-from nanvix_zutil.paths import repo_root
+from nanvix_zutil.paths import repo_root, sysroot
 
 
 class LibHello(ZScript):
@@ -46,14 +45,7 @@ class LibHello(ZScript):
 
     def _sysroot(self) -> PurePosixPath | Path:
         """Return the sysroot path, translated for Docker if active."""
-        sysroot_str = self.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
-            log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_BUILD_FAILURE,
-            )
-        host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.docker.translate_path(host) if self.docker else host
+        return self.docker.translate_path(sysroot()) if self.docker else sysroot()
 
     # ------------------------------------------------------------------
     # Lifecycle hooks

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -55,7 +55,6 @@ from nanvix_zutil.commands.info import NanvixInfo, get_nanvix_info
 from nanvix_zutil.config import (
     CFG_DOCKER_IMAGE,
     CFG_GH_TOKEN,
-    CFG_SYSROOT,
     DEFAULT_DEPLOYMENT_MODE,
     DEFAULT_MACHINE,
     DEFAULT_MEMORY_SIZE,
@@ -109,7 +108,6 @@ __all__ = [
     "BUILDROOT_CONTAINER_PATH",
     "CFG_DOCKER_IMAGE",
     "CFG_GH_TOKEN",
-    "CFG_SYSROOT",
     "Config",
     "DEFAULT_DEPLOYMENT_MODE",
     "DEFAULT_FORMATS",

--- a/src/nanvix_zutil/config.py
+++ b/src/nanvix_zutil/config.py
@@ -46,9 +46,6 @@ DEFAULT_MEMORY_SIZE: str = _DEFAULTS["NANVIX_MEMORY_SIZE"]
 # Standard config key names
 # ---------------------------------------------------------------------------
 
-CFG_SYSROOT: str = "NANVIX_SYSROOT"
-"""Path to the downloaded Nanvix sysroot directory."""
-
 CFG_GH_TOKEN: str = "GH_TOKEN"
 """GitHub token for authenticated API requests (rate limits)."""
 
@@ -64,7 +61,6 @@ ENV_VARS: dict[str, str] = {
     "NANVIX_MACHINE": f"Target machine (default: {DEFAULT_MACHINE})",
     "NANVIX_DEPLOYMENT_MODE": f"Deployment mode (default: {DEFAULT_DEPLOYMENT_MODE})",
     "NANVIX_MEMORY_SIZE": f"Memory size for artifact naming (default: {DEFAULT_MEMORY_SIZE})",
-    "NANVIX_SYSROOT": "Path to runtime sysroot (set by setup)",
     "NANVIX_DOCKER_IMAGE": "Docker image override (set by setup --with-docker)",
     "GH_TOKEN": "GitHub token for API rate limits",
 }

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -12,10 +12,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from nanvix_zutil import log
-from nanvix_zutil.config import CFG_SYSROOT
 from nanvix_zutil.docker import DockerConfig, is_windows
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
 from nanvix_zutil.paths import nanvix_root
+from nanvix_zutil.paths import sysroot as sysroot_path
 
 if TYPE_CHECKING:
     from nanvix_zutil.script import ZScript
@@ -201,15 +201,13 @@ def make_initrd(
     if args.bin_dir is None:
         if instance.sysroot is not None:
             args.bin_dir = instance.sysroot.path / "bin"
+        elif sysroot_path().is_dir():
+            args.bin_dir = sysroot_path() / "bin"
         else:
-            sysroot_str = instance.config.get(CFG_SYSROOT)
-            if sysroot_str:
-                args.bin_dir = Path(sysroot_str) / "bin"
-            else:
-                log.fatal(
-                    "Sysroot not available; run setup first.",
-                    code=EXIT_MISSING_DEP,
-                )
+            log.fatal(
+                "Sysroot not available; run setup first.",
+                code=EXIT_MISSING_DEP,
+            )
 
     if is_windows():
         mkimage = args.bin_dir / "mkimage.exe"

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -41,7 +41,7 @@ from nanvix_zutil.buildroot import (
     suffix_dep,
 )
 from nanvix_zutil.cli import build_parser
-from nanvix_zutil.config import CFG_DOCKER_IMAGE, CFG_GH_TOKEN, CFG_SYSROOT, Config
+from nanvix_zutil.config import CFG_DOCKER_IMAGE, CFG_GH_TOKEN, Config
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
     SYSROOT_CONTAINER_PATH,
@@ -64,6 +64,7 @@ from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfi
 from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.paths import buildroot as _buildroot_dir
 from nanvix_zutil.paths import nanvix_root, out_dir, repo_root
+from nanvix_zutil.paths import sysroot as _sysroot_dir
 from nanvix_zutil.resolver import is_stale, resolve
 from nanvix_zutil.sysroot import Sysroot
 
@@ -265,11 +266,10 @@ class ZScript:
             ),
         ]
 
-        sysroot_str = self.config.get(CFG_SYSROOT)
-        if sysroot_str:
+        if _sysroot_dir().is_dir():
             mounts.append(
                 Mount(
-                    host_path=Path(sysroot_str),
+                    host_path=_sysroot_dir(),
                     container_path=SYSROOT_CONTAINER_PATH,
                     readonly=True,
                 )
@@ -345,7 +345,6 @@ class ZScript:
                 gh_token=self.config.get(CFG_GH_TOKEN),
                 config=self.config,
             )
-        self.config.set(CFG_SYSROOT, str(self.sysroot.path))
 
         # On Windows, download host-native binaries (nanvixd.exe, mkramfs.exe)
         # BEFORE verifying required files — the base sysroot from

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,11 +60,11 @@ class TestConfigPersistence(unittest.TestCase):
 
     def test_round_trip(self) -> None:
         cfg = Config()
-        cfg.set("NANVIX_SYSROOT", "/some/path")
+        cfg.set("NANVIX_CUSTOM", "/some/path")
         cfg.save()
 
         cfg2 = Config()
-        self.assertEqual(cfg2.get("NANVIX_SYSROOT"), "/some/path")
+        self.assertEqual(cfg2.get("NANVIX_CUSTOM"), "/some/path")
 
     def test_load_ignores_malformed_json(self) -> None:
         (nanvix_root() / "env.json").write_text("not json", encoding="utf-8")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -130,14 +130,13 @@ def _pull_docker_image() -> None:
         subprocess.run(["docker", "pull", _DOCKER_IMAGE], check=True, timeout=_TIMEOUT)
 
 
-def _write_env_json(nanvix_dir: Path, sysroot: Path) -> None:
+def _write_env_json(nanvix_dir: Path) -> None:
     """Write env.json so nanvix-zutil build/test/clean can find paths."""
     cfg = {
         "NANVIX_TARGET": "x86",
         "NANVIX_MACHINE": "microvm",
         "NANVIX_DEPLOYMENT_MODE": "standalone",
         "NANVIX_MEMORY_SIZE": "256mb",
-        "NANVIX_SYSROOT": str(sysroot),
         "NANVIX_DOCKER_IMAGE": _DOCKER_IMAGE,
     }
     nanvix_dir.mkdir(parents=True, exist_ok=True)
@@ -163,49 +162,7 @@ def _setup_bin_hello_buildroot() -> None:
     shutil.copy2(_LIB_HELLO / "libhello.a", buildroot / "lib" / "libhello.a")
     shutil.copy2(_LIB_HELLO / "src" / "hello.h", buildroot / "include" / "hello.h")
 
-    _write_env_json(nanvix_dir, sysroot_src)
-
-
-def _setup_windows_sysroot() -> Path:
-    """Download sysroot and Windows host binaries for test-only runs.
-
-    On Windows CI, build artifacts are downloaded from the Linux job but
-    the sysroot is not included.  This helper downloads the sysroot and
-    Windows-native binaries (``nanvixd.exe``, etc.) so that functional
-    tests can run.
-
-    Returns the resolved sysroot path.
-    """
-    from nanvix_zutil import paths
-    from nanvix_zutil.sysroot import Sysroot
-
-    gh_token = os.environ.get("GH_TOKEN")
-
-    # `Sysroot.download` writes to `paths.sysroot()`, which resolves relative
-    # to the current `.nanvix/` root.  Ensure one exists under `_BIN_HELLO`
-    # and run the download from there.
-    (_BIN_HELLO / ".nanvix").mkdir(parents=True, exist_ok=True)
-    prev_cwd = Path.cwd()
-    os.chdir(_BIN_HELLO)
-    paths.nanvix_root.cache_clear()
-    try:
-        sysroot = Sysroot.download(
-            machine="microvm",
-            deployment_mode="standalone",
-            memory_size="256mb",
-            tag=f"v{_NANVIX_VERSION}",
-            gh_token=gh_token,
-        )
-        sysroot.download_windows_binaries(
-            machine="microvm",
-            deployment_mode="standalone",
-            memory_size="256mb",
-            gh_token=gh_token,
-        )
-        return sysroot.path.resolve()
-    finally:
-        os.chdir(prev_cwd)
-        paths.nanvix_root.cache_clear()
+    _write_env_json(nanvix_dir)
 
 
 # ===================================================================
@@ -339,8 +296,7 @@ class TestBinHelloTestOnly(unittest.TestCase):
             )
         # Download sysroot + Windows binaries so functional tests can run.
         if sys.platform == "win32":
-            sysroot = _setup_windows_sysroot()
-            _write_env_json(_BIN_HELLO / ".nanvix", sysroot)
+            _write_env_json(_BIN_HELLO / ".nanvix")
 
     def test_bin_hello(self) -> None:
         r = _run_z(_BIN_HELLO, "test")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -204,12 +204,12 @@ class TestIntegrationConfigPersistence(unittest.TestCase):
 
     def test_config_save_and_reload(self) -> None:
         script = _MockConsumer()
-        script.config.set("NANVIX_SYSROOT", "/tmp/sysroot")
+        script.config.set("NANVIX_CUSTOM", "/tmp/sysroot")
         script.config.save()
 
         # A fresh instance should see the persisted value.
         script2 = _MockConsumer()
-        self.assertEqual(script2.config.get("NANVIX_SYSROOT"), "/tmp/sysroot")
+        self.assertEqual(script2.config.get("NANVIX_CUSTOM"), "/tmp/sysroot")
 
 
 class TestIntegrationRunSubprocess(unittest.TestCase):


### PR DESCRIPTION
**BREAKING CHANGE.** Many downstreams refer to CFG_SYSROOT. This should be replaced with `paths.sysroot()`

Sysroot lives at `.nanvix/sysroot` by construction. Nothing needs to look it up in env.json anymore \u2014 `paths.sysroot()` is the sole source of truth for callers that don't already hold a `Sysroot`.
Purge stale NANVIX_SYSROOT refs. Vestigial string uses in tests and the copilot env-var table; no functional change.

Stack:
1. https://github.com/nanvix/zutils/pull/281
2: https://github.com/nanvix/zutils/pull/282
3: https://github.com/nanvix/zutils/pull/283

Related: #244 