### PR TITLE
[release] F: verify archive contents in package()

### DIFF
--- a/src/nanvix_zutil/commands/release.py
+++ b/src/nanvix_zutil/commands/release.py
@@ -25,7 +25,7 @@ from nanvix_zutil import log
 from nanvix_zutil.config import Config, Host
 from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR, EXIT_SUCCESS
 from nanvix_zutil.manifest import load_manifest
-from nanvix_zutil.paths import dev_out, dist_dir, regular_out
+from nanvix_zutil.paths import dev_out, dist_dir, nanvix_root, regular_out
 from nanvix_zutil.release import ArchiveFormat, package
 
 HELP: str = "Package release archives from .nanvix/out/staging into .nanvix/out/dist"
@@ -54,6 +54,39 @@ def _is_non_empty_dir(path: Path) -> bool:
     return path.is_dir() and any(path.iterdir())
 
 
+def _consumer_instance() -> object | None:
+    """Instantiate the consumer's ``ZScript`` subclass if ``.nanvix/z.py`` defines one.
+
+    Returns ``None`` when ``z.py`` is absent.  Import errors on ``z.py``
+    propagate — a broken consumer script must fail loudly.
+    """
+    if not (nanvix_root() / "z.py").exists():
+        return None
+    # Lazy import: ``__main__`` imports this module at top level for HELP.
+    from nanvix_zutil.__main__ import discover_script_class
+
+    return discover_script_class()()
+
+
+def consumer_required_files() -> list[Path]:
+    """Return ``required_files_for_release()`` from ``.nanvix/z.py`` if defined.
+
+    Returns ``[]`` when ``z.py`` is absent or defines no override.  The
+    returned paths are archive-relative and are handed to :func:`package`
+    for post-write verification.
+    """
+    instance = _consumer_instance()
+    if instance is None:
+        return []
+    fn = getattr(instance, "required_files_for_release", None)
+    if not callable(fn):
+        return []
+    result = fn()
+    if not isinstance(result, list):
+        return []
+    return [Path(str(p)) for p in result]  # type: ignore[reportUnknownVariableType]
+
+
 def release() -> None:
     """Package release archives from ``.nanvix/out/staging``."""
     manifest = load_manifest()
@@ -68,6 +101,8 @@ def release() -> None:
         f"-{config.deployment_mode}"
         f"-{config.memory_size}"
     )
+
+    require = consumer_required_files()
 
     # (source, archive suffix): regular/ -> no suffix, dev/ -> "-dev".
     slots: list[tuple[Path, str]] = []
@@ -88,7 +123,9 @@ def release() -> None:
         )
 
     for source, suffix in slots:
-        package([source], dist_dir(), f"{base}{suffix}", formats=(fmt,))
+        package(
+            [source], dist_dir(), f"{base}{suffix}", formats=(fmt,), require=require
+        )
 
 
 def main() -> None:

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -138,6 +138,50 @@ def _build_tarball(source: Path, dest: Path, compression: Literal["gz", "bz2"]) 
     return dest
 
 
+def _archive_members(archive: Path, fmt: ArchiveFormat) -> set[str]:
+    """Return the set of member names inside *archive*.
+
+    Args:
+        archive: Path to the archive file.
+        fmt: Format of the archive.
+
+    Returns:
+        Set of member names (POSIX-style paths) as stored inside the archive.
+    """
+    if fmt is ArchiveFormat.ZIP:
+        with zipfile.ZipFile(archive, "r") as zf:
+            return set(zf.namelist())
+    mode: Literal["r:gz", "r:bz2"] = "r:gz" if fmt is ArchiveFormat.TAR_GZ else "r:bz2"
+    with tarfile.open(archive, mode) as tf:
+        return set(tf.getnames())
+
+
+def _verify_archive(archive: Path, fmt: ArchiveFormat, require: Sequence[Path]) -> None:
+    """Verify *archive* contains every entry in *require*.
+
+    Each entry must match an archive member exactly.  To require that a
+    directory be non-empty, list a representative file inside it.
+
+    Args:
+        archive: Path to the archive to inspect.
+        fmt: Format of *archive*.
+        require: Required member paths, relative to the archive root.
+
+    Raises:
+        SystemExit: With :data:`~nanvix_zutil.exitcodes.EXIT_GENERAL_ERROR`
+            if any required entry is missing.
+    """
+    members = _archive_members(archive, fmt)
+    # POSIX separators: both zipfile and tarfile store members that way.
+    missing = [e.as_posix() for e in require if e.as_posix() not in members]
+    if missing:
+        log.fatal(
+            f"Archive {archive} missing required entries: {sorted(missing)}",
+            code=EXIT_GENERAL_ERROR,
+            hint="Check the build output and 'sources' passed to package().",
+        )
+
+
 def _build_zip(source: Path, dest: Path) -> Path:
     """Create a ZIP archive from *source* directory.
 
@@ -191,6 +235,7 @@ def package(
     name: str,
     formats: Sequence[ArchiveFormat] = DEFAULT_FORMATS,
     staging: Path | None = None,
+    require: Sequence[Path] = (),
 ) -> list[Path]:
     """Package one or more sources into release archives.
 
