### PR TITLE
Fix/remove unused env vars

### DIFF
--- a/src/nanvix_zutil/config.py
+++ b/src/nanvix_zutil/config.py
@@ -140,8 +140,8 @@ class Config:
     1. Seed with built-in defaults.
     2. Override with values from the persisted ``.nanvix/env.json`` file,
        if it exists.
-    3. Override with environment variables (including extra ``NANVIX_*`` keys
-       and ``GH_TOKEN``), which always take precedence.
+    3. Override with environment variables for known keys listed in
+       :data:`ENV_VARS`, which always take precedence.
 
     Effective precedence (highest to lowest) is therefore:
 
@@ -181,16 +181,14 @@ class Config:
             # Never persist secrets such as GH_TOKEN; strip if present.
             self._data.pop("GH_TOKEN", None)
 
-        # Apply environment variable overrides.
-        for key in list(self._data.keys()):
+        # Apply environment variable overrides for known keys.
+        for key in ENV_VARS:
+            # Never persist secrets such as GH_TOKEN.
+            if key == CFG_GH_TOKEN:
+                continue
             env_val = os.environ.get(key)
             if env_val is not None:
                 self._data[key] = env_val
-
-        # Apply any extra env vars not in defaults.
-        for key, val in os.environ.items():
-            if key.startswith("NANVIX_"):
-                self._data[key] = val
 
         # Validate enum-typed keys; fatal on invalid.
         for key, enum_cls in _ENUMS.items():
@@ -252,7 +250,8 @@ class Config:
     def get(self, key: str, default: str | None = None) -> str | None:
         """Retrieve a configuration value.
 
-        Environment variables always take precedence.
+        Environment variables take precedence, but only for known keys
+        listed in :data:`ENV_VARS`.
 
         Args:
             key: The configuration key.
@@ -261,9 +260,10 @@ class Config:
         Returns:
             The configuration value or *default*.
         """
-        env_val = os.environ.get(key)
-        if env_val is not None:
-            return env_val
+        if key in ENV_VARS:
+            env_val = os.environ.get(key)
+            if env_val is not None:
+                return env_val
         return self._data.get(key, default)
 
     def set(self, key: str, value: str) -> None:
@@ -311,8 +311,9 @@ class Config:
             persisted = cast(dict[str, object], raw)
             for k, v in persisted.items():
                 if isinstance(v, str):
-                    # Environment variables still win.
-                    if os.environ.get(k) is None:
-                        self._data[k] = v
+                    # Environment variables still win for known keys.
+                    if k in ENV_VARS and os.environ.get(k) is not None:
+                        continue
+                    self._data[k] = v
         except (json.JSONDecodeError, OSError):
             pass

--- a/src/nanvix_zutil/config.py
+++ b/src/nanvix_zutil/config.py
@@ -122,7 +122,6 @@ ENV_VARS: dict[str, str] = {
     "NANVIX_DEPLOYMENT_MODE": f"Deployment mode (default: {DEFAULT_DEPLOYMENT_MODE}; one of: {', '.join(DeploymentMode)})",
     "NANVIX_MEMORY_SIZE": f"Memory size for artifact naming (default: {DEFAULT_MEMORY_SIZE}; one of: {', '.join(MemorySize)})",
     "NANVIX_SYSROOT": "Path to runtime sysroot (set by setup)",
-    "NANVIX_DOCKER_IMAGE": "Docker image override (set by setup --with-docker)",
     "GH_TOKEN": "GitHub token for API rate limits",
 }
 

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -286,9 +286,6 @@ class DockerConfig:
         docker_cmd += ["-w", str(self.workdir)]
         docker_cmd += ["-e", "HOME=/tmp"]
 
-        user = os.environ.get("USER") or os.environ.get("USERNAME") or "nanvix"
-        docker_cmd += ["-e", f"USER={user}"]
-
         for key, val in self.extra_env.items():
             docker_cmd += ["-e", f"{key}={val}"]
 

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -24,9 +24,9 @@ from nanvix_zutil.paths import nanvix_root, sysroot
 # semicolon-separated list of ``C:\...`` paths with no ``/bin`` or ``/usr/bin``,
 # which overrides the image's Linux ``PATH`` and makes runc fail to resolve the
 # container's entrypoint (``exec: "sh": executable file not found in $PATH``).
-# ``HOME`` is always set explicitly by ``DockerConfig`` (currently to ``/tmp``);
-# ``USER`` is set explicitly on the standard (non-Windows) path.  In both cases
-# the caller must not override them.  ``LD_LIBRARY_PATH`` and ``PYTHONPATH``
+# ``HOME`` is always set explicitly by ``DockerConfig`` (currently to ``/tmp``).
+# ``USER``/``USERNAME`` are not forwarded; the container image sets its own.
+# The caller must not override them.  ``LD_LIBRARY_PATH`` and ``PYTHONPATH``
 # similarly refer to host filesystem locations that do not exist inside the
 # container.
 _CONTAINER_ENV_BLOCKLIST: frozenset[str] = frozenset(

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -818,8 +818,8 @@ class TestHelpersRun(unittest.TestCase):
                 forwarded.append((key, val))
 
         # The caller's host-only values must never reach the container.
-        # ``DockerConfig`` legitimately sets ``HOME``/``USER`` itself, so we
-        # check VALUES rather than keys for those cases.
+        # ``DockerConfig`` legitimately sets ``HOME`` itself, so we
+        # check VALUES rather than keys for that case.
         host_values = {
             "PATH": "C:\\Windows\\System32",
             "HOME": "/home/host",


### PR DESCRIPTION
[config] B: Drop NANVIX_DOCKER_IMAGE env var

Duplicates `--with-docker` flag. Closes #197.

---

[config] F: drop glob-read of NANVIX_* env vars

Only known keys get env overrides now. Glob was unused and bloated
the config surface. Closes #202

---

[zutils] B: Drop unused docker USER injection

This commit drops unused USER= environment variable injection. Closes #201.