@@ -215,6 +260,11 @@ def package(
             and the caller is responsible for its lifetime.  When omitted, a
             fresh temporary directory is created and removed automatically on
             return.
+        require: Optional list of archive member paths (relative to the
+            archive root) that must be present as exact members in every
+            produced archive.  To assert that a directory is non-empty, list
+            a representative file inside it.  Verification runs after each
+            archive is written.
 
     Returns:
         List of absolute paths to created archives, one per format, in
@@ -223,7 +273,8 @@ def package(
     Raises:
         SystemExit: With :data:`~nanvix_zutil.exitcodes.EXIT_GENERAL_ERROR`
             if any entry in *sources* does not exist, if staging or copying
-            fails, or if archive creation fails.  With
+            fails, or if archive creation fails, or if a produced archive is
+            missing an entry listed in *require*.  With
             :data:`~nanvix_zutil.exitcodes.EXIT_INVALID_ARGS` if *name* is
             empty, whitespace-only, or contains path separators or parent
             directory traversal, or if an unknown format is encountered,
@@ -369,6 +420,9 @@ def package(
                     code=EXIT_GENERAL_ERROR,
                     hint="Check disk space and permissions.",
                 )
+
+            if require:
+                _verify_archive(out, fmt, require)
 
             log.info(f"Created {out}")
             created.append(out.resolve())

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -139,6 +139,14 @@ class ZScript:
     # Subcommands that always run inside Docker.
     DOCKER_COMMANDS: frozenset[str | None] = frozenset({"setup", "build", "clean"})
 
+    def required_files_for_release(self) -> list[Path]:
+        """
+        Used by `package()` to verify that the release directory contains the expected files.
+        Leave empty to skip release verification.
+        Expects paths relative to the package root.
+        """
+        return []
+
     def sysroot_required_files(self) -> list[str]:
         """Return the sysroot files required for the current platform and mode.
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -489,6 +489,40 @@ class TestPackage(unittest.TestCase):
                 package([src], dest, "test", formats=42)  # type: ignore
             self.assertEqual(ctx.exception.code, EXIT_INVALID_ARGS)
 
+    def test_require_paths_present(self) -> None:
+        """package() succeeds when required paths are present in archives."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "src"
+            _make_source_tree(src)
+            dest = Path(tmp) / "dist"
+            out = package(
+                [src],
+                dest,
+                "test",
+                require=[Path("hello.txt"), Path("sub/data.bin")],
+            )
+            self.assertEqual(len(out), len(DEFAULT_FORMATS))
+
+    def test_require_missing_path_exits(self) -> None:
+        """package() exits when a required exact path is missing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "src"
+            _make_source_tree(src)
+            dest = Path(tmp) / "dist"
+            with self.assertRaises(SystemExit) as ctx:
+                package([src], dest, "test", require=[Path("missing.txt")])
+            self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
+
+    def test_require_missing_prefix_exits(self) -> None:
+        """package() exits when a required nested path is missing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "src"
+            _make_source_tree(src)
+            dest = Path(tmp) / "dist"
+            with self.assertRaises(SystemExit) as ctx:
+                package([src], dest, "test", require=[Path("nope/x")])
+            self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add optional 'require' kwarg. Runs after each archive is written. Closes #180.

Wire ZScript.required_files_for_release() into package() so downstreams can declare expected release contents.

Follow-up: Reintroduce release verification using this API in downstreams.