### PR TITLE
[zutils] Add SDK update foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
   integration-tests:
     name: Integration Tests (ubuntu-24.04)
     runs-on: ubuntu-24.04
+    outputs:
+      artifacts-available: ${{ steps.artifacts.outputs.available }}
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
@@ -88,8 +90,18 @@ jobs:
       - name: Build & test examples
         run: uv run pytest tests/test_examples.py -v -k "not Cleanup"
 
+      - name: Detect integration artifacts
+        id: artifacts
+        run: |
+          if find examples -type f \( -name '*.elf' -o -name '*.a' \) -print -quit \
+            | grep -q .; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload build artifacts for Windows test
-        if: success()
+        if: steps.artifacts.outputs.available == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: integration-test-artifacts
@@ -107,6 +119,7 @@ jobs:
   integration-tests-windows:
     name: Integration Tests (windows-latest)
     needs: [integration-tests]
+    if: needs.integration-tests.outputs.artifacts-available == 'true'
     runs-on: windows-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/nanvix/toolchain-gcc@sha256:ea33e4cae4041dcf55f0ec49f58de90ae1b5e9fb7c3c507971b40975b14aecd3
+      image: ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
     env:
       NANVIX_TOOLCHAIN: /opt/nanvix
       USER: runner

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ htmlcov/
 /.zed/
 .idea/
 *.swp
+
+# Persistent source-checkout update lock and crash-recovery state.
+/.nanvix-zutil-update.lock
+/.nanvix-zutil-update-journal.json
+/.*.nanvix-zutil-*
 *~
 
 # Downstream test artifacts (generated per-user)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ All code must pass before merging:
 - **Formatting** — `black` with no configuration overrides.
 - **Type checking** — `pyright` in strict mode. Every public function
   needs a complete type signature.
-- **Tests** — `pytest`. Functional tests require the `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`
+- **Tests** — `pytest`. Functional tests require the immutable Nanvix C/Clang SDK
   Docker image.
 - **Docstrings** — all public functions must have docstrings.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ nanvix-zutil test    # run tests
 nanvix-zutil lint            # lint .nanvix/*.py
 nanvix-zutil format          # format .nanvix/*.py
 nanvix-zutil format --check  # verify formatting (non-zero on diff)
+nanvix-zutil update-nanvix --check  # latest verified SDK release
+nanvix-zutil update-zutils --to v0.15.0 --templates-dir /path/to/templates --dry-run
 ```
 
 ## Installation
@@ -107,6 +109,23 @@ Additional references:
 | [Manifest Reference](docs/manifest.md) | `nanvix.toml` format and options |
 | [Local Development (`--with-nanvix`)](docs/with-nanvix.md) | Using local Nanvix builds |
 | [Contributing](CONTRIBUTING.md) | Contribution guidelines and release process |
+
+SDK manifests pin a verified GitHub Release contract and immutable OCI digest.
+`update-nanvix` resolves the latest authoritative release by default (or an
+exact tag/contract with `--to`), verifies its image, strictly resolves exact
+dependency releases, and atomically writes `nanvix.toml` plus the
+provenance-bearing `nanvix.lock`. Missing dependency provenance emits a blocked
+JSON result and writes nothing. Transitional Python/workflow image markers are
+updated only when present.
+
+Canonical `.nanvix/nanvix.lock` files are committed. Only update transaction
+state (`.nanvix-zutil-update.lock` and its journal/sidecars) is ignored.
+
+`update-zutils` verifies the exact release template archive, or a local source
+passed with `--templates-dir`, then atomically replaces `.zutils-version`, all
+three bootstrap scripts, and `.nanvix/.gitignore` while preserving modes and
+line endings. Both commands support `--dry-run`, `--check`,
+`--output-format json`, and `--output`; neither invokes Git.
 
 ## Examples
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -22,6 +22,7 @@ nanvix/<project>/
 └── .nanvix/
     ├── z.py       # ZScript subclass implementing hooks
     ├── nanvix.toml # Declarative dependencies
+    ├── nanvix.lock # Committed exact dependency/SDK provenance
     ├── env.json   # Persistent config (generated)
     ├── venv/      # Auto-created virtualenv
     ├── dist/      # Bundled release artifacts
@@ -29,8 +30,9 @@ nanvix/<project>/
     └── buildroot/ # Downloaded build-time deps
 ```
 
-`nanvix_zutil` creates no files outside `.nanvix/` in consumer repos.
-All artifacts live under `.nanvix/`.
+Build orchestration and update transaction state create no transient files
+outside `.nanvix/` in consumer repositories. The maintenance commands mutate
+only their documented, validated tracked-file allowlists.
 
 ### bootstrappers
 
@@ -51,6 +53,7 @@ The entrypoint for the zutils build system. Contains the following key files:
 | File         | Staged? | What it does                                                                                                       |
 | ------------ | ------- | ------------------------------------------------------------------------------------------------------------------ |
 | nanvix.toml  | ✅      | Hosts the dependencies and valid toolchains for this build. The manifest, similar to Cargo.toml or pyproject.toml. |
+| nanvix.lock  | ✅      | Canonical exact dependency graph and SDK provenance; generated atomically and committed.                         |
 | z.py         | ✅      | Entrypoint for the zutils library. Hosts an implementation of the `ZScript` class in Python.                       |
 | NANVIX.md    | ✅      | (Optional) Information about the port.                                                                             |
 | .gitignore   | ✅      | Ignores transient items - all items listed as "not staged."                                                        |
@@ -100,7 +103,7 @@ Zutils has a multi-phase lifecycle similar to other build tools. Most lifecycle 
 | Stage     | Example call                                              | Standalone? | Overridable? | What it does                                                            |
 | --------- | --------------------------------------------------------- | ----------- | ------------ | ----------------------------------------------------------------------- |
 | Bootstrap | `./z`                                                     | ⭐          | ❌           | Bootstraps the nanvix_zutil virtual environment.                        |
-| Setup     | `./z setup --with-docker nanvix/toolchain:latest-minimal` | ❌          | ❌           | See below.                                                              |
+| Setup     | `./z setup`                                               | ❌          | ❌           | Uses the manifest's immutable SDK build image.                           |
 | Build     | `./z build`                                               | ❌          | ✅           | See below.                                                              |
 | Test      | `./z test`                                                | ❌          | ✅           | Runs project-specific test suites. Should _not_ create build artefacts. |
 | Release   | `./z release`                                             | ✅          | ❌           | Packages build artefacts into tarballs and zip files for distribution. Honours a `release_targets()` override on the consumer's `ZScript` subclass when present. |
@@ -110,6 +113,8 @@ Zutils has a multi-phase lifecycle similar to other build tools. Most lifecycle 
 | Format    | `./z format [--check]`                                    | ✅          | ❌           | Formats python files in `.nanvix` with black. Pass `--check` to verify without modifying (non-zero on diff). |
 | Lint      | `./z lint`                                                | ✅          | ❌           | Lints python files in `.nanvix` with pyright.                           |
 | Info      | `./z info`                                                | ✅          | ❌           | Standalone command that queries GitHub for the relevant release files.  |
+| Update Nanvix | `nanvix-zutil update-nanvix`                           | ✅          | ❌           | Verifies SDK metadata and atomically updates manifest plus lock.         |
+| Update zutils | `nanvix-zutil update-zutils --to vX.Y.Z`                | ✅          | ❌           | Atomically replaces the pin, wrappers, and Nanvix gitignore.             |
 
 #### Bootstrap
 
@@ -131,6 +136,15 @@ Sets up the build environment. By default, this will download the correct nanvix
 1. Download and verify nanvix artefacts (or source locally if `--with-nanvix`)
 2. Resolve and download dependencies against latest release matching the nanvix version.
 3. Persist configuration for `.nanvix/env.json`.
+
+SDK manifests use strict resolution instead: zutils verifies the authoritative
+`sdk-release.json` GitHub Release asset against the immutable Docker digest,
+embedded `/opt/nanvix/nanvix-sdk.json`, and OCI labels. Dependency coordinates
+are exact `<version>-nanvix-<runtime>-sdk.<revision>` tags. Missing exact
+releases return a machine-readable blocked result; fallback is disabled.
+Setup derives Docker from `build-image@build-digest`, or from the SDK image when
+no dedicated build image is present. A conflicting `--with-docker` is rejected
+unless `--allow-local-docker-override` explicitly opts into local development.
 
 #### Build
 
@@ -196,8 +210,11 @@ The Docker build implementation expects certain paths. They are mounted as speci
 
 ## CI and Distribution
 
-Nanvix artefacts, meaning the OS itself alongside all ported libraries and binaries, are hosted on GitHub. Docker containers may be created for toolchains as well, hosted on ghcr.io. Example toolchains are `nanvix/toolchain:latest-minimal`, `nanvix/toolchain-gcc`, `nanvix/toolchain-python`.
+Nanvix artefacts, meaning the OS itself alongside all ported libraries and binaries, are hosted on GitHub. Versioned SDK images are hosted on ghcr.io and consumers pin immutable provider digests such as `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:…`.
 
-In addition, zutils releases trigger automated downstream pull requests to fully replace the bootstrap scripts. This usually just bumps the zutils version. The workflow for this is `nanvix-update-zutils.yml`.
+In addition, zutils releases trigger `update-zutils`, which verifies the exact
+template archive and replaces `.zutils-version`, `z`, `z.sh`, `z.ps1`, and
+`.nanvix/.gitignore` together. The automation workflow is
+`nanvix-update-zutils.yml`.
 
 Downstream consumers of zutils are enumerated at [workflows/consumer-repos.json](https://github.com/nanvix/workflows/blob/main/consumer-repos.json).

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -88,6 +88,28 @@ a machine-readable blocked result.
 The generated `.nanvix/nanvix.lock` is canonical provenance and must be
 committed. Update lock/journal files are transient and remain ignored.
 
+## CI resolver output
+
+`nanvix-zutil resolve` emits stable `key=value` lines. Legacy manifests retain
+the existing `nanvix_*` and `package_*` output exactly. SDK locks additionally
+emit:
+
+```text
+sdk_version
+sdk_provider_id
+sdk_provider
+sdk_image
+sdk_digest
+sdk_image_ref
+sdk_c_abi
+sdk_libc_tag
+sdk_libc_commit
+sdk_sysroot_sha256
+```
+
+These values come from verified lockfile provenance and are suitable for
+appending directly to `$GITHUB_OUTPUT`.
+
 `TAG`, `COMMITISH`, `ID`, and `LOCAL` refs are never suffixed — they
 resolve exactly as written.
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -10,7 +10,14 @@ build-time / runtime dependencies.
 [package]
 name = "hello-world"
 version = "0.1.0"
-nanvix-version = "0.12.257"
+nanvix-version = "0.20.0"
+
+[toolchain]
+kind = "nanvix-sdk"
+provider = "c-clang"
+sdk-version = "v0.20.0-sdk.1"
+sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
 ```
 
 ## `[package]`
@@ -24,6 +31,26 @@ nanvix-version = "0.12.257"
 `nanvix-version` is validated at parse time.  Tables and non-semver
 strings are rejected, with the exception of the literal `"latest"`,
 which resolves to the newest available sysroot release.
+
+## `[toolchain]`
+
+The preferred SDK mode pins the release version, provider, and immutable image
+as one typed coordinate:
+
+```toml
+[toolchain]
+kind = "nanvix-sdk"
+provider = "c-clang"
+sdk-version = "v0.20.0-sdk.1"
+sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+```
+
+The SDK version's runtime must equal `package.nanvix-version`. Optional
+`build-image` and `build-digest` fields select a different immutable image for
+builds; otherwise the SDK image is the effective build image. The early
+`type/version/image/digest` spelling remains readable for one transition
+release. Omitting `[toolchain]` selects legacy resolution.
 
 ## `[dependencies]` and `[system-dependencies]`
 
@@ -54,9 +81,12 @@ zlib = "1.2.3"
 # → resolves tag "1.2.3-nanvix-0.12.257"
 ```
 
-If that exact tag is not found, the resolver scans the repo for the
-newest release matching `1.2.3-nanvix-*` and uses it instead (e.g.
-`1.2.3-nanvix-0.12.291`).
+Legacy mode retains its existing fallback behavior. SDK mode derives the exact
+tag `1.2.3-nanvix-0.20.0-sdk.1`; it never falls back. A missing release yields
+a machine-readable blocked result.
+
+The generated `.nanvix/nanvix.lock` is canonical provenance and must be
+committed. Update lock/journal files are transient and remain ignored.
 
 `TAG`, `COMMITISH`, `ID`, and `LOCAL` refs are never suffixed — they
 resolve exactly as written.
@@ -72,7 +102,14 @@ The `nanvix/cpython` consumer manifest:
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.12.257"
+nanvix-version = "0.20.0"
+
+[toolchain]
+kind = "nanvix-sdk"
+provider = "c-clang"
+sdk-version = "v0.20.0-sdk.1"
+sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
 
 [dependencies]
 zlib = "1.2.3"

--- a/docs/test.md
+++ b/docs/test.md
@@ -68,7 +68,7 @@ filesystem, Docker). These run quickly without network access or Docker.
 projects. It may require:
 
 - Network access (for GitHub API calls)
-- Docker with the `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image
+- Docker with the immutable Nanvix C/Clang SDK image
 
 `test_integration.py` is mock-based and runs without Docker or network
 access.

--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -65,13 +65,14 @@ precedence over version-based resolution.
 cd /path/to/consumer   # e.g. usr/lib/zlib
 
 # Bootstrap venv and install feature-branch zutils
-./z setup --with-docker nanvix/toolchain:latest-minimal
+./z setup
 .nanvix/venv/bin/pip install -e /path/to/zutils
 
 # Clean sysroot and re-run with local override
 rm -rf .nanvix/sysroot .nanvix/env.json
 .nanvix/venv/bin/nanvix-zutil setup \
     --with-docker nanvix/toolchain:latest-minimal \
+    --allow-local-docker-override \
     --with-nanvix ~/src/nanvix/nanvix
 
 # Verify
@@ -92,7 +93,8 @@ cd /path/to/consumer
 PYTHONPATH=~/nanvix/usr/lib/zutils/src \
   python3 -m nanvix_zutil setup \
     --offline \
-    --with-docker ghcr.io/nanvix/toolchain-gcc:latest \
+    --with-docker ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f \
+    --allow-local-docker-override \
     --with-nanvix ~/nanvix/build \
     --sysroot-path ~/nanvix/build/sysroot
 
@@ -108,6 +110,7 @@ The `z.sh` and `z.ps1` wrappers forward `--with-nanvix` directly to
 
 ```bash
 ./z setup --with-docker nanvix/toolchain:latest-minimal \
+    --allow-local-docker-override \
     --with-nanvix ~/src/nanvix/nanvix
 ./z build
 ```

--- a/examples/bin-hello/.nanvix/nanvix.toml
+++ b/examples/bin-hello/.nanvix/nanvix.toml
@@ -1,7 +1,14 @@
 [package]
 name = "bin-hello"
 version = "0.1.0"
-nanvix-version = "0.13.19"
+nanvix-version = "0.20.0"
+
+[toolchain]
+kind = "nanvix-sdk"
+provider = "c-clang"
+sdk-version = "v0.20.0-sdk.1"
+sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
 
 [dependencies]
 lib-hello = { commitish = "HEAD" }

--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -7,7 +7,7 @@ Demonstrates dependency resolution with ``nanvix.toml``.  Run with
 ``--help`` to see available subcommands and Docker flags::
 
     nanvix-zutil setup                     # download sysroot + lib-hello (Docker auto-enabled)
-    nanvix-zutil setup --with-docker IMG   # download sysroot + lib-hello (custom Docker image)
+    nanvix-zutil setup                     # use immutable manifest SDK image
     nanvix-zutil build                     # cross-compile inside Docker container (auto)
     nanvix-zutil test                      # run tests (smoke + integration + functional)
     nanvix-zutil clean                     # remove build artifacts (host)
@@ -85,19 +85,10 @@ class BinHello(ZScript):
     def build(self) -> None:
         """Cross-compile main.c into hello.elf for Nanvix."""
         tc = TOOLCHAIN_CONTAINER_PATH
-        sysroot = self._sysroot()
         buildroot = self._buildroot_path()
-        cc = str(tc / "bin" / "i686-nanvix-gcc")
+        cc = f"{tc}/bin/clang --target=i686-unknown-nanvix --sysroot={tc}"
         cflags = f"-O2 -Wall -msse2 -mfpmath=sse -I{buildroot}/include"
-        ldflags = f"-T{sysroot}/lib/user.ld -static -Wl,-z,noexecstack"
-        libs = (
-            f"-Wl,--start-group"
-            f" {buildroot}/lib/libhello.a"
-            f" {sysroot}/lib/libposix.a"
-            f" {tc}/i686-nanvix/lib/libc.a"
-            f" {tc}/i686-nanvix/lib/libm.a"
-            f" -Wl,--end-group"
-        )
+        libs = f"{buildroot}/lib/libhello.a"
 
         # Single shell invocation so intermediate .o survives across
         # compile and link steps inside the same Docker container.
@@ -105,7 +96,7 @@ class BinHello(ZScript):
             "sh",
             "-c",
             f"{cc} {cflags} -c -o main.o src/main.c"
-            f" && {cc} {cflags} {ldflags} -o hello.elf main.o {libs}",
+            f" && {cc} {cflags} -o hello.elf main.o {libs}",
             cwd=repo_root(),
             docker=self.docker,
         )

--- a/examples/bin-hello/README.md
+++ b/examples/bin-hello/README.md
@@ -23,8 +23,8 @@ bin-hello/
 
 One of:
 
-- **Native toolchain** — `i686-nanvix-gcc` (default path: `/opt/nanvix/`)
-- **Docker** with `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image (pass via `./z setup --with-docker IMAGE`)
+- **Native SDK** — Clang targeting `i686-unknown-nanvix` (default prefix: `/opt/nanvix/`)
+- **Docker** with the immutable `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f` image
 
 ## Running
 

--- a/examples/lib-hello/.nanvix/nanvix.toml
+++ b/examples/lib-hello/.nanvix/nanvix.toml
@@ -1,4 +1,11 @@
 [package]
 name = "lib-hello"
 version = "0.1.0"
-nanvix-version = "0.13.19"
+nanvix-version = "0.20.0"
+
+[toolchain]
+kind = "nanvix-sdk"
+provider = "c-clang"
+sdk-version = "v0.20.0-sdk.1"
+sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -7,7 +7,7 @@ Demonstrates the full lifecycle with a real Nanvix build.  Run with
 ``--help`` to see available subcommands and Docker flags::
 
     nanvix-zutil setup                     # download sysroot (Docker auto-enabled)
-    nanvix-zutil setup --with-docker IMG   # download sysroot (custom Docker image)
+    nanvix-zutil setup                     # use immutable manifest SDK image
     nanvix-zutil build                     # cross-compile inside Docker container (auto)
     nanvix-zutil test                      # run tests (verifies libhello.a)
     nanvix-zutil clean                     # remove build artifacts (host)
@@ -62,8 +62,8 @@ class LibHello(ZScript):
     def build(self) -> None:
         """Cross-compile hello.c into libhello.a for Nanvix."""
         tc = TOOLCHAIN_CONTAINER_PATH
-        cc = str(tc / "bin" / "i686-nanvix-gcc")
-        ar = str(tc / "bin" / "i686-nanvix-ar")
+        cc = f"{tc}/bin/clang --target=i686-unknown-nanvix --sysroot={tc}"
+        ar = str(tc / "bin" / "llvm-ar")
         cflags = "-O2 -Wall -msse2 -mfpmath=sse"
 
         # Single shell invocation so intermediate .o survives across

--- a/examples/lib-hello/README.md
+++ b/examples/lib-hello/README.md
@@ -22,8 +22,8 @@ lib-hello/
 ## Prerequisites
 
 One of:
-- **Native toolchain** — `i686-nanvix-gcc` (default path: `/opt/nanvix/`)
-- **Docker** with `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` image (pass via `./z setup --with-docker IMAGE`)
+- **Native SDK** — Clang targeting `i686-unknown-nanvix` (default prefix: `/opt/nanvix/`)
+- **Docker** with the immutable `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f` image
 
 If you built the Nanvix toolchain locally (e.g. from `nanvix/nanvix`), point
 `NANVIX_TOOLCHAIN` at it:
@@ -32,7 +32,7 @@ If you built the Nanvix toolchain locally (e.g. from `nanvix/nanvix`), point
 export NANVIX_TOOLCHAIN=~/repos/nanvix/nanvix/toolchain
 ```
 
-In CI, the workflow runs inside the `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` Docker
+In CI, the workflow runs inside the pinned Nanvix C/Clang SDK Docker
 container where the toolchain is pre-installed at `/opt/nanvix`.
 
 ## Running
@@ -58,7 +58,7 @@ container where the toolchain is pre-installed at `/opt/nanvix`.
 
 1. **`./z setup`** downloads the Nanvix runtime sysroot from
    `nanvix/nanvix` GitHub releases.
-2. **`./z build`** cross-compiles `src/hello.c` using `i686-nanvix-gcc`
+2. **`./z build`** cross-compiles `src/hello.c` using the SDK's Clang
    and archives the object into `libhello.a`.
 3. **`./z test`** runs smoke tests (archive exists) and integration tests
    (valid ar archive magic).

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -11,6 +11,10 @@ Public re-exports:
 - :class:`~nanvix_zutil.buildroot.Dependency` — library dependency descriptor
 - :class:`~nanvix_zutil.sysroot.Sysroot` — runtime sysroot management
 - :class:`~nanvix_zutil.manifest.Manifest` — parsed TOML manifest
+- :class:`~nanvix_zutil.manifest.Toolchain` — typed legacy/SDK selection
+- :class:`~nanvix_zutil.manifest.SdkPin` — immutable manifest SDK coordinate
+- :class:`~nanvix_zutil.sdk.SdkRelease` — verified SDK release contract
+- :class:`~nanvix_zutil.sdk.SdkProvenance` — lockfile SDK provenance
 - :func:`~nanvix_zutil.manifest.load_manifest` — parse nanvix.toml
 - :class:`~nanvix_zutil.lockfile.Lockfile` — resolved dependency graph
 - :class:`~nanvix_zutil.lockfile.ResolvedPackage` — a resolved dependency
@@ -81,7 +85,11 @@ from nanvix_zutil.exitcodes import (
     EXIT_SUCCESS,
     EXIT_TEST_FAILURE,
 )
-from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
+from nanvix_zutil.github import (
+    resolve_commit,
+    resolve_release,
+    resolve_release_with_fallback,
+)
 from nanvix_zutil.helpers import (
     InitRdArgs,
     ensure_tool_installed,
@@ -95,17 +103,39 @@ from nanvix_zutil.lockfile import (
     ResolvedAsset,
     ResolvedPackage,
     read_lockfile,
+    serialize_lockfile,
     write_lockfile,
 )
-from nanvix_zutil.manifest import Manifest, load_manifest
+from nanvix_zutil.manifest import (
+    Manifest,
+    SdkPin,
+    Toolchain,
+    ToolchainKind,
+    load_manifest,
+)
 from nanvix_zutil.release import DEFAULT_FORMATS, ArchiveFormat, package
-from nanvix_zutil.resolver import is_stale, resolve
+from nanvix_zutil.resolver import BlockedResolution, is_stale, resolve
+from nanvix_zutil.sdk import (
+    SDK_RELEASE_ASSET,
+    SdkImage,
+    SdkProvenance,
+    SdkRelease,
+    SdkValidationError,
+    consumer_release_tag,
+    parse_sdk_version,
+    resolve_sdk_release,
+    sdk_consumer_release_tag,
+    validate_sdk_release,
+    verify_sdk_image,
+    verify_sdk_metadata,
+)
 from nanvix_zutil.script import ZScript
 from nanvix_zutil.sysroot import Sysroot
 
 __all__ = [
     "ArchiveFormat",
     "Buildroot",
+    "BlockedResolution",
     "BUILDROOT_CONTAINER_PATH",
     "CFG_DOCKER_IMAGE",
     "CFG_GH_TOKEN",
@@ -135,15 +165,24 @@ __all__ = [
     "RefKind",
     "ResolvedAsset",
     "ResolvedPackage",
+    "SDK_RELEASE_ASSET",
+    "SdkImage",
+    "SdkPin",
+    "SdkProvenance",
+    "SdkRelease",
+    "SdkValidationError",
     "SYSROOT_CONTAINER_PATH",
     "TOOLCHAIN_CONTAINER_PATH",
     "WORKSPACE_CONTAINER_PATH",
     "Sysroot",
+    "Toolchain",
+    "ToolchainKind",
     "ZScript",
     "is_windows",
     "ensure_tool_installed",
     "extract_nanvix_version",
     "extract_nanvix_version_base",
+    "consumer_release_tag",
     "get_nanvix_info",
     "is_stale",
     "load_manifest",
@@ -151,12 +190,20 @@ __all__ = [
     "package",
     "parse_semver_tuple",
     "read_lockfile",
+    "serialize_lockfile",
     "resolve",
+    "resolve_commit",
     "resolve_release",
     "resolve_release_with_fallback",
+    "resolve_sdk_release",
     "run",
     "suffix_dep",
+    "sdk_consumer_release_tag",
     "sync_configs",
     "write_lockfile",
     "InitRdArgs",
+    "parse_sdk_version",
+    "validate_sdk_release",
+    "verify_sdk_metadata",
+    "verify_sdk_image",
 ]

--- a/src/nanvix_zutil/__main__.py
+++ b/src/nanvix_zutil/__main__.py
@@ -20,6 +20,8 @@ from nanvix_zutil.commands import (
     lint,
     release,
     resolve,
+    update_nanvix,
+    update_zutils,
 )
 from nanvix_zutil.config import ENV_VARS
 from nanvix_zutil.exitcodes import (
@@ -39,6 +41,8 @@ _STANDALONE_HELP: dict[str, str] = {
     "lint": lint.HELP,
     "release": release.HELP,
     "resolve": resolve.HELP,
+    "update-nanvix": update_nanvix.HELP,
+    "update-zutils": update_zutils.HELP,
 }
 
 
@@ -201,6 +205,20 @@ def main() -> None:
 
         sys.argv = ["nanvix-zutil release", *remaining]
         release_main()
+        return
+
+    if subcmd == "update-nanvix":
+        from nanvix_zutil.commands.update_nanvix import main as update_nanvix_main
+
+        sys.argv = ["nanvix-zutil update-nanvix", *remaining]
+        update_nanvix_main()
+        return
+
+    if subcmd == "update-zutils":
+        from nanvix_zutil.commands.update_zutils import main as update_zutils_main
+
+        sys.argv = ["nanvix-zutil update-zutils", *remaining]
+        update_zutils_main()
         return
 
     if subcmd == "help":

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -63,9 +63,9 @@ SUBCOMMANDS: tuple[str, ...] = (
 
 #: Subcommands that accept the ``--with-docker`` flag.
 #:
-#: ``--with-docker IMAGE`` is required on ``setup`` to specify the Docker
-#: image.  ``build`` and ``clean`` load the image from persisted config
-#: (set during ``setup``).
+#: SDK manifests supply their immutable build image. Legacy manifests use
+#: ``--with-docker IMAGE`` on setup. ``build`` and ``clean`` load the persisted
+#: effective image.
 DOCKER_SUBCOMMANDS: tuple[str, ...] = ("setup",)
 
 #: Human-readable descriptions for each subcommand.
@@ -156,7 +156,7 @@ def build_parser(
             sub.add_argument(
                 "--with-docker",
                 type=str,
-                required=True,
+                required=False,
                 metavar="IMAGE",
                 dest="with_docker",
                 help="Docker image to use for containerised builds."
@@ -164,6 +164,13 @@ def build_parser(
                 " subsequent build/clean commands use it"
                 " automatically. test and benchmark always run on"
                 " the host.",
+            )
+            sub.add_argument(
+                "--allow-local-docker-override",
+                action="store_true",
+                default=False,
+                help="Explicitly allow --with-docker to override the immutable"
+                " SDK build image for local development.",
             )
             sub.add_argument(
                 "--offline",

--- a/src/nanvix_zutil/commands/resolve.py
+++ b/src/nanvix_zutil/commands/resolve.py
@@ -6,14 +6,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP, EXIT_SUCCESS
-from nanvix_zutil.manifest import load_manifest
+from nanvix_zutil.manifest import ToolchainKind, load_manifest
 from nanvix_zutil.paths import manifest_path
-from nanvix_zutil.resolver import resolve
+from nanvix_zutil.resolver import BlockedResolution, resolve
 
 HELP: str = "Resolve manifest and emit CI-ready metadata"
 """One-line description surfaced in ``nanvix-zutil --help``."""
@@ -67,7 +68,11 @@ def main() -> None:
         manifest,
         gh_token=gh_token,
         shallow=args.shallow,
+        strict=manifest.toolchain.kind == ToolchainKind.SDK,
     )
+    if isinstance(lockfile, BlockedResolution):
+        print(json.dumps(lockfile.to_dict(), sort_keys=True))
+        sys.exit(EXIT_MISSING_DEP)
 
     sysroot = next(
         (p for p in lockfile.packages if p.kind == "sysroot"),

--- a/src/nanvix_zutil/commands/resolve.py
+++ b/src/nanvix_zutil/commands/resolve.py
@@ -92,6 +92,22 @@ def main() -> None:
         "package_name": manifest.name,
         "package_version": manifest.version,
     }
+    sdk = lockfile.metadata.sdk
+    if sdk is not None:
+        result.update(
+            {
+                "sdk_version": sdk.sdk_version,
+                "sdk_provider_id": sdk.provider_id,
+                "sdk_provider": sdk.provider,
+                "sdk_image": sdk.image.name,
+                "sdk_digest": sdk.image.digest,
+                "sdk_image_ref": sdk.image.ref,
+                "sdk_c_abi": str(sdk.compat["c_abi"]),
+                "sdk_libc_tag": sdk.nanvix_tag,
+                "sdk_libc_commit": sdk.nanvix_commit,
+                "sdk_sysroot_sha256": sdk.sysroot_sha256,
+            }
+        )
 
     for key, value in result.items():
         print(f"{key}={value}")

--- a/src/nanvix_zutil/commands/update_nanvix.py
+++ b/src/nanvix_zutil/commands/update_nanvix.py
@@ -1,0 +1,589 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Atomically update coherent Nanvix SDK, runtime, and dependency pins."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import shutil
+import sys
+import tomllib
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+
+from nanvix_zutil.buildroot import Dependency, Ref, RefKind
+from nanvix_zutil.exitcodes import (
+    EXIT_GENERAL_ERROR,
+    EXIT_INVALID_ARGS,
+    EXIT_MISSING_DEP,
+    EXIT_SUCCESS,
+)
+from nanvix_zutil.lockfile import serialize_lockfile
+from nanvix_zutil.manifest import (
+    Manifest,
+    SdkPin,
+    Toolchain,
+    ToolchainKind,
+    load_manifest,
+)
+from nanvix_zutil.resolver import BlockedResolution, resolve
+from nanvix_zutil.sdk import SdkRelease, resolve_sdk_release, verify_sdk_image
+from nanvix_zutil.updater import (
+    UpdateTransaction,
+    UpdateError,
+    UpdateResult,
+    emit_result,
+    find_target_root,
+    is_zutils_source,
+    load_sdk_target,
+    update_transaction,
+)
+
+HELP = "Atomically update verified Nanvix SDK, runtime, and dependency pins"
+
+_VERSION_LINE = re.compile(
+    r'^(?P<prefix>\s*nanvix-version\s*=\s*")[^"]*(?P<suffix>".*)$',
+    re.MULTILINE,
+)
+_SDK_ASSIGNMENT = re.compile(
+    r'^(?P<prefix>\s*NANVIX_SDK_IMAGE\s*(?::\s*str\s*)?=\s*")[^"]*(?P<suffix>".*)$',
+    re.MULTILINE,
+)
+_DOCKER_IMAGE = re.compile(
+    r"^(?P<prefix>\s*docker-image\s*:\s*)(?P<quote>[\"']?)"
+    r"(?P<value>[^\"'\s#]+)(?P=quote)(?P<suffix>\s*(?:#.*)?)$",
+    re.MULTILINE,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the ``update-nanvix`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="nanvix-zutil update-nanvix",
+        description=(
+            "Resolve an authoritative SDK release, build a strict dependency"
+            " lock, and atomically update all coherent local pins."
+        ),
+    )
+    parser.add_argument(
+        "--to",
+        metavar="SDK_TAG_OR_CONTRACT",
+        help="SDK tag, local sdk-release.json, or inline contract."
+        " Defaults to the latest authoritative SDK GitHub Release.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--output-format", choices=("text", "json"), default="text")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _paths(root: Path) -> tuple[list[Path], list[Path], list[Path]]:
+    """Return exact manifest and optional transitional-marker paths."""
+    if is_zutils_source(root):
+        return (
+            [
+                Path("examples/bin-hello/.nanvix/nanvix.toml"),
+                Path("examples/lib-hello/.nanvix/nanvix.toml"),
+            ],
+            [
+                Path("examples/bin-hello/.nanvix/z.py"),
+                Path("examples/lib-hello/.nanvix/z.py"),
+            ],
+            [Path("templates/nanvix-ci.yml")],
+        )
+    return (
+        [Path(".nanvix/nanvix.toml")],
+        [Path(".nanvix/z.py")],
+        [Path(".github/workflows/nanvix-ci.yml")],
+    )
+
+
+def _replace_exact(
+    pattern: re.Pattern[str],
+    text: str,
+    value: str,
+    label: str,
+) -> str:
+    """Replace exactly one quoted assignment."""
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise UpdateError(
+            f"{label}: expected exactly one assignment, found {len(matches)}"
+        )
+    return pattern.sub(
+        lambda match: f'{match.group("prefix")}{value}{match.group("suffix")}',
+        text,
+        count=1,
+    )
+
+
+def _canonical_toolchain_block(
+    text: str,
+    sdk: SdkRelease,
+    existing_pin: SdkPin | None = None,
+) -> str:
+    """Replace or append the canonical ``[toolchain]`` SDK table."""
+    newline = "\r\n" if "\r\n" in text else "\n"
+    lines = text.splitlines(keepends=True)
+    header = re.compile(r"^\s*\[([^\]]+)\]\s*(?:#.*)?(?:\r?\n)?$")
+    start: int | None = None
+    end = len(lines)
+    for index, line in enumerate(lines):
+        match = header.match(line)
+        if match is None:
+            continue
+        if start is None and match.group(1).strip() == "toolchain":
+            start = index
+            continue
+        if start is not None:
+            if match.group(1).strip().startswith("toolchain."):
+                continue
+            end = index
+            break
+    block = (
+        f"[toolchain]{newline}"
+        f'kind = "nanvix-sdk"{newline}'
+        f'provider = "{sdk.provider_id}"{newline}'
+        f'sdk-version = "{sdk.sdk_version}"{newline}'
+        f'sdk-image = "{sdk.image.name}"{newline}'
+        f'sdk-digest = "{sdk.image.digest}"{newline}'
+    )
+    if (
+        existing_pin is not None
+        and existing_pin.build_image is not None
+        and existing_pin.build_digest is not None
+    ):
+        block += (
+            f'build-image = "{existing_pin.build_image}"{newline}'
+            f'build-digest = "{existing_pin.build_digest}"{newline}'
+        )
+    if start is None:
+        separator = "" if text.endswith(("\n", "\r")) else newline
+        return f"{text}{separator}{newline}{block}"
+    if end < len(lines):
+        block += newline
+    lines[start:end] = [block]
+    return "".join(lines)
+
+
+def _update_manifest(
+    content: bytes,
+    sdk: SdkRelease,
+    existing_pin: SdkPin | None = None,
+) -> bytes:
+    """Create the complete canonical manifest candidate."""
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise UpdateError("nanvix.toml is not UTF-8") from exc
+    text = _replace_exact(
+        _VERSION_LINE,
+        text,
+        sdk.runtime_version,
+        "nanvix.toml",
+    )
+    return _canonical_toolchain_block(text, sdk, existing_pin).encode("utf-8")
+
+
+def _sdk_pin(
+    sdk: SdkRelease,
+    existing_pin: SdkPin | None = None,
+) -> SdkPin:
+    """Build the typed manifest pin for a verified release."""
+    return SdkPin(
+        version=sdk.sdk_version,
+        provider_id=sdk.provider_id,
+        image=sdk.image.name,
+        digest=sdk.image.digest,
+        build_image=existing_pin.build_image if existing_pin is not None else None,
+        build_digest=(existing_pin.build_digest if existing_pin is not None else None),
+    )
+
+
+def _retarget_dependency(dep: Dependency, sdk: SdkRelease) -> Dependency:
+    """Retarget a version dependency to the selected SDK revision."""
+    if dep.ref.kind != RefKind.VERSION or not isinstance(dep.ref.value, str):
+        return dep
+    base = dep.ref.value.split("-nanvix-", maxsplit=1)[0]
+    return replace(
+        dep,
+        ref=Ref(
+            RefKind.VERSION,
+            f"{base}-nanvix-{sdk.sdk_version.removeprefix('v')}",
+        ),
+    )
+
+
+def _candidate_manifest(
+    current: Manifest,
+    sdk: SdkRelease,
+) -> Manifest:
+    """Retarget a parsed manifest to a verified SDK release."""
+    return replace(
+        current,
+        sysroot_ref=Ref(RefKind.TAG, sdk.runtime_version),
+        dependencies=[_retarget_dependency(dep, sdk) for dep in current.dependencies],
+        system_dependencies=[
+            _retarget_dependency(dep, sdk) for dep in current.system_dependencies
+        ],
+        toolchain=Toolchain(
+            ToolchainKind.SDK,
+            _sdk_pin(sdk, current.toolchain.sdk),
+        ),
+    )
+
+
+def _validate_manifest_candidate(
+    content: bytes,
+    sdk: SdkRelease,
+    pin: SdkPin | None = None,
+) -> None:
+    """Validate the canonical manifest table before any target write."""
+    try:
+        data = tomllib.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise UpdateError(f"candidate nanvix.toml is invalid: {exc}") from exc
+    package = data.get("package")
+    if (
+        not isinstance(package, dict)
+        or cast("dict[str, object]", package).get("nanvix-version")
+        != sdk.runtime_version
+    ):
+        raise UpdateError("candidate manifest runtime does not match the SDK")
+    expected: dict[str, object] = {
+        "kind": "nanvix-sdk",
+        "provider": sdk.provider_id,
+        "sdk-version": sdk.sdk_version,
+        "sdk-image": sdk.image.name,
+        "sdk-digest": sdk.image.digest,
+    }
+    if pin is not None and pin.build_image is not None and pin.build_digest is not None:
+        expected["build-image"] = pin.build_image
+        expected["build-digest"] = pin.build_digest
+    if data.get("toolchain") != expected:
+        raise UpdateError("candidate manifest toolchain table is not canonical")
+
+
+def _tuple_from_manifest(manifest: Manifest) -> dict[str, object]:
+    """Return the current coherent pin tuple for machine output."""
+    pin = manifest.toolchain.sdk
+    return {
+        "nanvix_version": str(manifest.sysroot_ref.value).removeprefix("v"),
+        "sdk_version": pin.version if pin is not None else None,
+        "sdk_image": pin.image_ref if pin is not None else None,
+        "build_image": pin.effective_build_ref if pin is not None else None,
+    }
+
+
+def _tuple_from_sdk(sdk: SdkRelease) -> dict[str, object]:
+    """Return the selected coherent pin tuple for machine output."""
+    return {
+        "nanvix_version": sdk.runtime_version,
+        "nanvix_tag": cast(str, sdk.libc["nanvix_tag"]),
+        "sdk_version": sdk.sdk_version,
+        "sdk_image": sdk.image.ref,
+        "build_image": sdk.image.ref,
+        "provider": sdk.provider_id,
+    }
+
+
+def _resolve_target(value: str | None, root: Path, gh_token: str | None) -> SdkRelease:
+    """Resolve local/inline input or an authoritative GitHub SDK Release."""
+    if value is not None:
+        local = load_sdk_target(value, root)
+        if local is not None:
+            verify_sdk_image(local, pull=False)
+            return local
+    return resolve_sdk_release(
+        value or "latest",
+        gh_token=gh_token,
+        verify_image=True,
+    )
+
+
+def _optional_marker_candidates(
+    root: Path,
+    scripts: list[Path],
+    workflows: list[Path],
+    old_images: set[str],
+    new_image: str,
+) -> tuple[dict[Path, bytes], dict[Path, Callable[[bytes], None]]]:
+    """Update transitional image markers only where they already exist."""
+    candidates: dict[Path, bytes] = {}
+    validators: dict[Path, Callable[[bytes], None]] = {}
+    for relative in scripts:
+        path = root / relative
+        if not path.is_file():
+            continue
+        text = path.read_bytes().decode("utf-8")
+        try:
+            ast.parse(text, filename=relative.as_posix())
+        except SyntaxError as exc:
+            raise UpdateError(f"{relative}: invalid Python: {exc}") from exc
+        matches = list(_SDK_ASSIGNMENT.finditer(text))
+        if len(matches) > 1:
+            raise UpdateError(f"{relative}: multiple transitional SDK markers")
+        if not matches:
+            continue
+        current = matches[0].group(0)
+        prefix = len(matches[0].group("prefix"))
+        suffix = len(matches[0].group("suffix"))
+        current_image = current[prefix : len(current) - suffix]
+        if old_images and current_image not in old_images:
+            raise UpdateError(f"{relative}: SDK marker disagrees with the manifest")
+        candidate = _replace_exact(
+            _SDK_ASSIGNMENT,
+            text,
+            new_image,
+            relative.as_posix(),
+        ).encode("utf-8")
+        candidates[relative] = candidate
+
+        def validate_script(
+            value: bytes,
+            label: str = relative.as_posix(),
+            expected: str = new_image,
+        ) -> None:
+            rendered = value.decode("utf-8")
+            ast.parse(rendered, filename=label)
+            matches = list(_SDK_ASSIGNMENT.finditer(rendered))
+            if len(matches) != 1 or expected not in matches[0].group(0):
+                raise UpdateError(f"{label}: invalid transitional SDK marker")
+
+        validators[relative] = validate_script
+
+    for relative in workflows:
+        path = root / relative
+        if not path.is_file():
+            continue
+        text = path.read_bytes().decode("utf-8")
+        matches = list(_DOCKER_IMAGE.finditer(text))
+        if not matches:
+            continue
+        current_images = {match.group("value") for match in matches}
+        if len(current_images) != 1 or (
+            old_images and not current_images.issubset(old_images)
+        ):
+            raise UpdateError(f"{relative}: docker-image inputs disagree")
+        candidate = _DOCKER_IMAGE.sub(
+            lambda match: (
+                f'{match.group("prefix")}{match.group("quote")}{new_image}'
+                f'{match.group("quote")}{match.group("suffix")}'
+            ),
+            text,
+        ).encode("utf-8")
+        candidates[relative] = candidate
+
+        def validate_workflow(
+            value: bytes,
+            label: str = relative.as_posix(),
+            expected: str = new_image,
+            count: int = len(matches),
+        ) -> None:
+            images = [
+                match.group("value")
+                for match in _DOCKER_IMAGE.finditer(value.decode("utf-8"))
+            ]
+            if len(images) != count or any(image != expected for image in images):
+                raise UpdateError(f"{label}: invalid docker-image candidate")
+
+        validators[relative] = validate_workflow
+    return candidates, validators
+
+
+def _run_locked(
+    args: argparse.Namespace,
+    root: Path,
+    transaction: UpdateTransaction,
+) -> tuple[UpdateResult, int]:
+    """Resolve and apply an SDK update under a recovered transaction lock."""
+    gh_token = os.environ.get("GH_TOKEN")
+    sdk = _resolve_target(args.to, root, gh_token)
+    manifests, scripts, workflows = _paths(root)
+    candidates: dict[Path, bytes] = {}
+    validators: dict[Path, Callable[[bytes], None]] = {}
+    old_tuples: list[dict[str, object]] = []
+    old_images: set[str] = set()
+    new_build_images: set[str] = set()
+    new_tuple = _tuple_from_sdk(sdk)
+
+    for relative in manifests:
+        path = root / relative
+        current = load_manifest(path)
+        old_tuples.append(_tuple_from_manifest(current))
+        current_pin = current.toolchain.sdk
+        if (
+            current_pin is not None
+            and current_pin.build_image is not None
+            and current_pin.version != sdk.sdk_version
+        ):
+            return (
+                UpdateResult(
+                    command="update-nanvix",
+                    status="blocked",
+                    target=sdk.sdk_version,
+                    changed_files=(),
+                    old={"manifests": old_tuples},
+                    new=new_tuple,
+                    blocker={
+                        "status": "blocked",
+                        "reason": "derived-build-image-update-required",
+                        "build_image": current_pin.effective_build_ref,
+                    },
+                ),
+                EXIT_MISSING_DEP,
+            )
+        if current.toolchain.sdk is not None:
+            old_images.add(current.toolchain.sdk.effective_build_ref)
+        manifest_bytes = _update_manifest(path.read_bytes(), sdk, current_pin)
+        candidate_pin = _sdk_pin(sdk, current_pin)
+        new_build_images.add(candidate_pin.effective_build_ref)
+        _validate_manifest_candidate(manifest_bytes, sdk, candidate_pin)
+        candidate_manifest = _candidate_manifest(current, sdk)
+        cache_dir = path.parent / "cache" / f"update-nanvix-{os.getpid()}"
+        try:
+            lock = resolve(
+                candidate_manifest,
+                gh_token=gh_token,
+                cache_dir=cache_dir,
+                strict=True,
+                verified_sdk_release=sdk,
+                manifest_content=manifest_bytes,
+            )
+        finally:
+            shutil.rmtree(cache_dir, ignore_errors=True)
+        if isinstance(lock, BlockedResolution):
+            result = UpdateResult(
+                command="update-nanvix",
+                status="blocked",
+                target=sdk.sdk_version,
+                changed_files=(),
+                old={"manifests": old_tuples},
+                new=new_tuple,
+                blocker=lock.to_dict(),
+            )
+            return result, EXIT_MISSING_DEP
+        lock_relative = relative.with_name("nanvix.lock")
+        lock_bytes = serialize_lockfile(lock)
+        candidates[relative] = manifest_bytes
+        candidates[lock_relative] = lock_bytes
+
+        def validate_manifest(
+            value: bytes,
+            release: SdkRelease = sdk,
+            expected_pin: SdkPin = candidate_pin,
+        ) -> None:
+            _validate_manifest_candidate(value, release, expected_pin)
+
+        def validate_lock(
+            value: bytes,
+            release: SdkRelease = sdk,
+        ) -> None:
+            try:
+                parsed = tomllib.loads(value.decode("utf-8"))
+            except (UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+                raise UpdateError(f"candidate nanvix.lock is invalid: {exc}") from exc
+            metadata = parsed.get("metadata")
+            if not isinstance(metadata, dict):
+                raise UpdateError("candidate lock is missing metadata")
+            sdk_data = cast("dict[str, object]", metadata).get("sdk")
+            if (
+                not isinstance(sdk_data, dict)
+                or cast("dict[str, object]", sdk_data).get("sdk-version")
+                != release.sdk_version
+            ):
+                raise UpdateError("candidate lock is missing SDK provenance")
+
+        validators[relative] = validate_manifest
+        validators[lock_relative] = validate_lock
+
+    if len(new_build_images) != 1:
+        raise UpdateError("candidate manifests disagree on the effective build image")
+    new_build_image = next(iter(new_build_images))
+    new_tuple["build_image"] = new_build_image
+    marker_candidates, marker_validators = _optional_marker_candidates(
+        root,
+        scripts,
+        workflows,
+        old_images,
+        new_build_image,
+    )
+    candidates.update(marker_candidates)
+    validators.update(marker_validators)
+
+    if args.dry_run or args.check:
+        changed = tuple(
+            sorted(
+                path.as_posix()
+                for path, content in candidates.items()
+                if not (root / path).is_file() or (root / path).read_bytes() != content
+            )
+        )
+        for path, validator in validators.items():
+            validator(candidates[path])
+    else:
+        changed = transaction.install(candidates, validators)
+    status = (
+        "up-to-date"
+        if not changed
+        else "outdated" if args.check else "would-update" if args.dry_run else "updated"
+    )
+    result = UpdateResult(
+        command="update-nanvix",
+        status=status,
+        target=sdk.sdk_version,
+        changed_files=changed,
+        old={"manifests": old_tuples},
+        new=new_tuple,
+    )
+    return result, EXIT_GENERAL_ERROR if args.check and changed else EXIT_SUCCESS
+
+
+def _run(args: argparse.Namespace) -> tuple[UpdateResult, int]:
+    """Recover managed files before parsing and hold the update lock."""
+    if args.check and args.dry_run:
+        raise UpdateError("--check and --dry-run are mutually exclusive")
+    root = find_target_root()
+    with update_transaction(root) as transaction:
+        return _run_locked(args, root, transaction)
+
+
+def main() -> None:
+    """Entry point for ``nanvix-zutil update-nanvix``."""
+    parser = _build_parser()
+    args = parser.parse_args()
+    try:
+        result, code = _run(args)
+        emit_result(
+            result,
+            output_format=args.output_format,
+            output=args.output,
+        )
+        sys.exit(code)
+    except (OSError, UpdateError) as exc:
+        if args.output_format == "json":
+            print(
+                json.dumps(
+                    {
+                        "level": "error",
+                        "code": EXIT_INVALID_ARGS,
+                        "message": str(exc),
+                    },
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        sys.exit(EXIT_INVALID_ARGS)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nanvix_zutil/commands/update_zutils.py
+++ b/src/nanvix_zutil/commands/update_zutils.py
@@ -1,0 +1,350 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Atomically update zutils pins and verified bootstrap templates."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from collections.abc import Callable
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+from nanvix_zutil import github
+from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR, EXIT_INVALID_ARGS, EXIT_SUCCESS
+from nanvix_zutil.updater import (
+    UpdateError,
+    UpdateResult,
+    UpdateTransaction,
+    emit_result,
+    find_target_root,
+    is_zutils_source,
+    update_transaction,
+)
+from nanvix_zutil.utils import SEMVER_RE
+
+HELP = "Atomically update zutils pins and verified bootstrap templates"
+
+_TEMPLATE_ASSET = "templates.zip"
+_TEMPLATE_NAMES = (
+    ".zutils-version",
+    "z",
+    "z.sh",
+    "z.ps1",
+    ".gitignore",
+)
+_SOURCE_SENTINEL = "nanvix-ci.yml"
+_SOURCE_NAMES = (*_TEMPLATE_NAMES, _SOURCE_SENTINEL)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the ``update-zutils`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="nanvix-zutil update-zutils",
+        description=(
+            "Atomically update the zutils pin and bootstrap files from an exact"
+            " release archive or a verified local templates source."
+        ),
+    )
+    parser.add_argument("--to", required=True, metavar="VERSION")
+    parser.add_argument(
+        "--templates-dir",
+        type=Path,
+        help="Local zutils templates directory for offline/testing use.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--output-format", choices=("text", "json"), default="text")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _validate_template_map(
+    templates: dict[str, bytes],
+    target: str,
+) -> dict[str, bytes]:
+    """Validate a complete template source for the exact target release."""
+    missing = sorted(set(_SOURCE_NAMES) - templates.keys())
+    if missing:
+        raise UpdateError(f"template source is missing: {', '.join(missing)}")
+    result: dict[str, bytes] = {}
+    for name in _SOURCE_NAMES:
+        content = templates[name]
+        try:
+            content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise UpdateError(f"template {name!r} is not UTF-8") from exc
+        result[name] = content
+    pin = result[".zutils-version"].decode("utf-8").strip()
+    if pin != target:
+        raise UpdateError(
+            f"template source targets {pin!r}, expected exact release {target!r}"
+        )
+    if not result["z"].startswith(b"#!") or not result["z.sh"].startswith(b"#!"):
+        raise UpdateError("z and z.sh templates must have shebangs")
+    if not result["z.ps1"].strip():
+        raise UpdateError("z.ps1 template is empty")
+    if b"nanvix/workflows" not in result[_SOURCE_SENTINEL]:
+        raise UpdateError("nanvix-ci.yml is not a zutils workflow template")
+    return result
+
+
+def _templates_from_directory(path: Path, target: str) -> dict[str, bytes]:
+    """Read and verify a local zutils templates source."""
+    try:
+        root = path.expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise UpdateError(f"templates directory does not exist: {path}") from exc
+    if not root.is_dir():
+        raise UpdateError(f"templates source is not a directory: {root}")
+    templates: dict[str, bytes] = {}
+    for name in _SOURCE_NAMES:
+        source = root / name
+        if not source.is_file() or source.is_symlink():
+            raise UpdateError(f"invalid or missing template: {source}")
+        templates[name] = source.read_bytes()
+    return _validate_template_map(templates, target)
+
+
+def _release_asset(release: dict[str, object], target: str) -> tuple[str, str]:
+    """Return the unique exact template archive URL and SHA-256 digest."""
+    if release.get("tag_name") != target:
+        raise UpdateError("resolved zutils release tag does not match --to")
+    raw_assets = release.get("assets")
+    if not isinstance(raw_assets, list):
+        raise UpdateError("zutils release has no assets")
+    matches: list[tuple[str, str]] = []
+    for item in cast("list[object]", raw_assets):
+        if not isinstance(item, dict):
+            continue
+        asset = cast("dict[str, object]", item)
+        if asset.get("name") != _TEMPLATE_ASSET:
+            continue
+        url = asset.get("browser_download_url")
+        digest = asset.get("digest")
+        if isinstance(url, str) and isinstance(digest, str):
+            matches.append((url, digest))
+    if len(matches) != 1:
+        raise UpdateError(f"zutils release must contain exactly one {_TEMPLATE_ASSET}")
+    url, digest = matches[0]
+    if re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None:
+        raise UpdateError("zutils template asset has no valid SHA-256 digest")
+    return url, digest
+
+
+def _download_archive(url: str, gh_token: str | None) -> bytes:
+    """Download a release template archive into memory."""
+    headers = {"Accept": "application/octet-stream", "User-Agent": "nanvix-zutil"}
+    if gh_token:
+        headers["Authorization"] = f"Bearer {gh_token}"
+    try:
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=30.0) as response:
+            return response.read()
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise UpdateError(f"failed to download zutils templates: {exc}") from exc
+
+
+def _verify_archive_digest(data: bytes, expected: str) -> None:
+    """Require downloaded archive bytes to match GitHub's asset digest."""
+    actual = f"sha256:{hashlib.sha256(data).hexdigest()}"
+    if actual != expected:
+        raise UpdateError(
+            f"zutils template archive digest mismatch: expected {expected},"
+            f" got {actual}"
+        )
+
+
+def _templates_from_archive(data: bytes, target: str) -> dict[str, bytes]:
+    """Safely extract required templates from an in-memory ZIP archive."""
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(data))
+    except (zipfile.BadZipFile, OSError) as exc:
+        raise UpdateError("zutils template archive is malformed") from exc
+    templates: dict[str, bytes] = {}
+    with archive:
+        for info in archive.infolist():
+            path = PurePosixPath(info.filename)
+            if info.is_dir():
+                continue
+            if path.is_absolute() or ".." in path.parts:
+                raise UpdateError("zutils template archive contains an unsafe path")
+            name = path.name
+            if name not in _SOURCE_NAMES:
+                continue
+            if name in templates:
+                raise UpdateError(f"duplicate template {name!r} in archive")
+            if info.external_attr >> 16 & 0o170000 == 0o120000:
+                raise UpdateError(f"template {name!r} is a symlink")
+            templates[name] = archive.read(info)
+    return _validate_template_map(templates, target)
+
+
+def _resolve_templates(
+    target: str,
+    templates_dir: Path | None,
+) -> dict[str, bytes]:
+    """Resolve local templates or the exact release archive."""
+    if templates_dir is not None:
+        return _templates_from_directory(templates_dir, target)
+    gh_token = os.environ.get("GH_TOKEN")
+    release = github.resolve_release("nanvix/zutils", target, gh_token=gh_token)
+    url, digest = _release_asset(release, target)
+    archive = _download_archive(url, gh_token)
+    _verify_archive_digest(archive, digest)
+    return _templates_from_archive(archive, target)
+
+
+def _target_maps(root: Path) -> list[dict[str, Path]]:
+    """Return exact source-name to target-path maps."""
+    if not is_zutils_source(root):
+        return [
+            {
+                ".zutils-version": Path(".zutils-version"),
+                "z": Path("z"),
+                "z.sh": Path("z.sh"),
+                "z.ps1": Path("z.ps1"),
+                ".gitignore": Path(".nanvix/.gitignore"),
+            }
+        ]
+    maps: list[dict[str, Path]] = [
+        {
+            ".zutils-version": Path("templates/.zutils-version"),
+            "z": Path("templates/z"),
+            "z.sh": Path("templates/z.sh"),
+            "z.ps1": Path("templates/z.ps1"),
+            ".gitignore": Path("templates/.gitignore"),
+        }
+    ]
+    for example in ("bin-hello", "lib-hello"):
+        base = Path("examples") / example
+        maps.append(
+            {
+                ".zutils-version": base / ".zutils-version",
+                "z": base / "z",
+                "z.sh": base / "z.sh",
+                "z.ps1": base / "z.ps1",
+                ".gitignore": base / ".nanvix/.gitignore",
+            }
+        )
+    return maps
+
+
+def _line_ending(content: bytes) -> bytes:
+    """Return the existing target's line-ending policy."""
+    return b"\r\n" if b"\r\n" in content else b"\n"
+
+
+def _convert_line_endings(content: bytes, newline: bytes) -> bytes:
+    """Normalize text to one target-specific line ending."""
+    normalized = content.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return normalized.replace(b"\n", newline)
+
+
+def _run_locked(
+    args: argparse.Namespace,
+    root: Path,
+    transaction: UpdateTransaction,
+) -> tuple[UpdateResult, int]:
+    """Plan and apply a zutils template update under its transaction lock."""
+    version = args.to.removeprefix("v")
+    if SEMVER_RE.fullmatch(version) is None:
+        raise UpdateError("--to must be a semantic version (vX.Y.Z or X.Y.Z)")
+    target = f"v{version}"
+    templates = _resolve_templates(target, args.templates_dir)
+    candidates: dict[Path, bytes] = {}
+    validators: dict[Path, Callable[[bytes], None]] = {}
+    create_modes: dict[Path, int] = {}
+    for target_map in _target_maps(root):
+        for source_name, relative in target_map.items():
+            path = root / relative
+            current = path.read_bytes() if path.is_file() else templates[source_name]
+            newline = _line_ending(current)
+            candidate = _convert_line_endings(templates[source_name], newline)
+            candidates[relative] = candidate
+            if source_name in {"z", "z.sh"}:
+                create_modes[relative] = 0o755
+
+            def validate(
+                value: bytes,
+                expected: bytes = candidate,
+                label: str = relative.as_posix(),
+            ) -> None:
+                if value != expected:
+                    raise UpdateError(f"{label}: invalid template candidate")
+
+            validators[relative] = validate
+    if args.dry_run or args.check:
+        changed = tuple(
+            sorted(
+                path.as_posix()
+                for path, content in candidates.items()
+                if not (root / path).is_file() or (root / path).read_bytes() != content
+            )
+        )
+        for path, validator in validators.items():
+            validator(candidates[path])
+    else:
+        changed = transaction.install(
+            candidates,
+            validators,
+            create_modes=create_modes,
+        )
+    status = (
+        "up-to-date"
+        if not changed
+        else "outdated" if args.check else "would-update" if args.dry_run else "updated"
+    )
+    result = UpdateResult("update-zutils", status, target, changed)
+    return result, EXIT_GENERAL_ERROR if args.check and changed else EXIT_SUCCESS
+
+
+def _run(args: argparse.Namespace) -> tuple[UpdateResult, int]:
+    """Recover managed files before parsing and hold the update lock."""
+    if args.check and args.dry_run:
+        raise UpdateError("--check and --dry-run are mutually exclusive")
+    root = find_target_root()
+    with update_transaction(root) as transaction:
+        return _run_locked(args, root, transaction)
+
+
+def main() -> None:
+    """Entry point for ``nanvix-zutil update-zutils``."""
+    parser = _build_parser()
+    args = parser.parse_args()
+    try:
+        result, code = _run(args)
+        emit_result(
+            result,
+            output_format=args.output_format,
+            output=args.output,
+        )
+        sys.exit(code)
+    except (OSError, UpdateError) as exc:
+        if args.output_format == "json":
+            print(
+                json.dumps(
+                    {
+                        "level": "error",
+                        "code": EXIT_INVALID_ARGS,
+                        "message": str(exc),
+                    },
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        sys.exit(EXIT_INVALID_ARGS)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nanvix_zutil/configs/.gitignore
+++ b/src/nanvix_zutil/configs/.gitignore
@@ -8,3 +8,6 @@ out
 black.toml
 env.json
 pyrightconfig.json
+.nanvix-zutil-update.lock
+.nanvix-zutil-update-journal.json
+.*.nanvix-zutil-*

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -11,7 +11,7 @@ fails immediately.  ``test`` and ``benchmark`` run natively on the host.
 
 Use ``--with-docker IMAGE`` during setup to specify the Docker image::
 
-    ./z setup --with-docker ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+    ./z setup --with-docker ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:<digest>
 """
 
 from __future__ import annotations
@@ -134,7 +134,8 @@ class DockerConfig:
     ``docker run`` invocation.
 
     Attributes:
-        image: Docker image name (e.g. ``"ghcr.io/nanvix/toolchain-gcc:sha-34a3641"``).
+        image: Immutable Docker image reference (for example,
+            ``"ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:<digest>"``).
         mounts: Ordered list of volume mounts.
         uid: User ID passed to ``--user``.  Defaults to the current process UID,
             or ``0`` on platforms where ``os.getuid`` is unavailable (e.g. Windows).

--- a/src/nanvix_zutil/github.py
+++ b/src/nanvix_zutil/github.py
@@ -11,9 +11,11 @@ avoid being rate-limited on public repositories.
 from __future__ import annotations
 
 import json
+import os
 import re
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Iterator
 from pathlib import Path
@@ -454,6 +456,35 @@ def resolve_release(
     return result
 
 
+def resolve_commit(
+    repo: str,
+    ref: str,
+    gh_token: str | None = None,
+) -> str:
+    """Resolve a GitHub ref to its immutable 40-character commit SHA."""
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    if gh_token:
+        headers["Authorization"] = f"Bearer {gh_token}"
+    encoded_ref = urllib.parse.quote(ref, safe="")
+    raw = _fetch_json(
+        f"{_GITHUB_API_BASE}/repos/{repo}/commits/{encoded_ref}",
+        headers,
+        f"{repo} commit {ref}",
+    )
+    if not isinstance(raw, dict):
+        log.fatal(
+            f"Unexpected commit response for {repo}@{ref}",
+            code=EXIT_NETWORK_ERROR,
+        )
+    sha = cast("dict[str, object]", raw).get("sha")
+    if not isinstance(sha, str) or re.fullmatch(r"[0-9a-f]{40}", sha) is None:
+        log.fatal(
+            f"GitHub returned an invalid commit SHA for {repo}@{ref}",
+            code=EXIT_NETWORK_ERROR,
+        )
+    return sha
+
+
 def resolve_release_with_fallback(
     repo: str,
     version_specifier: str,
@@ -601,8 +632,9 @@ def download_release_asset(
     """
     dest.mkdir(parents=True, exist_ok=True)
 
-    # Fast path: check cache.
-    if match_prefix:
+    # Preserve legacy flat-cache reuse when no exact pre-resolved release was
+    # supplied. Exact callers validate release/asset identity below.
+    if _release is None and match_prefix:
         # Collect all matching cached files and select deterministically to
         # avoid relying on filesystem iteration order.
         matches = [
@@ -620,7 +652,7 @@ def download_release_asset(
             cached = matches[0]
             log.info(f"Asset already present: {cached}")
             return cached
-    else:
+    elif _release is None:
         out_path = dest / asset_name
         if out_path.exists():
             log.info(f"Asset already present: {out_path}")
@@ -651,7 +683,8 @@ def download_release_asset(
     # pick deterministically (prefer .tar.bz2 over .tar.gz over .zip).
     _PREFIX_PREFERENCE = (".tar.bz2", ".tar.gz", ".zip")
 
-    prefix_candidates: list[tuple[str, str]] = []  # (name, url)
+    prefix_candidates: list[tuple[str, str, int | None]] = []
+    asset_id: int | None = None
 
     for item in assets:
         if not isinstance(item, dict):
@@ -663,16 +696,20 @@ def download_release_asset(
         if match_prefix:
             if name.startswith(asset_name):
                 raw_url = asset.get("browser_download_url")
+                raw_id = asset.get("id")
                 if not isinstance(raw_url, str) or not raw_url:
                     log.fatal(
                         f"Malformed asset entry for {repo}@{version_specifier}: missing or invalid browser_download_url",
                         code=EXIT_NETWORK_ERROR,
                         hint="GitHub returned an asset without a usable browser_download_url; this may indicate an API change or a corrupted release.",
                     )
-                prefix_candidates.append((name, raw_url))
+                if raw_id is not None and not isinstance(raw_id, int):
+                    continue
+                prefix_candidates.append((name, raw_url, raw_id))
         else:
             if name == asset_name:
                 raw_url = asset.get("browser_download_url")
+                raw_id = asset.get("id")
                 if not isinstance(raw_url, str) or not raw_url:
                     log.fatal(
                         f"Malformed asset entry for {repo}@{version_specifier}: missing or invalid browser_download_url",
@@ -681,6 +718,7 @@ def download_release_asset(
                     )
                 resolved_name = name
                 asset_url = raw_url
+                asset_id = raw_id if isinstance(raw_id, int) else None
                 break
 
     # When prefix-matching, pick the best candidate by preferred extension.
@@ -693,7 +731,7 @@ def download_release_asset(
             return len(_PREFIX_PREFERENCE)
 
         prefix_candidates.sort(key=lambda c: (_ext_rank(c[0]), c[0]))
-        resolved_name, asset_url = prefix_candidates[0]
+        resolved_name, asset_url, asset_id = prefix_candidates[0]
 
     if asset_url is None:
         if allow_missing:
@@ -705,19 +743,53 @@ def download_release_asset(
         )
 
     out_path = dest / resolved_name
+    metadata_path = dest / f".{resolved_name}.release.json"
+    release_tag = release.get("tag_name")
+    release_id = release.get("id")
+    identity: dict[str, object] = {
+        "repo": repo,
+        "release_tag": release_tag if isinstance(release_tag, str) else "",
+        "release_id": release_id if isinstance(release_id, int) else 0,
+        "asset_id": asset_id if asset_id is not None else 0,
+        "asset_name": resolved_name,
+        "asset_url": asset_url,
+    }
+    if _release is not None and out_path.is_file() and metadata_path.is_file():
+        try:
+            cached_identity: object = json.loads(metadata_path.read_text("utf-8"))
+        except (OSError, json.JSONDecodeError):
+            cached_identity = None
+        if cached_identity == identity:
+            log.info(f"Verified asset already present: {out_path}")
+            return out_path
+
     log.info(f"Downloading {resolved_name} from {repo}@{version_specifier}…")
     for attempt in range(1, _MAX_RETRIES + 1):
+        download_path = dest / f".{resolved_name}.download-{os.getpid()}"
+        metadata_tmp = dest / f".{resolved_name}.metadata-{os.getpid()}"
         try:
             dl_req = urllib.request.Request(asset_url, headers=headers)
             with (
                 urllib.request.urlopen(dl_req, timeout=_HTTP_TIMEOUT) as resp,
-                out_path.open("wb") as out_fh,
+                download_path.open("wb") as out_fh,
             ):
                 while True:
                     chunk = resp.read(1024 * 1024)
                     if not chunk:
                         break
                     out_fh.write(chunk)
+                out_fh.flush()
+                os.fsync(out_fh.fileno())
+            os.replace(download_path, out_path)
+            if _release is not None:
+                metadata_tmp.write_text(
+                    json.dumps(identity, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                    newline="\n",
+                )
+                with metadata_tmp.open("rb") as metadata_fh:
+                    os.fsync(metadata_fh.fileno())
+                os.replace(metadata_tmp, metadata_path)
             log.success(f"Downloaded {resolved_name}")
             return out_path
         except urllib.error.URLError as exc:
@@ -730,6 +802,9 @@ def download_release_asset(
             wait = _BACKOFF_BASE**attempt
             log.warning(f"Download attempt {attempt} failed; retrying in {wait:.0f}s…")
             time.sleep(wait)
+        finally:
+            download_path.unlink(missing_ok=True)
+            metadata_tmp.unlink(missing_ok=True)
 
     # Unreachable — log.fatal exits. Satisfy type checker.
     return out_path  # pragma: no cover

--- a/src/nanvix_zutil/github.py
+++ b/src/nanvix_zutil/github.py
@@ -36,6 +36,15 @@ _HTTP_TIMEOUT = 30.0  # seconds
 _PER_PAGE = 100  # releases per API page
 
 
+def _fsync_file(path: Path) -> None:
+    """Flush a file through a Windows-compatible read-write descriptor."""
+    descriptor = os.open(path, os.O_RDWR)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -787,8 +796,7 @@ def download_release_asset(
                     encoding="utf-8",
                     newline="\n",
                 )
-                with metadata_tmp.open("rb") as metadata_fh:
-                    os.fsync(metadata_fh.fileno())
+                _fsync_file(metadata_tmp)
                 os.replace(metadata_tmp, metadata_path)
             log.success(f"Downloaded {resolved_name}")
             return out_path

--- a/src/nanvix_zutil/lockfile.py
+++ b/src/nanvix_zutil/lockfile.py
@@ -27,6 +27,7 @@ from nanvix_zutil.exitcodes import (
     EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
 )
+from nanvix_zutil.sdk import SdkImage, SdkProvenance
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -53,6 +54,7 @@ class ResolvedAsset:
 
     name: str
     url: str
+    asset_id: int | None = None
 
 
 @dataclass
@@ -96,10 +98,15 @@ class LockfileMetadata:
             (e.g. ``"sha256:a1b2c3d4..."``).
         nanvix_zutil_version: Version of ``nanvix-zutil`` that
             generated this lockfile.
+        sdk: Verified SDK provenance, or ``None`` for a legacy lock.
+        shallow: Whether transitive dependency discovery was intentionally
+            omitted when this lock was generated.
     """
 
     manifest_hash: str
     nanvix_zutil_version: str
+    sdk: SdkProvenance | None = None
+    shallow: bool = False
 
 
 @dataclass
@@ -140,8 +147,8 @@ def get_zutil_version() -> str:
 # ---------------------------------------------------------------------------
 
 
-def write_lockfile(lockfile: Lockfile, path: Path) -> None:
-    """Serialize a :class:`Lockfile` to TOML and write it to *path*.
+def serialize_lockfile(lockfile: Lockfile) -> bytes:
+    """Serialize a :class:`Lockfile` to canonical UTF-8 TOML bytes.
 
     The output starts with the standard lockfile header comment and
     includes a blank line before each ``[[package]]`` block for
@@ -149,18 +156,47 @@ def write_lockfile(lockfile: Lockfile, path: Path) -> None:
 
     Args:
         lockfile: The lockfile to serialize.
-        path: Destination file path.
+    Returns:
+        Canonical lockfile bytes with LF line endings.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-
     lines: list[str] = [_LOCKFILE_HEADER, ""]
 
     # [metadata]
-    meta_dict: dict[str, str] = {
+    meta_dict: dict[str, object] = {
         "manifest-hash": lockfile.metadata.manifest_hash,
         "nanvix-zutil-version": lockfile.metadata.nanvix_zutil_version,
     }
+    if lockfile.metadata.shallow:
+        meta_dict["shallow"] = True
     lines.append(tomli_w.dumps({"metadata": meta_dict}).rstrip())
+    if lockfile.metadata.sdk is not None:
+        sdk = lockfile.metadata.sdk
+        sdk_dict: dict[str, object] = {
+            "schema-version": sdk.schema_version,
+            "sdk-version": sdk.sdk_version,
+            "provider-id": sdk.provider_id,
+            "provider": sdk.provider,
+            "role": sdk.role,
+            "image-name": sdk.image.name,
+            "image-digest": sdk.image.digest,
+            "image-ref": sdk.image.ref,
+            "nanvix-tag": sdk.nanvix_tag,
+            "nanvix-version": sdk.nanvix_version,
+            "nanvix-commit": sdk.nanvix_commit,
+            "sysroot-sha256": sdk.sysroot_sha256,
+        }
+        lines.append("")
+        lines.append("[metadata.sdk]")
+        lines.append(tomli_w.dumps(sdk_dict).rstrip())
+        for name, values in (
+            ("target", sdk.target),
+            ("toolchain", sdk.toolchain),
+            ("compat", sdk.compat),
+            ("features", sdk.features),
+        ):
+            lines.append("")
+            lines.append(f"[metadata.sdk.{name}]")
+            lines.append(tomli_w.dumps(values).rstrip())
     lines.append("")
 
     # [[package]] blocks
@@ -193,14 +229,28 @@ def write_lockfile(lockfile: Lockfile, path: Path) -> None:
             lines.append(tomli_w.dumps({key: value}).rstrip())
 
         # Serialize assets as [[package.assets]] sub-tables
-        for asset_dict in asset_dicts:
+        for index, asset_dict in enumerate(asset_dicts):
             lines.append("")
             lines.append("[[package.assets]]")
             lines.append(tomli_w.dumps({"name": asset_dict["name"]}).rstrip())
             lines.append(tomli_w.dumps({"url": asset_dict["url"]}).rstrip())
+            asset_id = pkg.assets[index].asset_id
+            if asset_id is not None:
+                lines.append(tomli_w.dumps({"id": asset_id}).rstrip())
 
     lines.append("")
-    path.write_text("\n".join(lines), encoding="utf-8", newline="\n")
+    return "\n".join(lines).encode("utf-8")
+
+
+def write_lockfile(lockfile: Lockfile, path: Path) -> None:
+    """Serialize a :class:`Lockfile` and write it to *path*.
+
+    Args:
+        lockfile: The lockfile to serialize.
+        path: Destination file path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(serialize_lockfile(lockfile))
 
 
 # ---------------------------------------------------------------------------
@@ -260,9 +310,33 @@ def read_lockfile(path: Path) -> Lockfile:
             code=EXIT_INVALID_ARGS,
         )
 
+    shallow_value = meta.get("shallow", False)
+    # Transitional writer 0.15.0 accidentally emitted shallow as a string;
+    # accept it when reading while all new writes use a TOML boolean.
+    if shallow_value == "true":
+        shallow_value = True
+    if not isinstance(shallow_value, bool):
+        log.fatal(
+            f"Lockfile {path}: invalid metadata 'shallow'",
+            code=EXIT_INVALID_ARGS,
+        )
+    raw_sdk = meta.get("sdk")
+    sdk = (
+        _parse_sdk_provenance(cast("dict[str, object]", raw_sdk), path)
+        if isinstance(raw_sdk, dict)
+        else None
+    )
+    if raw_sdk is not None and sdk is None:
+        log.fatal(
+            f"Lockfile {path}: metadata.sdk must be a table",
+            code=EXIT_INVALID_ARGS,
+        )
+
     metadata = LockfileMetadata(
         manifest_hash=manifest_hash,
         nanvix_zutil_version=zutil_version,
+        sdk=sdk,
+        shallow=shallow_value,
     )
 
     # Parse packages
@@ -284,6 +358,71 @@ def read_lockfile(path: Path) -> Lockfile:
         packages.append(_parse_package(pkg_data, path))
 
     return Lockfile(metadata=metadata, packages=packages)
+
+
+def _parse_sdk_provenance(
+    data: dict[str, object],
+    path: Path,
+) -> SdkProvenance:
+    """Parse verified SDK provenance from lockfile metadata."""
+
+    def text(key: str) -> str:
+        value = data.get(key)
+        if not isinstance(value, str) or not value:
+            log.fatal(
+                f"Lockfile {path}: metadata.sdk missing or invalid {key!r}",
+                code=EXIT_INVALID_ARGS,
+            )
+        return value
+
+    def object_table(key: str, *, required: bool = False) -> dict[str, object]:
+        value = data.get(key)
+        if value is None and not required:
+            return {}
+        if not isinstance(value, dict):
+            log.fatal(
+                f"Lockfile {path}: metadata.sdk {key!r} must be a table",
+                code=EXIT_INVALID_ARGS,
+            )
+        return dict(cast("dict[str, object]", value))
+
+    raw_compat = object_table("compat", required=True)
+    schema_version = data.get("schema-version", 1)
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != 1
+    ):
+        log.fatal(
+            f"Lockfile {path}: unsupported metadata.sdk schema-version",
+            code=EXIT_INVALID_ARGS,
+        )
+    image = SdkImage(
+        name=text("image-name"),
+        digest=text("image-digest"),
+        ref=text("image-ref"),
+    )
+    if image.ref != f"{image.name}@{image.digest}":
+        log.fatal(
+            f"Lockfile {path}: metadata.sdk image coordinate is inconsistent",
+            code=EXIT_INVALID_ARGS,
+        )
+    return SdkProvenance(
+        sdk_version=text("sdk-version"),
+        provider_id=text("provider-id"),
+        provider=text("provider"),
+        role=text("role"),
+        image=image,
+        nanvix_tag=text("nanvix-tag"),
+        nanvix_version=text("nanvix-version"),
+        nanvix_commit=text("nanvix-commit"),
+        sysroot_sha256=text("sysroot-sha256"),
+        compat=raw_compat,
+        schema_version=1,
+        target=object_table("target"),
+        toolchain=object_table("toolchain"),
+        features=object_table("features"),
+    )
 
 
 def _parse_package(data: dict[str, object], path: Path) -> ResolvedPackage:
@@ -402,12 +541,18 @@ def _parse_package(data: dict[str, object], path: Path) -> ResolvedPackage:
         asset_data = cast("dict[str, object]", raw_asset_item)
         a_name = asset_data.get("name")
         a_url = asset_data.get("url")
+        a_id = asset_data.get("id")
         if not isinstance(a_name, str) or not isinstance(a_url, str):
             log.fatal(
                 f"Lockfile {path}: package '{name}' asset missing 'name' or 'url'",
                 code=EXIT_INVALID_ARGS,
             )
-        assets.append(ResolvedAsset(name=a_name, url=a_url))
+        if a_id is not None and not isinstance(a_id, int):
+            log.fatal(
+                f"Lockfile {path}: package '{name}' asset id must be an integer",
+                code=EXIT_INVALID_ARGS,
+            )
+        assets.append(ResolvedAsset(name=a_name, url=a_url, asset_id=a_id))
 
     return ResolvedPackage(
         name=name,
@@ -516,6 +661,11 @@ def compute_manifest_hash(path: Path) -> str:
             code=EXIT_MISSING_DEP,
             hint="Ensure nanvix.toml exists in .nanvix/.",
         )
-    raw_bytes = path.read_bytes().replace(b"\r\n", b"\n")
+    return compute_manifest_hash_bytes(path.read_bytes())
+
+
+def compute_manifest_hash_bytes(raw_bytes: bytes) -> str:
+    """Compute the normalized manifest hash from in-memory bytes."""
+    raw_bytes = raw_bytes.replace(b"\r\n", b"\n")
     digest = hashlib.sha256(raw_bytes).hexdigest()
     return f"sha256:{digest}"

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -10,7 +10,8 @@ string (``version`` specifier), or a table with one of ``version``,
 ``tag``, ``commitish``, or ``id``.
 
 Only ``version`` specifier refs (plain string or ``{ version = "..." }``)
-are auto-suffixed with ``-nanvix-{sysroot_version}``.  ``tag``,
+are auto-suffixed with ``-nanvix-{sysroot_version}`` in legacy mode or
+``-nanvix-{runtime}-sdk.{revision}`` in SDK mode. ``tag``,
 ``commitish``, and ``id`` specifiers are exact-match and never suffixed.
 Refs that already contain ``-nanvix-`` are rejected to prevent accidental
 duplication.  When the sysroot is ``"latest"``, auto-suffixing is
@@ -22,17 +23,99 @@ from __future__ import annotations
 import re
 import tomllib
 from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
 from typing import cast
 
 from nanvix_zutil import log
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_MISSING_DEP
 from nanvix_zutil.paths import manifest_path
+from nanvix_zutil.sdk import SdkValidationError, parse_sdk_version
 from nanvix_zutil.utils import SEMVER_RE
 
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
+
+
+class ToolchainKind(Enum):
+    """Consumer toolchain selection mode."""
+
+    LEGACY = "legacy"
+    SDK = "nanvix-sdk"
+
+
+@dataclass(frozen=True)
+class SdkPin:
+    """Immutable SDK coordinate declared by a consumer manifest."""
+
+    version: str
+    provider_id: str
+    image: str
+    digest: str
+    build_image: str | None = None
+    build_digest: str | None = None
+
+    @property
+    def provider(self) -> str:
+        """Return the SDK provider identifier."""
+        return self.provider_id
+
+    @property
+    def sdk_image(self) -> str:
+        """Return the SDK provider image name."""
+        return self.image
+
+    @property
+    def sdk_digest(self) -> str:
+        """Return the SDK provider image digest."""
+        return self.digest
+
+    @property
+    def image_name(self) -> str:
+        """Return the image repository without its digest."""
+        return self.image.partition("@")[0]
+
+    @property
+    def image_ref(self) -> str:
+        """Return the canonical immutable image reference."""
+        return f"{self.image_name}@{self.digest}"
+
+    @property
+    def sdk_image_ref(self) -> str:
+        """Return the canonical immutable SDK provider reference."""
+        return self.image_ref
+
+    @property
+    def build_image_ref(self) -> str | None:
+        """Return the optional immutable build-image reference."""
+        if self.build_image is None or self.build_digest is None:
+            return None
+        return f"{self.build_image}@{self.build_digest}"
+
+    @property
+    def effective_build_ref(self) -> str:
+        """Return the image used for builds, falling back to the SDK image."""
+        return self.build_image_ref or self.sdk_image_ref
+
+
+@dataclass(frozen=True)
+class Toolchain:
+    """Typed manifest toolchain configuration."""
+
+    kind: ToolchainKind
+    sdk: SdkPin | None = None
+
+    @classmethod
+    def legacy(cls) -> Toolchain:
+        """Return the transitional legacy toolchain selection."""
+        return cls(kind=ToolchainKind.LEGACY)
+
+    @property
+    def effective_build_ref(self) -> str | None:
+        """Return the immutable build reference, if this is an SDK toolchain."""
+        return self.sdk.effective_build_ref if self.sdk is not None else None
 
 
 @dataclass
@@ -45,6 +128,7 @@ class Manifest:
         sysroot_ref: Nanvix sysroot version reference.
         dependencies: Build-time dependencies as :class:`Dependency` objects.
         system_dependencies: Runtime dependencies as :class:`Dependency` objects.
+        toolchain: Typed legacy or immutable SDK toolchain selection.
     """
 
     name: str
@@ -52,6 +136,7 @@ class Manifest:
     sysroot_ref: Ref
     dependencies: list[Dependency] = field(default_factory=lambda: [])
     system_dependencies: list[Dependency] = field(default_factory=lambda: [])
+    toolchain: Toolchain = field(default_factory=Toolchain.legacy)
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +151,7 @@ _URL_UNSAFE = set("/\\#?%")
 _LOCAL_PATH_RE = re.compile(
     r"^(?:/|\./|\.\./|[A-Za-z]:[/\\])",
 )
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def is_local_path(value: str) -> bool:
@@ -272,12 +358,206 @@ def _parse_dependencies(
     return deps
 
 
+def _parse_toolchain(raw: object, nanvix_version: str) -> Toolchain:
+    """Parse the optional typed ``[toolchain]`` table.
+
+    The canonical form uses ``kind = "nanvix-sdk"`` with ``sdk-*`` fields.
+    Early ``type/version/image`` and ``[toolchain.sdk]`` forms remain readable
+    for one transition release.
+    """
+    if raw is None:
+        return Toolchain.legacy()
+    if not isinstance(raw, dict):
+        log.fatal(
+            f"{manifest_path()}: [toolchain] must be a TOML table",
+            code=EXIT_INVALID_ARGS,
+        )
+    table = cast("dict[str, object]", raw)
+    nested = table.get("sdk")
+    if nested is not None:
+        if not isinstance(nested, dict):
+            log.fatal(
+                f"{manifest_path()}: [toolchain.sdk] must be a TOML table",
+                code=EXIT_INVALID_ARGS,
+            )
+        values = cast("dict[str, object]", nested)
+        outer_keys = set(table) - {"type", "kind", "sdk"}
+        if outer_keys:
+            log.fatal(
+                f"{manifest_path()}: SDK pin fields must not be split between"
+                " [toolchain] and [toolchain.sdk]",
+                code=EXIT_INVALID_ARGS,
+            )
+    else:
+        values = {
+            key: value for key, value in table.items() if key not in {"type", "kind"}
+        }
+
+    if "type" in table and "kind" in table:
+        log.fatal(
+            f"{manifest_path()}: [toolchain] must not define both 'type' and 'kind'",
+            code=EXIT_INVALID_ARGS,
+        )
+    raw_kind = table.get("type", table.get("kind"))
+    if raw_kind is None:
+        kind = ToolchainKind.SDK if values else ToolchainKind.LEGACY
+    elif isinstance(raw_kind, str):
+        if raw_kind == "sdk":
+            raw_kind = ToolchainKind.SDK.value
+        try:
+            kind = ToolchainKind(raw_kind)
+        except ValueError:
+            log.fatal(
+                f"{manifest_path()}: unsupported toolchain type {raw_kind!r}",
+                code=EXIT_INVALID_ARGS,
+                hint="Use 'legacy' or 'nanvix-sdk'.",
+            )
+    else:
+        log.fatal(
+            f"{manifest_path()}: toolchain type must be a string",
+            code=EXIT_INVALID_ARGS,
+        )
+
+    if kind == ToolchainKind.LEGACY:
+        if values:
+            log.fatal(
+                f"{manifest_path()}: legacy [toolchain] must not contain SDK pin fields",
+                code=EXIT_INVALID_ARGS,
+            )
+        return Toolchain.legacy()
+
+    aliases = {
+        "version": "sdk-version",
+        "sdk_version": "sdk-version",
+        "provider": "provider_id",
+        "provider-id": "provider_id",
+        "provider_id": "provider_id",
+        "image": "sdk-image",
+        "digest": "sdk-digest",
+    }
+    normalized: dict[str, object] = {}
+    for key, value in values.items():
+        canonical = aliases.get(key, key)
+        if canonical in normalized:
+            log.fatal(
+                f"{manifest_path()}: duplicate SDK pin field {canonical!r}",
+                code=EXIT_INVALID_ARGS,
+            )
+        normalized[canonical] = value
+    allowed = {
+        "sdk-version",
+        "provider_id",
+        "sdk-image",
+        "sdk-digest",
+        "build-image",
+        "build-digest",
+    }
+    unexpected = sorted(set(normalized) - allowed)
+    if unexpected:
+        log.fatal(
+            f"{manifest_path()}: unexpected SDK pin fields: {', '.join(unexpected)}",
+            code=EXIT_INVALID_ARGS,
+        )
+
+    def required_string(key: str) -> str:
+        value = normalized.get(key)
+        if not isinstance(value, str) or not value:
+            log.fatal(
+                f"{manifest_path()}: SDK toolchain requires non-empty {key!r}",
+                code=EXIT_INVALID_ARGS,
+            )
+        return value
+
+    version = required_string("sdk-version")
+    provider_id = required_string("provider_id")
+    image = required_string("sdk-image")
+    digest_value = normalized.get("sdk-digest")
+    image_name, separator, embedded_digest = image.partition("@")
+    if separator:
+        if digest_value is not None and digest_value != embedded_digest:
+            log.fatal(
+                f"{manifest_path()}: SDK image digest and digest field disagree",
+                code=EXIT_INVALID_ARGS,
+            )
+        digest = embedded_digest
+    else:
+        digest = required_string("sdk-digest")
+    if _DIGEST_RE.fullmatch(digest) is None:
+        log.fatal(
+            f"{manifest_path()}: SDK digest must be sha256 followed by 64 lowercase hex digits",
+            code=EXIT_INVALID_ARGS,
+        )
+    expected_image = f"ghcr.io/nanvix/nanvix-sdk-{provider_id}"
+    if image_name != expected_image:
+        log.fatal(
+            f"{manifest_path()}: SDK image {image_name!r} does not match"
+            f" provider {provider_id!r} (expected {expected_image!r})",
+            code=EXIT_INVALID_ARGS,
+        )
+    try:
+        runtime, _revision = parse_sdk_version(version)
+    except SdkValidationError as exc:
+        log.fatal(f"{manifest_path()}: {exc}", code=EXIT_INVALID_ARGS)
+    if runtime != nanvix_version.removeprefix("v"):
+        log.fatal(
+            f"{manifest_path()}: SDK {version!r} targets Nanvix {runtime},"
+            f" but package.nanvix-version is {nanvix_version!r}",
+            code=EXIT_INVALID_ARGS,
+        )
+    if provider_id != "c-clang":
+        log.fatal(
+            f"{manifest_path()}: unsupported SDK provider {provider_id!r}",
+            code=EXIT_INVALID_ARGS,
+        )
+    build_image_value = normalized.get("build-image")
+    build_digest_value = normalized.get("build-digest")
+    if (build_image_value is None) != (build_digest_value is None):
+        log.fatal(
+            f"{manifest_path()}: build-image and build-digest must be specified together",
+            code=EXIT_INVALID_ARGS,
+        )
+    build_image: str | None = None
+    build_digest: str | None = None
+    if build_image_value is not None and build_digest_value is not None:
+        if not isinstance(build_image_value, str) or not build_image_value:
+            log.fatal(
+                f"{manifest_path()}: build-image must be a non-empty string",
+                code=EXIT_INVALID_ARGS,
+            )
+        if (
+            not isinstance(build_digest_value, str)
+            or _DIGEST_RE.fullmatch(build_digest_value) is None
+        ):
+            log.fatal(
+                f"{manifest_path()}: build-digest must be a SHA-256 digest",
+                code=EXIT_INVALID_ARGS,
+            )
+        if "@" in build_image_value:
+            log.fatal(
+                f"{manifest_path()}: canonical build-image must not include a digest",
+                code=EXIT_INVALID_ARGS,
+            )
+        build_image = build_image_value
+        build_digest = build_digest_value
+    return Toolchain(
+        kind=ToolchainKind.SDK,
+        sdk=SdkPin(
+            version=version,
+            provider_id=provider_id,
+            image=image_name,
+            digest=digest,
+            build_image=build_image,
+            build_digest=build_digest,
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 
-def load_manifest() -> Manifest:
+def load_manifest(path: Path | None = None) -> Manifest:
     """Parse a ``nanvix.toml`` manifest file.
 
     Reads the TOML file, validates required keys, enforces semver for
@@ -292,14 +572,15 @@ def load_manifest() -> Manifest:
         SystemExit: With exit code ``3`` if the file does not exist, or
             exit code ``2`` if the manifest is malformed.
     """
-    if not manifest_path().is_file():
+    source_path = path or manifest_path()
+    if not source_path.is_file():
         log.fatal(
-            f"Required file not found: {manifest_path()}",
+            f"Required file not found: {source_path}",
             code=EXIT_MISSING_DEP,
             hint="Create a nanvix.toml in the .nanvix/ directory.",
         )
 
-    raw_bytes = manifest_path().read_bytes()
+    raw_bytes = source_path.read_bytes()
     try:
         data: dict[str, object] = tomllib.loads(raw_bytes.decode("utf-8"))
     except tomllib.TOMLDecodeError as exc:
@@ -345,6 +626,8 @@ def load_manifest() -> Manifest:
         )
 
     sysroot_ref = _parse_nanvix_version(raw_nanvix_version)
+    assert isinstance(sysroot_ref.value, str)
+    toolchain = _parse_toolchain(data.get("toolchain"), sysroot_ref.value)
 
     # --- [dependencies] (optional) ---
     deps_raw: object = data.get("dependencies", {})
@@ -373,12 +656,12 @@ def load_manifest() -> Manifest:
     # (which resolves the sysroot first and knows the actual version).
     # Strip the leading "v" from the sysroot version to match the release
     # tag format used by nanvix-zutil (e.g. "1.3.1-nanvix-0.12.291").
-    if (
-        sysroot_ref.value != "latest"
-        and isinstance(sysroot_ref.value, str)
-        and sysroot_ref.kind != RefKind.LOCAL
-    ):
-        version_suffix = sysroot_ref.value.removeprefix("v")
+    if sysroot_ref.value != "latest" and sysroot_ref.kind != RefKind.LOCAL:
+        version_suffix = (
+            toolchain.sdk.version.removeprefix("v")
+            if toolchain.kind == ToolchainKind.SDK and toolchain.sdk is not None
+            else sysroot_ref.value.removeprefix("v")
+        )
         for dep in [*dependencies, *system_dependencies]:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
                 if "-nanvix-" in dep.ref.value:
@@ -394,4 +677,5 @@ def load_manifest() -> Manifest:
         sysroot_ref=sysroot_ref,
         dependencies=dependencies,
         system_dependencies=system_dependencies,
+        toolchain=toolchain,
     )

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -31,6 +31,15 @@ from typing import Literal, Sequence
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR, EXIT_INVALID_ARGS
+from nanvix_zutil.sdk import consumer_release_tag, sdk_consumer_release_tag
+
+__all__ = [
+    "ArchiveFormat",
+    "DEFAULT_FORMATS",
+    "consumer_release_tag",
+    "package",
+    "sdk_consumer_release_tag",
+]
 
 # ---------------------------------------------------------------------------
 # Archive format enum

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -13,12 +13,12 @@ per-scope archives.
 from __future__ import annotations
 
 import shutil
-import tempfile
+import os
 from collections import deque
 from dataclasses import dataclass
 from dataclasses import replace as _dc_replace
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast, overload
 
 from nanvix_zutil import github, log
 from nanvix_zutil.buildroot import (
@@ -36,11 +36,13 @@ from nanvix_zutil.lockfile import (
     ResolvedAsset,
     ResolvedPackage,
     compute_manifest_hash,
+    compute_manifest_hash_bytes,
     download_lockfile_asset,
     get_zutil_version,
 )
-from nanvix_zutil.manifest import Manifest
-from nanvix_zutil.paths import manifest_path
+from nanvix_zutil.manifest import Manifest, ToolchainKind, load_manifest
+from nanvix_zutil.paths import manifest_path, nanvix_root
+from nanvix_zutil.sdk import SdkProvenance, SdkRelease, resolve_sdk_release
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -60,6 +62,29 @@ class _QueueItem:
     dep: Dependency
     transitive: bool = False
     required_by: str = ""
+
+
+@dataclass(frozen=True)
+class BlockedResolution:
+    """Machine-readable strict-resolution failure."""
+
+    status: str
+    package: str
+    repo: str
+    requested_tag: str
+    sdk_version: str
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-compatible blocked result."""
+        return {
+            "status": self.status,
+            "package": self.package,
+            "repo": self.repo,
+            "requested_tag": self.requested_tag,
+            "sdk_version": self.sdk_version,
+            "reason": self.reason,
+        }
 
 
 _ARCHIVE_EXTENSIONS = (".tar.bz2", ".tar.gz", ".zip")
@@ -88,11 +113,14 @@ def _collect_assets(release: dict[str, object]) -> list[ResolvedAsset]:
         asset = cast("dict[str, object]", item)
         name = asset.get("name")
         url = asset.get("browser_download_url")
+        asset_id = asset.get("id")
         if not isinstance(name, str) or not isinstance(url, str):
+            continue
+        if asset_id is not None and not isinstance(asset_id, int):
             continue
         if not any(name.endswith(ext) for ext in _ARCHIVE_EXTENSIONS):
             continue
-        result.append(ResolvedAsset(name=name, url=url))
+        result.append(ResolvedAsset(name=name, url=url, asset_id=asset_id))
     return result
 
 
@@ -199,13 +227,59 @@ def _unsuffix_deps(deps: list[Dependency]) -> list[Dependency]:
 # ---------------------------------------------------------------------------
 
 
+@overload
 def resolve(
     manifest: Manifest,
     gh_token: str | None = None,
     cache_dir: Path | None = None,
     *,
     shallow: bool = False,
-) -> Lockfile:
+    strict: Literal[True],
+    verified_sdk_release: SdkRelease | None = None,
+    verify_sdk_image: bool = True,
+    manifest_content: bytes | None = None,
+) -> Lockfile | BlockedResolution: ...
+
+
+@overload
+def resolve(
+    manifest: Manifest,
+    gh_token: str | None = None,
+    cache_dir: Path | None = None,
+    *,
+    shallow: bool = False,
+    strict: Literal[False] = False,
+    verified_sdk_release: SdkRelease | None = None,
+    verify_sdk_image: bool = True,
+    manifest_content: bytes | None = None,
+) -> Lockfile: ...
+
+
+@overload
+def resolve(
+    manifest: Manifest,
+    gh_token: str | None = None,
+    cache_dir: Path | None = None,
+    *,
+    shallow: bool = False,
+    strict: bool,
+    verified_sdk_release: SdkRelease | None = None,
+    verify_sdk_image: bool = True,
+    manifest_content: bytes | None = None,
+) -> Lockfile | BlockedResolution: ...
+
+
+def resolve(
+    manifest: Manifest,
+    gh_token: str | None = None,
+    cache_dir: Path | None = None,
+    *,
+    shallow: bool = False,
+    strict: bool = False,
+    verified_sdk_release: SdkRelease | None = None,
+    verify_sdk_image: bool = True,
+    manifest_content: bytes | None = None,
+) -> Lockfile | BlockedResolution:
     """Resolve a manifest into a fully pinned lockfile.
 
     Implements BFS over the dependency graph:
@@ -223,10 +297,18 @@ def resolve(
     Args:
         manifest: Parsed manifest from :func:`load_manifest`.
         gh_token: Optional GitHub personal access token.
-        cache_dir: Directory for temporary lockfile downloads.  Defaults
-            to a ``tempfile.mkdtemp()``; cleaned up on completion.
+        cache_dir: Directory for temporary lockfile downloads. Defaults to a
+            confined per-process directory under ``.nanvix/cache``.
         shallow: When ``True``, skip transitive dependency discovery.
             Resolves only the sysroot and direct dependencies.
+        strict: Require exact SDK-aware coordinates and provenance-bearing
+            dependency locks.
+        verified_sdk_release: Already verified SDK contract. Supplying this
+            avoids redundant Docker verification.
+        verify_sdk_image: Verify the selected SDK image when resolving the
+            contract. Enabled by default for strict resolution.
+        manifest_content: Candidate manifest bytes used to hash an atomic
+            update before the target file is written.
 
     Returns:
         The fully resolved :class:`Lockfile`.
@@ -235,11 +317,31 @@ def resolve(
         SystemExit: On cycle detection, version conflicts, or network
             errors.
     """
-    tmp_dir = Path(cache_dir) if cache_dir else Path(tempfile.mkdtemp())
+    sdk_mode = manifest.toolchain.kind == ToolchainKind.SDK
+    if strict and not sdk_mode:
+        log.fatal(
+            "strict resolver mode requires an SDK [toolchain] pin",
+            code=EXIT_INVALID_ARGS,
+        )
+    tmp_dir = (
+        Path(cache_dir)
+        if cache_dir
+        else nanvix_root() / "cache" / f"resolve-{os.getpid()}"
+    )
     owns_tmp = cache_dir is None
+    tmp_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        return _resolve_inner(manifest, gh_token, tmp_dir, shallow=shallow)
+        return _resolve_inner(
+            manifest,
+            gh_token,
+            tmp_dir,
+            shallow=shallow,
+            strict=strict,
+            verified_sdk_release=verified_sdk_release,
+            verify_sdk_image=verify_sdk_image,
+            manifest_content=manifest_content,
+        )
     finally:
         if owns_tmp and tmp_dir.exists():
             shutil.rmtree(tmp_dir, ignore_errors=True)
@@ -251,26 +353,78 @@ def _resolve_inner(
     cache_dir: Path,
     *,
     shallow: bool,
-) -> Lockfile:
+    strict: bool,
+    verified_sdk_release: SdkRelease | None,
+    verify_sdk_image: bool,
+    manifest_content: bytes | None,
+) -> Lockfile | BlockedResolution:
     """Inner resolver logic (separated for cleanup in ``resolve()``)."""
     resolved: dict[str, ResolvedPackage] = {}
     releases: dict[str, dict[str, object]] = {}
+    sdk_release: SdkRelease | None = None
+    sdk_provenance: SdkProvenance | None = None
 
     # 1. Resolve sysroot
+    sysroot_specifier = manifest.sysroot_ref.value
+    if strict:
+        sdk_pin = manifest.toolchain.sdk
+        assert sdk_pin is not None
+        sdk_release = verified_sdk_release or resolve_sdk_release(
+            sdk_pin.version,
+            provider_id=sdk_pin.provider_id,
+            gh_token=gh_token,
+            verify_image=verify_sdk_image,
+        )
+        if (
+            sdk_release.sdk_version != sdk_pin.version
+            or sdk_release.provider_id != sdk_pin.provider_id
+        ):
+            log.fatal(
+                "Trusted SDK release does not match the manifest coordinate",
+                code=EXIT_INVALID_ARGS,
+            )
+        if (
+            sdk_release.image.name != sdk_pin.image_name
+            or sdk_release.image.digest != sdk_pin.digest
+            or sdk_release.image.ref != sdk_pin.image_ref
+        ):
+            log.fatal(
+                "Manifest SDK image pin does not match the verified SDK release",
+                code=EXIT_INVALID_ARGS,
+            )
+        sysroot_specifier = cast(str, sdk_release.libc["nanvix_tag"])
+        sdk_provenance = sdk_release.provenance()
     try:
         sysroot_release = github.resolve_release(
             "nanvix/nanvix",
-            manifest.sysroot_ref.value,
+            sysroot_specifier,
             gh_token=gh_token,
             semver=True,
         )
     except SystemExit:
         log.note(
-            "while resolving the Nanvix sysroot"
-            f" (nanvix/nanvix@{manifest.sysroot_ref.value})"
+            "while resolving the Nanvix sysroot" f" (nanvix/nanvix@{sysroot_specifier})"
         )
         raise
     tag, commitish, rel_id = _extract_release_fields(sysroot_release)
+    if sdk_release is not None:
+        expected_tag = cast(str, sdk_release.libc["nanvix_tag"])
+        expected_commit = cast(str, sdk_release.libc["nanvix_commit"])
+        if tag != expected_tag:
+            log.fatal(
+                f"SDK runtime tag skew: expected {expected_tag}, resolved {tag}",
+                code=EXIT_INVALID_ARGS,
+            )
+        resolved_runtime_commit = github.resolve_commit(
+            "nanvix/nanvix",
+            expected_tag,
+            gh_token=gh_token,
+        )
+        if resolved_runtime_commit != expected_commit:
+            log.fatal(
+                "SDK runtime commit does not match the Nanvix release",
+                code=EXIT_INVALID_ARGS,
+            )
     # ref preserves the original specifier ("latest" or semver) — resolved_tag
     # is the canonical pin used for deterministic artifact downloads.
     sysroot_pkg = ResolvedPackage(
@@ -411,6 +565,21 @@ def _resolve_inner(
     # 2. Seed queue with direct deps
     queue: deque[_QueueItem] = deque()
     all_deps = list(manifest.dependencies) + list(manifest.system_dependencies)
+    if strict:
+        assert sdk_release is not None
+        for dep in all_deps:
+            if (
+                dep.ref.kind != RefKind.VERSION
+                or not isinstance(dep.ref.value, str)
+                or not dep.ref.value.endswith(
+                    f"-nanvix-{sdk_release.sdk_version.removeprefix('v')}"
+                )
+            ):
+                log.fatal(
+                    f"Strict SDK dependency '{dep.name}' must use a version"
+                    " specifier so its exact SDK-aware release tag is derived",
+                    code=EXIT_INVALID_ARGS,
+                )
     for dep in all_deps:
         queue.append(_QueueItem(dep=dep))
 
@@ -418,6 +587,19 @@ def _resolve_inner(
     while queue:
         item = queue.popleft()
         dep = item.dep
+        if strict:
+            assert sdk_release is not None
+            expected_suffix = f"-nanvix-{sdk_release.sdk_version.removeprefix('v')}"
+            if (
+                dep.ref.kind != RefKind.VERSION
+                or not isinstance(dep.ref.value, str)
+                or not dep.ref.value.endswith(expected_suffix)
+            ):
+                log.fatal(
+                    f"Strict SDK dependency '{dep.name}' does not use exact"
+                    f" SDK-aware coordinate '*{expected_suffix}'",
+                    code=EXIT_INVALID_ARGS,
+                )
 
         if dep.name in resolved:
             # Version conflict detection: same name, different release
@@ -446,8 +628,18 @@ def _resolve_inner(
                 dep.ref.value,
                 gh_token=gh_token,
             )
-        except SystemExit:
+        except SystemExit as exc:
             requester = item.required_by or "manifest"
+            if strict and exc.code == 3:
+                assert sdk_release is not None
+                return BlockedResolution(
+                    status="blocked",
+                    package=dep.name,
+                    repo=dep.repo,
+                    requested_tag=str(dep.ref.value),
+                    sdk_version=sdk_release.sdk_version,
+                    reason="exact-sdk-release-missing",
+                )
             log.note(
                 f"while resolving dependency '{dep.name}'"
                 f" ({dep.repo}@{dep.ref.value}),"
@@ -470,12 +662,31 @@ def _resolve_inner(
         resolved[dep.name] = pkg
         releases[dep.name] = dep_release
 
-        # Discover transitive deps (unless shallow)
-        if not shallow:
+        # Strict SDK resolution always verifies the dependency's shallow lock
+        # provenance, even when this resolver invocation is itself shallow.
+        if strict or not shallow:
             inner_lock = download_lockfile_asset(
                 dep_release, cache_dir, gh_token=gh_token, dep_name=dep.name
             )
+            if inner_lock is None and strict:
+                assert sdk_release is not None
+                return BlockedResolution(
+                    status="blocked",
+                    package=dep.name,
+                    repo=dep.repo,
+                    requested_tag=str(dep.ref.value),
+                    sdk_version=sdk_release.sdk_version,
+                    reason="provenance-lock-missing",
+                )
             if inner_lock is not None:
+                if strict and inner_lock.metadata.sdk != sdk_provenance:
+                    log.fatal(
+                        f"Dependency '{dep.name}' lock provenance does not match"
+                        " the selected SDK",
+                        code=EXIT_INVALID_ARGS,
+                    )
+                if shallow:
+                    continue
                 for trans_pkg in inner_lock.packages:
                     if trans_pkg.kind == "sysroot":
                         continue
@@ -527,17 +738,23 @@ def _resolve_inner(
         pkg.assets = _collect_assets(releases[name])
 
     # 6. Assemble lockfile
-    manifest_hash = compute_manifest_hash(manifest_path())
+    manifest_hash = (
+        compute_manifest_hash_bytes(manifest_content)
+        if manifest_content is not None
+        else compute_manifest_hash(manifest_path())
+    )
 
     metadata = LockfileMetadata(
         manifest_hash=manifest_hash,
         nanvix_zutil_version=get_zutil_version(),
+        sdk=sdk_provenance,
+        shallow=shallow,
     )
 
     return Lockfile(metadata=metadata, packages=list(resolved.values()))
 
 
-def is_stale(lockfile: Lockfile) -> bool:
+def is_stale(lockfile: Lockfile, *, shallow: bool | None = None) -> bool:
     """Check whether a lockfile is stale relative to its manifest.
 
     Compares the ``manifest_hash`` stored in the lockfile metadata
@@ -550,9 +767,31 @@ def is_stale(lockfile: Lockfile) -> bool:
 
     Args:
         lockfile: The lockfile to check.
+        shallow: Expected shallow-lock mode. When supplied, a lock generated
+            in the other mode is stale.
 
     Returns:
         ``True`` if the lockfile is stale (hashes differ).
     """
+    if shallow is not None and lockfile.metadata.shallow != shallow:
+        return True
     current_hash = compute_manifest_hash(manifest_path())
-    return lockfile.metadata.manifest_hash != current_hash
+    if lockfile.metadata.manifest_hash != current_hash:
+        return True
+    if (
+        lockfile.metadata.sdk is None
+        and b"[toolchain]" not in manifest_path().read_bytes()
+    ):
+        return False
+    manifest = load_manifest()
+    sdk_pin = manifest.toolchain.sdk
+    provenance = lockfile.metadata.sdk
+    if sdk_pin is None:
+        return provenance is not None
+    if provenance is None:
+        return True
+    return (
+        provenance.sdk_version != sdk_pin.version
+        or provenance.provider_id != sdk_pin.provider_id
+        or provenance.image.ref != sdk_pin.image_ref
+    )

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -61,11 +61,11 @@ from nanvix_zutil.helpers import (
     sync_configs,
 )
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
-from nanvix_zutil.manifest import Manifest, load_manifest
+from nanvix_zutil.manifest import Manifest, ToolchainKind, load_manifest
 from nanvix_zutil.paths import buildroot as _buildroot_dir
 from nanvix_zutil.paths import nanvix_root, out_dir, repo_root
 from nanvix_zutil.paths import sysroot as _sysroot_dir
-from nanvix_zutil.resolver import is_stale, resolve
+from nanvix_zutil.resolver import BlockedResolution, is_stale, resolve
 from nanvix_zutil.sysroot import Sysroot
 
 
@@ -113,6 +113,18 @@ class ZScript:
     SYSROOT_REQUIRED_FILES_WINDOWS: tuple[str, ...] = (
         "lib/libposix.a",
         "lib/user.ld",
+        "bin/nanvixd.exe",
+        "bin/kernel.elf",
+        "bin/mkramfs.exe",
+    )
+
+    SDK_RUNTIME_REQUIRED_FILES: tuple[str, ...] = (
+        "bin/nanvixd.elf",
+        "bin/kernel.elf",
+        "bin/mkramfs.elf",
+    )
+
+    SDK_RUNTIME_REQUIRED_FILES_WINDOWS: tuple[str, ...] = (
         "bin/nanvixd.exe",
         "bin/kernel.elf",
         "bin/mkramfs.exe",
@@ -190,7 +202,11 @@ class ZScript:
         Subclasses can extend by overriding the class attributes or
         this method.
         """
-        if is_windows():
+        if self.manifest.toolchain.kind == ToolchainKind.SDK and is_windows():
+            files = list(self.SDK_RUNTIME_REQUIRED_FILES_WINDOWS)
+        elif self.manifest.toolchain.kind == ToolchainKind.SDK:
+            files = list(self.SDK_RUNTIME_REQUIRED_FILES)
+        elif is_windows():
             files = list(self.SYSROOT_REQUIRED_FILES_WINDOWS)
         else:
             files = list(self.SYSROOT_REQUIRED_FILES)
@@ -395,13 +411,68 @@ class ZScript:
             # This is acceptable because offline resolution uses local
             # paths (deps/<name>/) which are version-agnostic.
 
+        sdk_releases: dict[str, dict[str, object]] = {}
+        sdk_mode = self.manifest.toolchain.kind == ToolchainKind.SDK
+        if sdk_mode and not self._offline:
+            resolution = resolve(
+                self.manifest,
+                gh_token=self.config.get(CFG_GH_TOKEN),
+                strict=True,
+            )
+            if isinstance(resolution, BlockedResolution):
+                log.fatal(
+                    f"SDK dependency resolution blocked: {resolution.package}"
+                    f" requires {resolution.requested_tag}",
+                    code=EXIT_MISSING_DEP,
+                    hint=resolution.reason,
+                )
+            packages = {pkg.name: pkg for pkg in resolution.packages}
+            selected: list[str] = []
+            pending = [dep.name for dep in deps]
+            while pending:
+                name = pending.pop(0)
+                if name in selected:
+                    continue
+                package = packages.get(name)
+                if package is None:
+                    log.fatal(
+                        f"Strict SDK lock has no package '{name}'",
+                        code=EXIT_MISSING_DEP,
+                    )
+                selected.append(name)
+                pending.extend(package.dependencies)
+            direct = {dep.name for dep in deps}
+            for name in selected:
+                package = packages[name]
+                sdk_releases[name] = {
+                    "tag_name": package.resolved_tag,
+                    "target_commitish": package.resolved_commitish,
+                    "id": package.release_id,
+                    "assets": [
+                        {
+                            "id": asset.asset_id,
+                            "name": asset.name,
+                            "browser_download_url": asset.url,
+                        }
+                        for asset in package.assets
+                    ],
+                }
+                if name not in direct:
+                    deps.append(
+                        Dependency(
+                            name=package.name,
+                            repo=package.repo,
+                            ref=package.ref,
+                        )
+                    )
+
         if deps:
             self.buildroot = Buildroot.create()
             for dep in deps:
                 # When --with-nanvix is active, try local artifacts first.
                 # In offline mode, try for ALL deps (not just nanvix-owned).
                 # In online mode, only try for nanvix-owned deps.
-                if nanvix_local:
+                if nanvix_local and (self._offline or not sdk_mode):
                     should_try_local = self._offline or dep.repo.startswith("nanvix/")
                     if should_try_local and self.buildroot.install_local_nanvix(
                         dep, Path(nanvix_local)
@@ -423,7 +494,14 @@ class ZScript:
                     # cross-mode asset fallback in install_dep().
                     release: dict[str, object] | None = None
                     base_version = extract_nanvix_version_base(str(dep.ref.value))
-                    if base_version is not None:
+                    if sdk_mode:
+                        release = sdk_releases.get(dep.name)
+                        if release is None:
+                            log.fatal(
+                                f"Strict SDK release missing for '{dep.name}'",
+                                code=EXIT_MISSING_DEP,
+                            )
+                    elif base_version is not None:
                         release, fb_ver = resolve_release_with_fallback(
                             repo=dep.repo,
                             version_specifier=str(dep.ref.value),
@@ -509,7 +587,15 @@ class ZScript:
             self.manifest,
             gh_token=self.config.get(CFG_GH_TOKEN),
             shallow=shallow,
+            strict=self.manifest.toolchain.kind == ToolchainKind.SDK,
         )
+        if isinstance(lockfile, BlockedResolution):
+            log.fatal(
+                f"SDK dependency resolution blocked: {lockfile.package}"
+                f" requires exact tag {lockfile.requested_tag}",
+                code=EXIT_MISSING_DEP,
+                hint=lockfile.reason,
+            )
         lock_path = nanvix_root() / "nanvix.lock"
         write_lockfile(lockfile, lock_path)
         log.success(f"Wrote {lock_path}")
@@ -662,26 +748,42 @@ class ZScript:
         # but we do not require Docker to be installed or the image to
         # exist locally.
         if args.subcommand in ZScript.DOCKER_COMMANDS:
-            image: str | None = getattr(args, "with_docker", None)
+            requested_image: str | None = getattr(args, "with_docker", None)
             persisted_image = instance.config.get(CFG_DOCKER_IMAGE)
+            manifest_image = instance.manifest.toolchain.effective_build_ref
+            allow_override = bool(getattr(args, "allow_local_docker_override", False))
+
+            if args.subcommand == "setup":
+                if (
+                    requested_image is not None
+                    and manifest_image is not None
+                    and requested_image != manifest_image
+                    and not allow_override
+                ):
+                    log.fatal(
+                        f"--with-docker {requested_image!r} conflicts with the"
+                        f" manifest build image {manifest_image!r}",
+                        code=EXIT_INVALID_ARGS,
+                        hint="Omit --with-docker, or use"
+                        " --allow-local-docker-override for an intentional"
+                        " local-development override.",
+                    )
+                image = requested_image or manifest_image or persisted_image
+            else:
+                image = persisted_image
 
             if image is None:
-                if not persisted_image:
-                    log.fatal(
-                        "No Docker image configured — run 'setup --with-docker IMAGE' first.",
-                        code=EXIT_INVALID_ARGS,
-                    )
-                image = persisted_image
+                log.fatal(
+                    "No Docker image configured. SDK manifests must define an"
+                    " immutable build image; legacy manifests must run"
+                    " 'setup --with-docker IMAGE'.",
+                    code=EXIT_INVALID_ARGS,
+                )
 
             # TODO: Move into setup()
             # https://github.com/nanvix/zutils/issues/187
             # https://github.com/nanvix/zutils/issues/190
             if args.subcommand == "setup":
-                if persisted_image is not None and persisted_image != image:
-                    log.warning(
-                        f"Overriding previously configured Docker image '{persisted_image}'"
-                        f" with '{image}'."
-                    )
                 instance.config.set(CFG_DOCKER_IMAGE, image)
                 instance.config.save()
 

--- a/src/nanvix_zutil/sdk.py
+++ b/src/nanvix_zutil/sdk.py
@@ -1,0 +1,655 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Nanvix SDK release coordinates and provenance verification."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import cast
+
+from nanvix_zutil import github
+from nanvix_zutil.exitcodes import (
+    EXIT_INVALID_ARGS,
+    EXIT_MISSING_DEP,
+    EXIT_NETWORK_ERROR,
+)
+from nanvix_zutil.log import fatal
+
+SDK_RELEASE_ASSET = "sdk-release.json"
+SDK_REPOSITORY = "nanvix/sdk"
+SDK_LABEL_PREFIX = "dev.nanvix.sdk."
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_SDK_VERSION_RE = re.compile(
+    r"^v?(?P<runtime>[0-9]+\.[0-9]+\.[0-9]+)-sdk\.(?P<revision>[1-9][0-9]*)$"
+)
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_REQUIRED_TOP_LEVEL = frozenset(
+    {
+        "schema_version",
+        "sdk_version",
+        "provider_id",
+        "provider",
+        "role",
+        "image",
+        "target",
+        "toolchain",
+        "libc",
+        "compat",
+        "features",
+    }
+)
+
+
+class SdkValidationError(ValueError):
+    """Raised when SDK release provenance is malformed or inconsistent."""
+
+
+@dataclass(frozen=True)
+class SdkImage:
+    """Immutable SDK image coordinate."""
+
+    name: str
+    digest: str
+    ref: str
+
+
+@dataclass(frozen=True)
+class SdkProvenance:
+    """Verified SDK provenance persisted in a consumer lockfile."""
+
+    sdk_version: str
+    provider_id: str
+    provider: str
+    role: str
+    image: SdkImage
+    nanvix_tag: str
+    nanvix_version: str
+    nanvix_commit: str
+    sysroot_sha256: str
+    compat: dict[str, object]
+    schema_version: int = 1
+    target: dict[str, object] = field(default_factory=lambda: dict[str, object]())
+    toolchain: dict[str, object] = field(default_factory=lambda: dict[str, object]())
+    features: dict[str, object] = field(default_factory=lambda: dict[str, object]())
+
+
+@dataclass(frozen=True)
+class SdkRelease:
+    """Validated ``sdk-release.json`` contract."""
+
+    schema_version: int
+    sdk_version: str
+    provider_id: str
+    provider: str
+    role: str
+    image: SdkImage
+    target: dict[str, object]
+    toolchain: dict[str, object]
+    libc: dict[str, object]
+    compat: dict[str, object]
+    features: dict[str, object]
+
+    @property
+    def runtime_version(self) -> str:
+        """Return the Nanvix runtime version pinned by this SDK."""
+        return cast(str, self.libc["nanvix_version"])
+
+    @property
+    def revision(self) -> int:
+        """Return the numeric SDK revision."""
+        match = _SDK_VERSION_RE.fullmatch(self.sdk_version)
+        assert match is not None
+        return int(match.group("revision"))
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the canonical release contract as a JSON-compatible object."""
+        return {
+            "schema_version": self.schema_version,
+            "sdk_version": self.sdk_version,
+            "provider_id": self.provider_id,
+            "provider": self.provider,
+            "role": self.role,
+            "image": {
+                "name": self.image.name,
+                "digest": self.image.digest,
+                "ref": self.image.ref,
+            },
+            "target": dict(self.target),
+            "toolchain": dict(self.toolchain),
+            "libc": dict(self.libc),
+            "compat": dict(self.compat),
+            "features": dict(self.features),
+        }
+
+    def provenance(self) -> SdkProvenance:
+        """Return the lockfile provenance represented by this contract."""
+        return SdkProvenance(
+            sdk_version=self.sdk_version,
+            provider_id=self.provider_id,
+            provider=self.provider,
+            role=self.role,
+            image=self.image,
+            nanvix_tag=cast(str, self.libc["nanvix_tag"]),
+            nanvix_version=self.runtime_version,
+            nanvix_commit=cast(str, self.libc["nanvix_commit"]),
+            sysroot_sha256=cast(str, self.libc["sysroot_sha256"]),
+            compat=dict(self.compat),
+            schema_version=self.schema_version,
+            target=dict(self.target),
+            toolchain=dict(self.toolchain),
+            features=dict(self.features),
+        )
+
+
+def parse_sdk_version(version: str) -> tuple[str, int]:
+    """Parse ``v<RUNTIME>-sdk.<REVISION>`` into runtime and revision."""
+    match = _SDK_VERSION_RE.fullmatch(version)
+    if match is None:
+        raise SdkValidationError(
+            f"invalid SDK version {version!r}; expected v<RUNTIME>-sdk.<REVISION>"
+        )
+    return match.group("runtime"), int(match.group("revision"))
+
+
+def sdk_consumer_release_tag(package_version: str, sdk_version: str) -> str:
+    """Build an exact SDK-aware consumer dependency release tag."""
+    if not package_version or any(ch.isspace() for ch in package_version):
+        raise SdkValidationError(
+            "package version must be non-empty and whitespace-free"
+        )
+    runtime, revision = parse_sdk_version(sdk_version)
+    return f"{package_version}-nanvix-{runtime}-sdk.{revision}"
+
+
+def consumer_release_tag(
+    package_version: str,
+    nanvix_version: str,
+    sdk_version: str | None = None,
+) -> str:
+    """Build a legacy or SDK-aware consumer dependency release tag."""
+    if sdk_version is None:
+        return f"{package_version}-nanvix-{nanvix_version.removeprefix('v')}"
+    runtime, _revision = parse_sdk_version(sdk_version)
+    if runtime != nanvix_version.removeprefix("v"):
+        raise SdkValidationError(
+            f"SDK runtime {runtime} does not match Nanvix {nanvix_version}"
+        )
+    return sdk_consumer_release_tag(package_version, sdk_version)
+
+
+def _object(value: object, path: str) -> dict[str, object]:
+    """Return *value* as an object or raise a path-specific validation error."""
+    if not isinstance(value, dict):
+        raise SdkValidationError(f"{path} must be an object")
+    return cast(dict[str, object], value)
+
+
+def _string(
+    value: object,
+    path: str,
+    *,
+    pattern: re.Pattern[str] | None = None,
+) -> str:
+    """Return a non-empty string after optional pattern validation."""
+    if not isinstance(value, str) or not value:
+        raise SdkValidationError(f"{path} must be a non-empty string")
+    if pattern is not None and pattern.fullmatch(value) is None:
+        raise SdkValidationError(f"{path} has invalid value {value!r}")
+    return value
+
+
+def validate_sdk_release(data: object) -> SdkRelease:
+    """Validate and parse a schema-version-1 SDK release contract."""
+    root = _object(data, "sdk release")
+    missing = sorted(_REQUIRED_TOP_LEVEL - root.keys())
+    if missing:
+        raise SdkValidationError(
+            f"sdk release is missing required keys: {', '.join(missing)}"
+        )
+    extra = sorted(root.keys() - _REQUIRED_TOP_LEVEL)
+    if extra:
+        raise SdkValidationError(f"sdk release has unexpected keys: {', '.join(extra)}")
+    if (
+        not isinstance(root["schema_version"], int)
+        or isinstance(root["schema_version"], bool)
+        or root["schema_version"] != 1
+    ):
+        raise SdkValidationError("schema_version must be 1")
+
+    sdk_version = _string(root["sdk_version"], "sdk_version")
+    runtime_from_version, _revision = parse_sdk_version(sdk_version)
+    provider_id = _string(root["provider_id"], "provider_id")
+    provider = _string(root["provider"], "provider")
+    role = _string(root["role"], "role")
+    if provider_id != "c-clang" or provider != "clang" or role != "c":
+        raise SdkValidationError(
+            "unsupported SDK provider tuple; expected c-clang/clang/c"
+        )
+
+    image_data = _object(root["image"], "image")
+    if set(image_data) != {"name", "digest", "ref"}:
+        raise SdkValidationError("image must contain exactly name, digest, and ref")
+    image = SdkImage(
+        name=_string(image_data["name"], "image.name"),
+        digest=_string(image_data["digest"], "image.digest", pattern=_DIGEST_RE),
+        ref=_string(image_data["ref"], "image.ref"),
+    )
+    if image.ref != f"{image.name}@{image.digest}":
+        raise SdkValidationError(
+            "image.ref must be the immutable '<image.name>@<image.digest>' coordinate"
+        )
+    expected_image = f"ghcr.io/nanvix/nanvix-sdk-{provider_id}"
+    if image.name != expected_image:
+        raise SdkValidationError(
+            f"image.name must be {expected_image!r} for provider {provider_id!r}"
+        )
+
+    target = _object(root["target"], "target")
+    toolchain = _object(root["toolchain"], "toolchain")
+    libc = _object(root["libc"], "libc")
+    compat = _object(root["compat"], "compat")
+    features = _object(root["features"], "features")
+    expected_nested_keys = {
+        "target": {"triple", "alias"},
+        "toolchain": {"llvm_version", "llvm_commit", "port_branch"},
+        "libc": {
+            "nanvix_tag",
+            "nanvix_version",
+            "nanvix_commit",
+            "sysroot_sha256",
+        },
+        "compat": {"c_abi", "cxx_abi", "abi", "min_nanvix_os"},
+        "features": {
+            "localization",
+            "filesystem",
+            "wide_chars",
+            "compiler_rt",
+            "dynamic_loader",
+        },
+    }
+    for name, value in (
+        ("target", target),
+        ("toolchain", toolchain),
+        ("libc", libc),
+        ("compat", compat),
+        ("features", features),
+    ):
+        expected_keys = expected_nested_keys[name]
+        if set(value) != expected_keys:
+            missing_keys = sorted(expected_keys - value.keys())
+            extra_keys = sorted(value.keys() - expected_keys)
+            details = [
+                *(f"missing {key}" for key in missing_keys),
+                *(f"unexpected {key}" for key in extra_keys),
+            ]
+            raise SdkValidationError(
+                f"{name} does not match schema: {', '.join(details)}"
+            )
+    for key in ("triple", "alias"):
+        _string(target.get(key), f"target.{key}")
+    if target["triple"] != "i686-unknown-nanvix":
+        raise SdkValidationError("target.triple must be 'i686-unknown-nanvix'")
+    if target["alias"] != "i686-nanvix":
+        raise SdkValidationError("target.alias must be 'i686-nanvix'")
+
+    for key in ("llvm_version", "llvm_commit", "port_branch"):
+        _string(toolchain.get(key), f"toolchain.{key}")
+    _string(toolchain["llvm_commit"], "toolchain.llvm_commit", pattern=_COMMIT_RE)
+
+    for key in (
+        "nanvix_tag",
+        "nanvix_version",
+        "nanvix_commit",
+        "sysroot_sha256",
+    ):
+        _string(libc.get(key), f"libc.{key}")
+    nanvix_tag = cast(str, libc["nanvix_tag"])
+    nanvix_version = cast(str, libc["nanvix_version"])
+    if nanvix_tag != f"v{nanvix_version}":
+        raise SdkValidationError("libc.nanvix_tag and libc.nanvix_version disagree")
+    if nanvix_version != runtime_from_version:
+        raise SdkValidationError("sdk_version and libc.nanvix_version disagree")
+    _string(libc["nanvix_commit"], "libc.nanvix_commit", pattern=_COMMIT_RE)
+    sysroot_digest = cast(str, libc["sysroot_sha256"])
+    if (
+        _DIGEST_RE.fullmatch(sysroot_digest) is None
+        and re.fullmatch(r"[0-9a-f]{64}", sysroot_digest) is None
+    ):
+        raise SdkValidationError("libc.sysroot_sha256 must be a SHA-256 digest")
+
+    for key in ("c_abi", "cxx_abi", "abi", "min_nanvix_os"):
+        _string(compat.get(key), f"compat.{key}")
+    for key in ("localization", "filesystem", "wide_chars", "dynamic_loader"):
+        if not isinstance(features.get(key), bool):
+            raise SdkValidationError(f"features.{key} must be a boolean")
+    compiler_rt = features.get("compiler_rt")
+    if compiler_rt not in {"builtins-only", "full"}:
+        raise SdkValidationError(
+            "features.compiler_rt must be 'builtins-only' or 'full'"
+        )
+    min_os = cast(str, compat["min_nanvix_os"]).removeprefix("v")
+    try:
+        min_parts = tuple(int(part) for part in min_os.split("."))
+        runtime_parts = tuple(int(part) for part in nanvix_version.split("."))
+    except ValueError as exc:
+        raise SdkValidationError(
+            "compat.min_nanvix_os must be a semantic version"
+        ) from exc
+    if len(min_parts) != 3 or min_parts > runtime_parts:
+        raise SdkValidationError("compat.min_nanvix_os exceeds the pinned runtime")
+
+    return SdkRelease(
+        schema_version=1,
+        sdk_version=sdk_version,
+        provider_id=provider_id,
+        provider=provider,
+        role=role,
+        image=image,
+        target=dict(target),
+        toolchain=dict(toolchain),
+        libc=dict(libc),
+        compat=dict(compat),
+        features=dict(features),
+    )
+
+
+def _artifact_contract(contract: SdkRelease) -> dict[str, object]:
+    """Return fields that can be embedded before an image digest exists."""
+    result = contract.to_dict()
+    del result["image"]
+    # These release-level coordinates are derived from the provider image and
+    # SDK tag for schema-1 images published before the completion asset existed.
+    # Newer images may carry them too; verification normalizes both forms.
+    del result["provider_id"]
+    libc = _object(result["libc"], "libc")
+    libc.pop("nanvix_version", None)
+    return result
+
+
+def _normalize_embedded(
+    value: object,
+    path: str,
+    contract: SdkRelease,
+) -> dict[str, object]:
+    """Normalize release-derived fields absent from schema-1 image manifests."""
+    source = _object(value, path)
+    result = dict(source)
+    raw_image = result.pop("image", None)
+    if raw_image is not None and raw_image != contract.to_dict()["image"]:
+        raise SdkValidationError(f"{path} image coordinate conflicts with release")
+    raw_provider_id = result.pop("provider_id", None)
+    if raw_provider_id is not None and raw_provider_id != contract.provider_id:
+        raise SdkValidationError(f"{path} provider_id conflicts with release")
+    raw_libc = result.get("libc")
+    if isinstance(raw_libc, dict):
+        libc = dict(cast("dict[str, object]", raw_libc))
+        raw_version = libc.pop("nanvix_version", None)
+        if raw_version is not None and raw_version != contract.runtime_version:
+            raise SdkValidationError(
+                f"{path} libc.nanvix_version conflicts with release"
+            )
+        result["libc"] = libc
+    return result
+
+
+def verify_sdk_metadata(
+    contract: SdkRelease,
+    embedded: object,
+    labels: object,
+    docker_digest: str,
+) -> None:
+    """Verify release, embedded manifest, OCI labels, and Docker digest agree."""
+    expected = _artifact_contract(contract)
+    comparable = _normalize_embedded(
+        embedded,
+        "embedded SDK manifest",
+        contract,
+    )
+    if comparable != expected:
+        raise SdkValidationError(
+            "embedded /opt/nanvix/nanvix-sdk.json does not match sdk-release.json"
+        )
+
+    label_obj = _object(labels, "OCI labels")
+    manifest_label = label_obj.get(f"{SDK_LABEL_PREFIX}manifest")
+    if isinstance(manifest_label, str):
+        try:
+            label_manifest: object = json.loads(manifest_label)
+        except json.JSONDecodeError as exc:
+            raise SdkValidationError(
+                "OCI SDK manifest label is malformed JSON"
+            ) from exc
+        if (
+            _normalize_embedded(
+                label_manifest,
+                "OCI SDK manifest label",
+                contract,
+            )
+            != expected
+        ):
+            raise SdkValidationError("OCI SDK manifest label does not match release")
+    else:
+        missing: list[str] = []
+        mismatched: list[str] = []
+
+        def compare(prefix: str, value: object) -> None:
+            if isinstance(value, dict):
+                for key, child in cast(dict[str, object], value).items():
+                    compare(f"{prefix}.{key}" if prefix else key, child)
+                return
+            key = f"{SDK_LABEL_PREFIX}{prefix}"
+            actual = label_obj.get(key)
+            rendered = (
+                "true" if value is True else "false" if value is False else str(value)
+            )
+            if actual is None:
+                # schema-1 images compute the staged sysroot digest during the
+                # build, after static OCI labels are assembled. The value is
+                # authoritative in the embedded manifest and release contract.
+                if prefix != "libc.sysroot_sha256":
+                    missing.append(key)
+            elif actual != rendered:
+                mismatched.append(key)
+
+        compare("", expected)
+        optional_labels = {
+            f"{SDK_LABEL_PREFIX}provider_id": contract.provider_id,
+            f"{SDK_LABEL_PREFIX}libc.nanvix_version": contract.runtime_version,
+            f"{SDK_LABEL_PREFIX}image.name": contract.image.name,
+            f"{SDK_LABEL_PREFIX}image.digest": contract.image.digest,
+            f"{SDK_LABEL_PREFIX}image.ref": contract.image.ref,
+        }
+        for key, expected_value in optional_labels.items():
+            actual = label_obj.get(key)
+            if actual is not None and actual != expected_value:
+                mismatched.append(key)
+        if missing or mismatched:
+            details = [*(f"missing {key}" for key in missing)]
+            details.extend(f"mismatched {key}" for key in mismatched)
+            raise SdkValidationError(
+                "OCI labels do not match release: " + ", ".join(details)
+            )
+
+    if docker_digest != contract.image.digest:
+        raise SdkValidationError(
+            f"Docker digest {docker_digest!r} does not match {contract.image.digest!r}"
+        )
+
+
+def _release_asset(release: dict[str, object]) -> tuple[str, str]:
+    """Extract the unique SDK contract URL and digest from release metadata."""
+    raw_assets = release.get("assets")
+    if not isinstance(raw_assets, list):
+        raise SdkValidationError("GitHub SDK release has no assets array")
+    matches: list[tuple[str, str]] = []
+    for item in cast(list[object], raw_assets):
+        if not isinstance(item, dict):
+            continue
+        asset = cast(dict[str, object], item)
+        if asset.get("name") != SDK_RELEASE_ASSET:
+            continue
+        url = asset.get("browser_download_url")
+        digest = asset.get("digest")
+        if isinstance(url, str) and isinstance(digest, str):
+            matches.append((url, digest))
+    if len(matches) != 1:
+        raise SdkValidationError(
+            f"GitHub SDK release must contain exactly one {SDK_RELEASE_ASSET}"
+        )
+    url, digest = matches[0]
+    if _DIGEST_RE.fullmatch(digest) is None:
+        raise SdkValidationError("SDK release contract asset has no valid digest")
+    return url, digest
+
+
+def _fetch_contract(
+    url: str,
+    expected_digest: str,
+    gh_token: str | None,
+) -> object:
+    """Fetch a release contract without writing it to disk."""
+    headers = {
+        "Accept": "application/octet-stream",
+        "User-Agent": "nanvix-zutil",
+    }
+    if gh_token:
+        headers["Authorization"] = f"Bearer {gh_token}"
+    try:
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=30.0) as response:
+            data = response.read()
+        actual_digest = f"sha256:{hashlib.sha256(data).hexdigest()}"
+        if actual_digest != expected_digest:
+            raise SdkValidationError(
+                "SDK release contract asset digest does not match GitHub metadata"
+            )
+        return json.loads(data)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise SdkValidationError(
+            f"failed to fetch SDK release contract: {exc}"
+        ) from exc
+
+
+def resolve_sdk_release(
+    version: str = "latest",
+    *,
+    provider_id: str = "c-clang",
+    gh_token: str | None = None,
+    verify_image: bool = True,
+) -> SdkRelease:
+    """Resolve and verify an authoritative SDK GitHub Release asset."""
+    try:
+        release = github.resolve_release(SDK_REPOSITORY, version, gh_token=gh_token)
+        asset_url, asset_digest = _release_asset(release)
+        contract = validate_sdk_release(
+            _fetch_contract(asset_url, asset_digest, gh_token)
+        )
+        release_tag = release.get("tag_name")
+        if not isinstance(release_tag, str) or release_tag != contract.sdk_version:
+            raise SdkValidationError("GitHub release tag and sdk_version disagree")
+        if provider_id != contract.provider_id:
+            raise SdkValidationError(
+                f"requested provider {provider_id!r}, release provides {contract.provider_id!r}"
+            )
+        if version != "latest" and version != contract.sdk_version:
+            raise SdkValidationError(
+                f"requested SDK {version!r}, release provides {contract.sdk_version!r}"
+            )
+        if verify_image:
+            verify_sdk_image(contract)
+        return contract
+    except SdkValidationError as exc:
+        fatal(str(exc), code=EXIT_INVALID_ARGS)
+    except SystemExit:
+        raise
+    except OSError as exc:
+        fatal(f"failed to resolve SDK release: {exc}", code=EXIT_NETWORK_ERROR)
+
+
+def verify_sdk_image(contract: SdkRelease, *, pull: bool = True) -> None:
+    """Verify an SDK image's digest, embedded manifest, and OCI labels.
+
+    Args:
+        contract: Validated release contract.
+        pull: Pull the immutable reference first. Offline callers may set this
+            to ``False`` to verify an already-present image.
+    """
+    try:
+        if pull:
+            pull_result = subprocess.run(
+                ["docker", "pull", contract.image.ref],
+                capture_output=True,
+                text=True,
+                timeout=600,
+                check=False,
+            )
+            if pull_result.returncode != 0:
+                fatal(
+                    f"failed to pull verified SDK image {contract.image.ref}:"
+                    f" {pull_result.stderr.strip()}",
+                    code=EXIT_MISSING_DEP,
+                )
+        inspect = subprocess.run(
+            ["docker", "image", "inspect", contract.image.ref],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        embedded = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                contract.image.ref,
+                "cat",
+                "/opt/nanvix/nanvix-sdk.json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        fatal(f"Docker SDK verification failed: {exc}", code=EXIT_MISSING_DEP)
+    if inspect.returncode != 0 or embedded.returncode != 0:
+        fatal("Docker SDK metadata inspection failed", code=EXIT_MISSING_DEP)
+    try:
+        inspected: object = json.loads(inspect.stdout)
+        embedded_data: object = json.loads(embedded.stdout)
+        if not isinstance(inspected, list):
+            raise SdkValidationError(
+                "docker image inspect returned an unexpected result"
+            )
+        inspected_items = cast("list[object]", inspected)
+        if len(inspected_items) != 1:
+            raise SdkValidationError(
+                "docker image inspect returned an unexpected result"
+            )
+        image_data = _object(inspected_items[0], "docker image inspect")
+        config = _object(image_data.get("Config"), "docker image Config")
+        labels = config.get("Labels")
+        repo_digests = image_data.get("RepoDigests")
+        if not isinstance(repo_digests, list):
+            raise SdkValidationError("docker image inspect has no RepoDigests")
+        expected_ref = contract.image.ref
+        if expected_ref not in repo_digests:
+            raise SdkValidationError(
+                "Docker RepoDigests does not contain the release ref"
+            )
+        verify_sdk_metadata(
+            contract,
+            embedded_data,
+            labels,
+            expected_ref.rpartition("@")[2],
+        )
+    except (json.JSONDecodeError, SdkValidationError) as exc:
+        fatal(f"SDK image verification failed: {exc}", code=EXIT_INVALID_ARGS)

--- a/src/nanvix_zutil/updater.py
+++ b/src/nanvix_zutil/updater.py
@@ -157,6 +157,15 @@ def _fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
+def _fsync_file(path: Path) -> None:
+    """Flush a file through a Windows-compatible read-write descriptor."""
+    descriptor = os.open(path, os.O_RDWR)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _write_journal(journal: Path, data: dict[str, object]) -> None:
     """Crash-safely replace the transaction journal."""
     sidecar = journal.with_name(f".{journal.name}.{os.getpid()}.new")
@@ -189,8 +198,7 @@ def _remove_journal(journal: Path, data: dict[str, object]) -> None:
         payload = (json.dumps(data, sort_keys=True) + "\n").encode("utf-8")
         journal.write_bytes(payload)
         journal.chmod(0o600)
-        with journal.open("rb") as stream:
-            os.fsync(stream.fileno())
+        _fsync_file(journal)
         raise
 
 
@@ -208,8 +216,7 @@ def _restore_snapshot(
     sidecar.write_bytes(snapshot)
     sidecar.chmod(mode)
     try:
-        with sidecar.open("rb") as stream:
-            os.fsync(stream.fileno())
+        _fsync_file(sidecar)
         os.replace(sidecar, target)
         _fsync_directory(target.parent)
     finally:
@@ -458,8 +465,7 @@ def _atomic_write_candidates(
             sidecar = target.with_name(f".{target.name}.nanvix-zutil-{os.getpid()}")
             sidecar.write_bytes(normalized[relative])
             sidecar.chmod(modes[relative])
-            with sidecar.open("rb") as stream:
-                os.fsync(stream.fileno())
+            _fsync_file(sidecar)
             sidecars[relative] = sidecar
         for name in changed:
             relative = Path(name)

--- a/src/nanvix_zutil/updater.py
+++ b/src/nanvix_zutil/updater.py
@@ -1,0 +1,566 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Pure, confined, atomic file-update helpers."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import stat
+import tomllib
+from collections.abc import Callable
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from nanvix_zutil.sdk import SdkRelease, validate_sdk_release
+
+
+class UpdateError(ValueError):
+    """Raised when an update candidate violates a safety invariant."""
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Deterministic result from an update command."""
+
+    command: str
+    status: str
+    target: str
+    changed_files: tuple[str, ...]
+    old: dict[str, object] | None = None
+    new: dict[str, object] | None = None
+    blocker: dict[str, object] | None = None
+
+    @property
+    def changed(self) -> bool:
+        """Return whether tracked target files differ."""
+        return bool(self.changed_files)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a machine-readable result."""
+        result: dict[str, object] = {
+            "command": self.command,
+            "status": self.status,
+            "target": self.target,
+            "changed": self.changed,
+            "changed_files": list(self.changed_files),
+        }
+        if self.old is not None:
+            result["old"] = self.old
+        if self.new is not None:
+            result["new"] = self.new
+        if self.blocker is not None:
+            result["blocker"] = self.blocker
+        return result
+
+
+def find_target_root(start: Path | None = None) -> Path:
+    """Find a consumer or zutils source root without invoking Git."""
+    current = (start or Path.cwd()).resolve()
+    for root in (current, *current.parents):
+        if (root / ".nanvix").is_dir():
+            return root
+        if (
+            (root / "pyproject.toml").is_file()
+            and (root / "templates").is_dir()
+            and (root / "examples").is_dir()
+        ):
+            try:
+                data = tomllib.loads((root / "pyproject.toml").read_text("utf-8"))
+            except (OSError, tomllib.TOMLDecodeError):
+                continue
+            project = data.get("project")
+            if (
+                isinstance(project, dict)
+                and cast("dict[str, object]", project).get("name") == "nanvix-zutil"
+            ):
+                return root
+    raise UpdateError("could not find a Nanvix consumer or zutils source root")
+
+
+def is_zutils_source(root: Path) -> bool:
+    """Return whether *root* is a zutils source checkout."""
+    return (root / "templates" / ".zutils-version").is_file() and (
+        root / "examples"
+    ).is_dir()
+
+
+def load_sdk_target(value: str, root: Path) -> SdkRelease | None:
+    """Parse an inline or local ``sdk-release.json`` target.
+
+    A plain semantic version is intentionally not resolved over the network;
+    update commands consume an already verified release contract and never
+    access credentials.
+    """
+    candidate = Path(value)
+    data: object
+    if value.lstrip().startswith("{"):
+        try:
+            data = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise UpdateError(f"--to contains malformed JSON: {exc}") from exc
+    elif (
+        candidate.is_absolute()
+        or (root / candidate).exists()
+        or "/" in value
+        or "\\" in value
+    ):
+        path = candidate if candidate.is_absolute() else root / candidate
+        try:
+            resolved = path.resolve(strict=True)
+            resolved.relative_to(root)
+        except (OSError, ValueError) as exc:
+            raise UpdateError(
+                "SDK contract path must be an existing file under the target root"
+            ) from exc
+        try:
+            data = json.loads(resolved.read_text("utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise UpdateError(f"cannot read SDK contract {resolved}: {exc}") from exc
+    else:
+        return None
+    try:
+        return validate_sdk_release(data)
+    except ValueError as exc:
+        raise UpdateError(str(exc)) from exc
+
+
+def _safe_target(root: Path, relative: Path) -> Path:
+    """Resolve a transaction destination without following a target symlink."""
+    if relative.is_absolute() or ".." in relative.parts:
+        raise UpdateError(f"unsafe update path: {relative}")
+    raw_target = root / relative
+    try:
+        parent = raw_target.parent.resolve(strict=True)
+        parent.relative_to(root)
+    except (OSError, ValueError) as exc:
+        raise UpdateError(f"update path escapes target root: {relative}") from exc
+    target = parent / raw_target.name
+    if target.is_symlink():
+        raise UpdateError(f"update target is a symlink: {relative}")
+    return target
+
+
+def _fsync_directory(path: Path) -> None:
+    """Flush directory metadata where the platform supports it."""
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_journal(journal: Path, data: dict[str, object]) -> None:
+    """Crash-safely replace the transaction journal."""
+    sidecar = journal.with_name(f".{journal.name}.{os.getpid()}.new")
+    payload = (json.dumps(data, sort_keys=True) + "\n").encode("utf-8")
+    descriptor = os.open(
+        sidecar,
+        os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+        0o600,
+    )
+    try:
+        offset = 0
+        while offset < len(payload):
+            offset += os.write(descriptor, payload[offset:])
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.replace(sidecar, journal)
+        _fsync_directory(journal.parent)
+    finally:
+        sidecar.unlink(missing_ok=True)
+
+
+def _remove_journal(journal: Path, data: dict[str, object]) -> None:
+    """Remove a journal durably, recreating it if directory fsync fails."""
+    journal.unlink(missing_ok=True)
+    try:
+        _fsync_directory(journal.parent)
+    except OSError:
+        payload = (json.dumps(data, sort_keys=True) + "\n").encode("utf-8")
+        journal.write_bytes(payload)
+        journal.chmod(0o600)
+        with journal.open("rb") as stream:
+            os.fsync(stream.fileno())
+        raise
+
+
+def _restore_snapshot(
+    target: Path,
+    snapshot: bytes | None,
+    mode: int,
+) -> None:
+    """Restore one snapshot using a mode-safe same-directory replacement."""
+    if snapshot is None:
+        target.unlink(missing_ok=True)
+        _fsync_directory(target.parent)
+        return
+    sidecar = target.with_name(f".{target.name}.nanvix-zutil-rollback-{os.getpid()}")
+    sidecar.write_bytes(snapshot)
+    sidecar.chmod(mode)
+    try:
+        with sidecar.open("rb") as stream:
+            os.fsync(stream.fileno())
+        os.replace(sidecar, target)
+        _fsync_directory(target.parent)
+    finally:
+        sidecar.unlink(missing_ok=True)
+
+
+def _recover_journal(root: Path, journal: Path) -> None:
+    """Recover an interrupted multi-file transaction while holding its lock."""
+    if not journal.is_file():
+        return
+    try:
+        raw: object = json.loads(journal.read_text("utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("journal root is not an object")
+        data = cast("dict[str, object]", raw)
+        if data.get("state") == "committed":
+            _remove_journal(journal, data)
+            return
+        if data.get("state") != "installing":
+            raise ValueError("journal state is invalid")
+        raw_files = data.get("files")
+        if not isinstance(raw_files, list):
+            raise ValueError("journal files are missing")
+        entries: list[tuple[Path, bytes | None, int]] = []
+        for item in cast("list[object]", raw_files):
+            if not isinstance(item, dict):
+                raise ValueError("journal file entry is invalid")
+            entry = cast("dict[str, object]", item)
+            relative_value = entry.get("path")
+            mode = entry.get("mode")
+            encoded = entry.get("content")
+            if (
+                not isinstance(relative_value, str)
+                or not isinstance(mode, int)
+                or isinstance(mode, bool)
+            ):
+                raise ValueError("journal file metadata is invalid")
+            target = _safe_target(root, Path(relative_value))
+            if encoded is None:
+                snapshot = None
+            elif isinstance(encoded, str):
+                snapshot = base64.b64decode(encoded, validate=True)
+            else:
+                raise ValueError("journal content is invalid")
+            entries.append((target, snapshot, mode))
+        for target, snapshot, mode in entries:
+            _restore_snapshot(target, snapshot, mode)
+        _remove_journal(journal, data)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise UpdateError(f"cannot recover interrupted update: {exc}") from exc
+
+
+def _windows_lock(descriptor: int) -> None:
+    """Acquire a non-blocking one-byte Windows file lock."""
+    import msvcrt
+
+    if os.fstat(descriptor).st_size == 0:
+        os.write(descriptor, b"\0")
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    locking = cast(
+        "Callable[[int, int, int], None]",
+        getattr(msvcrt, "locking"),
+    )
+    mode = cast(int, getattr(msvcrt, "LK_NBLCK"))
+    try:
+        locking(descriptor, mode, 1)
+    except OSError as exc:
+        raise BlockingIOError("update lock is held") from exc
+
+
+def _windows_unlock(descriptor: int) -> None:
+    """Release a one-byte Windows file lock."""
+    import msvcrt
+
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    locking = cast(
+        "Callable[[int, int, int], None]",
+        getattr(msvcrt, "locking"),
+    )
+    mode = cast(int, getattr(msvcrt, "LK_UNLCK"))
+    locking(descriptor, mode, 1)
+
+
+def _lock_descriptor(descriptor: int) -> None:
+    """Acquire a non-destructive cross-platform OS file lock."""
+    if os.name == "nt":
+        _windows_lock(descriptor)
+        return
+    import fcntl
+
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        raise BlockingIOError("update lock is held") from exc
+
+
+def _unlock_descriptor(descriptor: int) -> None:
+    """Release a cross-platform OS file lock."""
+    if os.name == "nt":
+        _windows_unlock(descriptor)
+        return
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+def _state_paths(root: Path) -> tuple[Path, Path]:
+    """Return confined lock and journal paths for a target repository."""
+    state_dir = root if is_zutils_source(root) else root / ".nanvix"
+    if not state_dir.is_dir():
+        raise UpdateError(f"update state directory does not exist: {state_dir}")
+    return (
+        state_dir / ".nanvix-zutil-update.lock",
+        state_dir / ".nanvix-zutil-update-journal.json",
+    )
+
+
+@dataclass
+class UpdateTransaction:
+    """A locked, recovered repository update transaction."""
+
+    root: Path
+    journal: Path
+
+    def install(
+        self,
+        candidates: dict[Path, bytes],
+        validators: dict[Path, Callable[[bytes], None]],
+        *,
+        create_modes: dict[Path, int] | None = None,
+    ) -> tuple[str, ...]:
+        """Validate and atomically install candidate bytes."""
+        return _atomic_write_candidates(
+            self.root,
+            candidates,
+            validators,
+            self.journal,
+            create_modes=create_modes or {},
+        )
+
+
+@contextmanager
+def update_transaction(root: Path) -> Generator[UpdateTransaction]:
+    """Lock and recover a repository before any managed file is parsed."""
+    resolved_root = root.resolve()
+    lock, journal = _state_paths(resolved_root)
+    descriptor = os.open(lock, os.O_CREAT | os.O_RDWR, 0o600)
+    locked = False
+    try:
+        try:
+            _lock_descriptor(descriptor)
+            locked = True
+        except BlockingIOError as exc:
+            raise UpdateError("another nanvix-zutil update is already running") from exc
+        _recover_journal(resolved_root, journal)
+        yield UpdateTransaction(resolved_root, journal)
+    finally:
+        try:
+            if locked:
+                _unlock_descriptor(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def atomic_write_candidates(
+    root: Path,
+    candidates: dict[Path, bytes],
+    validators: dict[Path, Callable[[bytes], None]],
+    *,
+    create_modes: dict[Path, int] | None = None,
+) -> tuple[str, ...]:
+    """Recover, lock, and atomically install candidate bytes."""
+    with update_transaction(root) as transaction:
+        return transaction.install(
+            candidates,
+            validators,
+            create_modes=create_modes,
+        )
+
+
+def _atomic_write_candidates(
+    root: Path,
+    candidates: dict[Path, bytes],
+    validators: dict[Path, Callable[[bytes], None]],
+    journal: Path,
+    *,
+    create_modes: dict[Path, int],
+) -> tuple[str, ...]:
+    """Install candidates while retaining a recoverable journal."""
+    normalized: dict[Path, bytes] = {}
+    snapshots: dict[Path, bytes | None] = {}
+    modes: dict[Path, int] = {}
+    targets: dict[Path, Path] = {}
+    for relative, content in candidates.items():
+        target = _safe_target(root, relative)
+        if target.exists() and not target.is_file():
+            raise UpdateError(f"target is not a regular file: {relative.as_posix()}")
+        validator = validators.get(relative)
+        if validator is not None:
+            validator(content)
+        normalized[relative] = content
+        snapshots[relative] = target.read_bytes() if target.exists() else None
+        modes[relative] = (
+            stat.S_IMODE(target.stat().st_mode)
+            if target.exists()
+            else create_modes.get(relative, 0o644)
+        )
+        targets[relative] = target
+
+    changed = tuple(
+        sorted(
+            relative.as_posix()
+            for relative, content in normalized.items()
+            if snapshots[relative] != content
+        )
+    )
+    if not changed:
+        return ()
+
+    def encode_snapshot(relative: Path) -> str | None:
+        snapshot = snapshots[relative]
+        return (
+            base64.b64encode(snapshot).decode("ascii") if snapshot is not None else None
+        )
+
+    journal_data: dict[str, object] = {
+        "state": "installing",
+        "files": [
+            {
+                "path": name,
+                "mode": modes[Path(name)],
+                "content": encode_snapshot(Path(name)),
+            }
+            for name in changed
+        ],
+    }
+    _write_journal(journal, journal_data)
+    sidecars: dict[Path, Path] = {}
+    installed: list[Path] = []
+    committed = False
+    rollback_complete = False
+    try:
+        for name in changed:
+            relative = Path(name)
+            target = targets[relative]
+            sidecar = target.with_name(f".{target.name}.nanvix-zutil-{os.getpid()}")
+            sidecar.write_bytes(normalized[relative])
+            sidecar.chmod(modes[relative])
+            with sidecar.open("rb") as stream:
+                os.fsync(stream.fileno())
+            sidecars[relative] = sidecar
+        for name in changed:
+            relative = Path(name)
+            target = targets[relative]
+            os.replace(sidecars[relative], target)
+            installed.append(relative)
+            _fsync_directory(target.parent)
+        journal_data["state"] = "committed"
+        _write_journal(journal, journal_data)
+        committed = True
+    except OSError as exc:
+        rollback_errors: list[str] = []
+        for relative in reversed(installed):
+            try:
+                _restore_snapshot(
+                    targets[relative],
+                    snapshots[relative],
+                    modes[relative],
+                )
+            except OSError as rollback_error:
+                rollback_errors.append(f"{relative}: {rollback_error}")
+        rollback_complete = not rollback_errors
+        if rollback_errors:
+            raise UpdateError(
+                "atomic update failed and rollback is incomplete; journal"
+                f" retained: {'; '.join(rollback_errors)}"
+            ) from exc
+        raise UpdateError(f"atomic update failed and was rolled back: {exc}") from exc
+    finally:
+        for sidecar in sidecars.values():
+            sidecar.unlink(missing_ok=True)
+        if committed or rollback_complete:
+            _remove_journal(journal, journal_data)
+    return changed
+
+
+def emit_result(
+    result: UpdateResult,
+    *,
+    output_format: str,
+    output: Path | None,
+) -> None:
+    """Emit an update result to stdout or a confined output file."""
+    if output_format == "json":
+        rendered = json.dumps(result.to_dict(), sort_keys=True) + "\n"
+    else:
+        files = ", ".join(result.changed_files) if result.changed_files else "none"
+        rendered = (
+            f"{result.command}: {result.status}; target={result.target};"
+            f" changed-files={files}\n"
+        )
+    if output is None or str(output) == "-":
+        print(rendered, end="")
+        return
+    root = find_target_root()
+    destination = output if output.is_absolute() else root / output
+    try:
+        destination = destination.resolve()
+        destination.relative_to(root)
+    except ValueError as exc:
+        raise UpdateError("--output must stay within the target repository") from exc
+    relative = destination.relative_to(root).as_posix()
+    protected = {
+        ".nanvix/nanvix.toml",
+        ".nanvix/nanvix.lock",
+        ".nanvix/z.py",
+        ".nanvix/.gitignore",
+        ".github/workflows/nanvix-ci.yml",
+        ".zutils-version",
+        "z",
+        "z.sh",
+        "z.ps1",
+        "templates/.zutils-version",
+        "templates/.gitignore",
+        "templates/nanvix-ci.yml",
+        "templates/z",
+        "templates/z.sh",
+        "templates/z.ps1",
+        "examples/bin-hello/.nanvix/.gitignore",
+        "examples/bin-hello/.nanvix/nanvix.lock",
+        "examples/bin-hello/.nanvix/nanvix.toml",
+        "examples/bin-hello/.nanvix/z.py",
+        "examples/bin-hello/.zutils-version",
+        "examples/bin-hello/z",
+        "examples/bin-hello/z.sh",
+        "examples/bin-hello/z.ps1",
+        "examples/lib-hello/.nanvix/.gitignore",
+        "examples/lib-hello/.nanvix/nanvix.lock",
+        "examples/lib-hello/.nanvix/nanvix.toml",
+        "examples/lib-hello/.nanvix/z.py",
+        "examples/lib-hello/.zutils-version",
+        "examples/lib-hello/z",
+        "examples/lib-hello/z.sh",
+        "examples/lib-hello/z.ps1",
+    }
+    if relative in protected:
+        raise UpdateError("--output must not overwrite a managed update target")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    sidecar = destination.with_name(f".{destination.name}.nanvix-zutil-{os.getpid()}")
+    try:
+        sidecar.write_text(rendered, encoding="utf-8", newline="\n")
+        os.replace(sidecar, destination)
+    finally:
+        sidecar.unlink(missing_ok=True)

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -3,5 +3,7 @@ cache
 sysroot
 buildroot
 env.json
-nanvix.lock
 __pycache__
+.nanvix-zutil-update.lock
+.nanvix-zutil-update-journal.json
+.*.nanvix-zutil-*

--- a/templates/nanvix-ci.yml
+++ b/templates/nanvix-ci.yml
@@ -27,5 +27,7 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v{{WORKFLOW_VERSION}}
     with:
       caller-event-name: ${{ github.event_name }}
+      docker-image: ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f  # yamllint disable-line rule:line-length
+      nanvix-version-source: sdk
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,12 +98,24 @@ class TestDockerFlags(unittest.TestCase):
         args = parser.parse_args(["setup", "--with-docker", "my/image:tag"])
         self.assertEqual(args.with_docker, "my/image:tag")
 
-    def test_setup_requires_with_docker(self) -> None:
-        """setup without --with-docker is rejected."""
+    def test_setup_allows_manifest_default_image(self) -> None:
+        """setup may derive its image from an SDK manifest."""
         parser = build_parser()
-        with self.assertRaises(SystemExit) as ctx:
-            parser.parse_args(["setup"])
-        self.assertEqual(ctx.exception.code, 2)
+        args = parser.parse_args(["setup"])
+        self.assertIsNone(args.with_docker)
+        self.assertFalse(args.allow_local_docker_override)
+
+    def test_explicit_local_override_flag(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "setup",
+                "--with-docker",
+                "local/image:dev",
+                "--allow-local-docker-override",
+            ]
+        )
+        self.assertTrue(args.allow_local_docker_override)
 
     def test_docker_flags_rejected_on_build(self) -> None:
         """build subcommand does not accept Docker flags (moved to setup)."""

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -133,7 +133,7 @@ class TestDockerConfigBuildRunCmd(unittest.TestCase):
 
     def _make_config(self) -> DockerConfig:
         return DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
             mounts=[
                 Mount(
                     host_path=self._workspace,
@@ -158,7 +158,10 @@ class TestDockerConfigBuildRunCmd(unittest.TestCase):
     def test_contains_image(self, _mock: object) -> None:
         cfg = self._make_config()
         cmd = cfg.build_run_cmd("make", "all")
-        self.assertIn("ghcr.io/nanvix/toolchain-gcc:sha-34a3641", cmd)
+        self.assertIn(
+            "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
+            cmd,
+        )
 
     def test_contains_user(self, _mock: object) -> None:
         cfg = self._make_config()
@@ -336,7 +339,7 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         output_files: list[str] | None = None,
     ) -> DockerConfig:
         return DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
             mounts=[
                 Mount(
                     host_path=self._workspace,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -29,13 +29,15 @@ import shutil
 import subprocess
 import sys
 import unittest
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _LIB_HELLO = _REPO_ROOT / "examples" / "lib-hello"
 _BIN_HELLO = _REPO_ROOT / "examples" / "bin-hello"
-_DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
-_NANVIX_VERSION = "0.13.19"
+_DOCKER_IMAGE = "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+_NANVIX_VERSION = "0.20.0"
 _TIMEOUT = 300
 
 
@@ -78,8 +80,26 @@ def _can_run_docker_lifecycle() -> bool:
     return _has_docker()
 
 
-_CAN_LIFECYCLE = _can_run_docker_lifecycle()
-_SKIP_NO_DOCKER = "Docker lifecycle not available (no daemon or Windows host)"
+def _has_authoritative_sdk_release() -> bool:
+    """Return whether the pinned SDK completion release is published."""
+    request = urllib.request.Request(
+        "https://api.github.com/repos/nanvix/sdk/releases/tags/v0.20.0-sdk.1",
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    token = os.environ.get("GH_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            return True
+    except (urllib.error.URLError, TimeoutError):
+        return False
+
+
+_CAN_LIFECYCLE = _can_run_docker_lifecycle() and _has_authoritative_sdk_release()
+_SKIP_NO_DOCKER = (
+    "SDK lifecycle unavailable (Docker or authoritative SDK Release missing)"
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -141,6 +141,54 @@ class TestDownloadReleaseAssetSuccess(unittest.TestCase):
         assert isinstance(first_req, urllib.request.Request)
         self.assertIn("Authorization", first_req.headers)
 
+    def test_exact_release_identity_prevents_stale_flat_cache_reuse(self) -> None:
+        dest = Path(self._tmpdir.name)
+        asset_name = "zlib-microvm-standalone-256mb.tar.gz"
+        release_one: dict[str, object] = {
+            "tag_name": "1.3.1-nanvix-0.20.0-sdk.1",
+            "id": 101,
+            "assets": [
+                {
+                    "id": 1001,
+                    "name": asset_name,
+                    "browser_download_url": "https://example.com/one",
+                }
+            ],
+        }
+        release_two: dict[str, object] = {
+            "tag_name": "1.3.1-nanvix-0.20.0-sdk.2",
+            "id": 102,
+            "assets": [
+                {
+                    "id": 1002,
+                    "name": asset_name,
+                    "browser_download_url": "https://example.com/two",
+                }
+            ],
+        }
+        first = _make_urlopen_response(b"first-release", chunked=True)
+        second = _make_urlopen_response(b"second-release", chunked=True)
+        with patch("urllib.request.urlopen", side_effect=[first, second]) as opened:
+            github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                version_specifier="1.3.1-nanvix-0.20.0-sdk.1",
+                asset_name=asset_name,
+                dest=dest,
+                _release=release_one,
+            )
+            result = github_mod.download_release_asset(
+                repo="nanvix/zlib",
+                version_specifier="1.3.1-nanvix-0.20.0-sdk.2",
+                asset_name=asset_name,
+                dest=dest,
+                _release=release_two,
+            )
+        self.assertEqual(opened.call_count, 2)
+        self.assertEqual(result.read_bytes(), b"second-release")
+        metadata = json.loads((dest / f".{asset_name}.release.json").read_text())
+        self.assertEqual(metadata["release_id"], 102)
+        self.assertEqual(metadata["asset_id"], 1002)
+
 
 class TestDownloadReleaseAssetNotFound(unittest.TestCase):
     """download_release_asset exits with code 3 when the asset is absent."""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -7,6 +7,7 @@
 
 import collections.abc
 import json
+import os
 import tempfile
 import unittest
 import urllib.error
@@ -188,6 +189,19 @@ class TestDownloadReleaseAssetSuccess(unittest.TestCase):
         metadata = json.loads((dest / f".{asset_name}.release.json").read_text())
         self.assertEqual(metadata["release_id"], 102)
         self.assertEqual(metadata["asset_id"], 1002)
+
+    def test_metadata_fsync_uses_read_write_descriptor(self) -> None:
+        path = Path(self._tmpdir.name) / "metadata"
+        path.write_text("{}")
+        with (
+            patch("nanvix_zutil.github.os.open", return_value=77) as opened,
+            patch("nanvix_zutil.github.os.fsync") as fsync,
+            patch("nanvix_zutil.github.os.close") as close,
+        ):
+            github_mod._fsync_file(path)
+        opened.assert_called_once_with(path, os.O_RDWR)
+        fsync.assert_called_once_with(77)
+        close.assert_called_once_with(77)
 
 
 class TestDownloadReleaseAssetNotFound(unittest.TestCase):

--- a/tests/test_resolve_cmd.py
+++ b/tests/test_resolve_cmd.py
@@ -13,7 +13,8 @@ from nanvix_zutil import paths
 from nanvix_zutil.buildroot import Ref, RefKind
 from nanvix_zutil.commands.resolve import main
 from nanvix_zutil.lockfile import Lockfile, LockfileMetadata, ResolvedPackage
-from nanvix_zutil.manifest import Manifest
+from nanvix_zutil.manifest import Manifest, SdkPin, Toolchain, ToolchainKind
+from nanvix_zutil.sdk import SdkImage, SdkProvenance
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -66,6 +67,49 @@ def _make_lockfile_no_sysroot() -> Lockfile:
     )
 
 
+def _make_sdk_manifest() -> Manifest:
+    """Return a fake canonical SDK manifest."""
+    digest = f"sha256:{'a' * 64}"
+    return Manifest(
+        name=_NAME,
+        version=_VERSION,
+        sysroot_ref=Ref(kind=RefKind.TAG, value="0.20.0"),
+        toolchain=Toolchain(
+            ToolchainKind.SDK,
+            SdkPin(
+                version="v0.20.0-sdk.1",
+                provider_id="c-clang",
+                image="ghcr.io/nanvix/nanvix-sdk-c-clang",
+                digest=digest,
+            ),
+        ),
+    )
+
+
+def _make_sdk_lockfile() -> Lockfile:
+    """Return a lockfile carrying verified SDK provenance."""
+    image = SdkImage(
+        name="ghcr.io/nanvix/nanvix-sdk-c-clang",
+        digest=f"sha256:{'a' * 64}",
+        ref=("ghcr.io/nanvix/nanvix-sdk-c-clang@" f"sha256:{'a' * 64}"),
+    )
+    provenance = SdkProvenance(
+        sdk_version="v0.20.0-sdk.1",
+        provider_id="c-clang",
+        provider="clang",
+        role="c",
+        image=image,
+        nanvix_tag="v0.20.0",
+        nanvix_version="0.20.0",
+        nanvix_commit="b" * 40,
+        sysroot_sha256="c" * 64,
+        compat={"c_abi": "i686-nanvix-sysv-1"},
+    )
+    lockfile = _make_lockfile()
+    lockfile.metadata.sdk = provenance
+    return lockfile
+
+
 def _write_manifest() -> None:
     """Write a minimal manifest into the autouse-fixture .nanvix/ dir."""
     (paths.manifest_path()).write_text('[package]\nname="zlib"\nversion="1.3.1"\n')
@@ -107,6 +151,56 @@ class TestDefaultOutput(unittest.TestCase):
         self.assertIn(f"nanvix_version={_TAG.lstrip('v')}", output)
         self.assertIn(f"package_name={_NAME}", output)
         self.assertIn(f"package_version={_VERSION}", output)
+        self.assertEqual(
+            output.splitlines(),
+            [
+                f"nanvix_tag={_TAG}",
+                f"nanvix_sha={_SHA[:7]}",
+                f"nanvix_version={_TAG.lstrip('v')}",
+                f"package_name={_NAME}",
+                f"package_version={_VERSION}",
+            ],
+        )
+
+    @patch("nanvix_zutil.commands.resolve.resolve")
+    @patch("nanvix_zutil.commands.resolve.load_manifest")
+    def test_sdk_key_value_output(
+        self,
+        mock_load: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        mock_load.return_value = _make_sdk_manifest()
+        mock_resolve.return_value = _make_sdk_lockfile()
+        _write_manifest()
+
+        output = StringIO()
+        with (
+            patch("sys.argv", ["nanvix-zutil resolve"]),
+            patch("sys.stdout", output),
+            self.assertRaises(SystemExit) as context,
+        ):
+            main()
+
+        self.assertEqual(context.exception.code, 0)
+        values = dict(
+            line.split("=", maxsplit=1) for line in output.getvalue().splitlines()
+        )
+        self.assertEqual(values["sdk_version"], "v0.20.0-sdk.1")
+        self.assertEqual(values["sdk_provider_id"], "c-clang")
+        self.assertEqual(values["sdk_provider"], "clang")
+        self.assertEqual(
+            values["sdk_image"],
+            "ghcr.io/nanvix/nanvix-sdk-c-clang",
+        )
+        self.assertEqual(values["sdk_digest"], f"sha256:{'a' * 64}")
+        self.assertEqual(
+            values["sdk_image_ref"],
+            "ghcr.io/nanvix/nanvix-sdk-c-clang@" f"sha256:{'a' * 64}",
+        )
+        self.assertEqual(values["sdk_c_abi"], "i686-nanvix-sysv-1")
+        self.assertEqual(values["sdk_libc_tag"], "v0.20.0")
+        self.assertEqual(values["sdk_libc_commit"], "b" * 40)
+        self.assertEqual(values["sdk_sysroot_sha256"], "c" * 64)
 
 
 class TestShallowFlag(unittest.TestCase):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -12,15 +12,27 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from nanvix_zutil import helpers, paths
-from nanvix_zutil.buildroot import RefKind
+from nanvix_zutil.buildroot import Ref, RefKind
+from nanvix_zutil.config import CFG_DOCKER_IMAGE, Config
 from nanvix_zutil.docker import (
     BUILDROOT_CONTAINER_PATH,
     WORKSPACE_CONTAINER_PATH,
     DockerConfig,
     Mount,
 )
-from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
+from nanvix_zutil.exitcodes import (
+    EXIT_BUILD_FAILURE,
+    EXIT_INVALID_ARGS,
+    EXIT_MISSING_DEP,
+)
 from nanvix_zutil.helpers import InitRdArgs
+from nanvix_zutil.lockfile import (
+    Lockfile,
+    LockfileMetadata,
+    ResolvedAsset,
+    ResolvedPackage,
+)
+from nanvix_zutil.resolver import BlockedResolution
 from nanvix_zutil.script import ZScript
 from tests.testutils import (
     MANIFEST_LATEST_WITH_DEPS,
@@ -258,6 +270,8 @@ class TestZScriptSyncConfigs(unittest.TestCase):
         nanvix_dir = paths.nanvix_root()
         content = (nanvix_dir / ".gitignore").read_text()
         self.assertNotIn("nanvix.lock", content)
+        self.assertIn(".nanvix-zutil-update.lock", content)
+        self.assertIn(".nanvix-zutil-update-journal.json", content)
 
     def test_setup_skips_identical_configs(self) -> None:
         """setup() is a no-op for configs when content already matches."""
@@ -391,6 +405,166 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
             self.assertIn(hook, available)
 
 
+class TestSdkDockerSelection(unittest.TestCase):
+    """SDK manifests provide and protect the effective build image."""
+
+    def setUp(self) -> None:
+        digest = f"sha256:{'a' * 64}"
+        paths.manifest_path().write_text(
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.20.0"\n'
+            "\n[toolchain]\n"
+            'kind = "nanvix-sdk"\n'
+            'provider = "c-clang"\n'
+            'sdk-version = "v0.20.0-sdk.1"\n'
+            'sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"\n'
+            f'sdk-digest = "{digest}"\n'
+        )
+        self.image = f"ghcr.io/nanvix/nanvix-sdk-c-clang@{digest}"
+
+    def test_setup_defaults_to_manifest_image(self) -> None:
+        with (
+            patch("sys.argv", ["z.py", "setup"]),
+            patch.object(ZScript, "setup", return_value=False),
+            patch("nanvix_zutil.script.check_docker") as check,
+        ):
+            ZScript.main()
+        check.assert_called_once_with(self.image)
+        self.assertEqual(Config().get(CFG_DOCKER_IMAGE), self.image)
+
+    def test_setup_prefers_dedicated_build_image(self) -> None:
+        build_digest = f"sha256:{'b' * 64}"
+        with paths.manifest_path().open("a", encoding="utf-8") as manifest:
+            manifest.write(
+                'build-image = "ghcr.io/nanvix/port-builder"\n'
+                f'build-digest = "{build_digest}"\n'
+            )
+        expected = f"ghcr.io/nanvix/port-builder@{build_digest}"
+        with (
+            patch("sys.argv", ["z.py", "setup"]),
+            patch.object(ZScript, "setup", return_value=False),
+            patch("nanvix_zutil.script.check_docker") as check,
+        ):
+            ZScript.main()
+        check.assert_called_once_with(expected)
+        self.assertEqual(Config().get(CFG_DOCKER_IMAGE), expected)
+
+    def test_conflicting_cli_image_fails_without_override(self) -> None:
+        with (
+            patch(
+                "sys.argv",
+                ["z.py", "setup", "--with-docker", "local/image:dev"],
+            ),
+            patch("nanvix_zutil.script.check_docker"),
+            self.assertRaises(SystemExit) as context,
+        ):
+            ZScript.main()
+        self.assertEqual(context.exception.code, EXIT_INVALID_ARGS)
+
+    def test_explicit_local_override_is_persisted(self) -> None:
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "z.py",
+                    "setup",
+                    "--with-docker",
+                    "local/image:dev",
+                    "--allow-local-docker-override",
+                ],
+            ),
+            patch.object(ZScript, "setup", return_value=False),
+            patch("nanvix_zutil.script.check_docker"),
+        ):
+            ZScript.main()
+        self.assertEqual(Config().get(CFG_DOCKER_IMAGE), "local/image:dev")
+
+    def test_sdk_setup_installs_only_strict_resolved_release(self) -> None:
+        with paths.manifest_path().open("a", encoding="utf-8") as manifest:
+            manifest.write('\n[dependencies]\nzlib = "1.3.1"\n')
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = paths.nanvix_root() / "sysroot"
+        fake_sysroot.tag = "v0.20.0"
+        package = ResolvedPackage(
+            name="zlib",
+            repo="nanvix/zlib",
+            kind="dependency",
+            ref=Ref(
+                RefKind.VERSION,
+                "1.3.1-nanvix-0.20.0-sdk.1",
+            ),
+            resolved_tag="1.3.1-nanvix-0.20.0-sdk.1",
+            resolved_commitish="d" * 40,
+            release_id=42,
+            assets=[
+                ResolvedAsset(
+                    "zlib-microvm-standalone-256mb.tar.gz",
+                    "https://example.invalid/zlib.tar.gz",
+                )
+            ],
+        )
+        lock = Lockfile(
+            LockfileMetadata("sha256:x", "0.15.0"),
+            packages=[package],
+        )
+        fake_buildroot = MagicMock()
+        with (
+            patch(
+                "nanvix_zutil.script.Sysroot.download",
+                return_value=fake_sysroot,
+            ),
+            patch(
+                "nanvix_zutil.script.Buildroot.create",
+                return_value=fake_buildroot,
+            ),
+            patch("nanvix_zutil.script.resolve", return_value=lock) as resolver,
+            patch("nanvix_zutil.script.resolve_release_with_fallback") as fallback,
+        ):
+            script = ZScript()
+            used_fallback = script.setup()
+        self.assertFalse(used_fallback)
+        resolver.assert_called_once()
+        self.assertTrue(resolver.call_args.kwargs["strict"])
+        fallback.assert_not_called()
+        fake_buildroot.install_dep.assert_called_once()
+        release = fake_buildroot.install_dep.call_args.kwargs["_release"]
+        self.assertEqual(
+            release["tag_name"],
+            "1.3.1-nanvix-0.20.0-sdk.1",
+        )
+
+    def test_sdk_setup_blocked_dependency_writes_no_buildroot(self) -> None:
+        with paths.manifest_path().open("a", encoding="utf-8") as manifest:
+            manifest.write('\n[dependencies]\nzlib = "1.3.1"\n')
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = paths.nanvix_root() / "sysroot"
+        fake_sysroot.tag = "v0.20.0"
+        blocked = BlockedResolution(
+            status="blocked",
+            package="zlib",
+            repo="nanvix/zlib",
+            requested_tag="1.3.1-nanvix-0.20.0-sdk.1",
+            sdk_version="v0.20.0-sdk.1",
+            reason="exact-sdk-release-missing",
+        )
+        with (
+            patch(
+                "nanvix_zutil.script.Sysroot.download",
+                return_value=fake_sysroot,
+            ),
+            patch("nanvix_zutil.script.resolve", return_value=blocked),
+            patch("nanvix_zutil.script.Buildroot.create") as create,
+            patch("nanvix_zutil.script.resolve_release_with_fallback") as fallback,
+            self.assertRaises(SystemExit) as context,
+        ):
+            ZScript().setup()
+        self.assertEqual(context.exception.code, EXIT_MISSING_DEP)
+        create.assert_not_called()
+        fallback.assert_not_called()
+
+
 class TestHelpersRun(unittest.TestCase):
     """helpers.run() executes subprocesses correctly."""
 
@@ -418,7 +592,7 @@ class TestHelpersRun(unittest.TestCase):
 
     def _make_docker(self, repo_root: Path) -> DockerConfig:
         return DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
             mounts=[
                 Mount(
                     host_path=repo_root,
@@ -454,7 +628,7 @@ class TestHelpersRun(unittest.TestCase):
         (empty) output_files — the dispatch no longer requires
         these fields to be populated."""
         docker = DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
             mounts=[
                 Mount(
                     host_path=Path.cwd(),
@@ -527,7 +701,7 @@ class TestHelpersRun(unittest.TestCase):
     def test_run_env_forwarded_into_container(self, *_mocks: object) -> None:
         """env vars passed to run() are forwarded as -e flags in Docker mode."""
         docker = DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
             mounts=[],
             uid=1000,
             gid=1000,
@@ -550,7 +724,7 @@ class TestHelpersRun(unittest.TestCase):
     def test_run_env_forwarded_into_container_as_flags(self, *_mocks: object) -> None:
         """env vars appear as -e KEY=VAL in the docker run command."""
         docker = DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
             mounts=[],
             uid=1000,
             gid=1000,
@@ -582,7 +756,7 @@ class TestHelpersRun(unittest.TestCase):
         (PATH/HOME/USER/...) into the container, including mixed-case
         variants.  Non-blocklisted keys still pass through."""
         docker = DockerConfig(
-            image="ghcr.io/nanvix/toolchain-gcc:sha-34a3641",
+            image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
             mounts=[],
             uid=1000,
             gid=1000,
@@ -804,7 +978,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
         # Pre-persist Docker image so build can find it.
         nanvix_dir = paths.nanvix_root()
         (nanvix_dir / "env.json").write_text(
-            '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"}'
+            '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"}'
         )
 
         with (
@@ -833,7 +1007,7 @@ class TestZScriptAutoDocker(unittest.TestCase):
         # Pre-persist Docker image so build can find it.
         nanvix_dir = paths.nanvix_root()
         (nanvix_dir / "env.json").write_text(
-            '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"}'
+            '{"NANVIX_DOCKER_IMAGE": "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"}'
         )
 
         def fake_run(cmd: list[str], **kwargs: object) -> sp.CompletedProcess[str]:

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -431,7 +431,10 @@ class TestSdkDockerSelection(unittest.TestCase):
             patch("nanvix_zutil.script.check_docker") as check,
         ):
             ZScript.main()
-        check.assert_called_once_with(self.image)
+        if sys.platform == "win32":
+            check.assert_not_called()
+        else:
+            check.assert_called_once_with(self.image)
         self.assertEqual(Config().get(CFG_DOCKER_IMAGE), self.image)
 
     def test_setup_prefers_dedicated_build_image(self) -> None:
@@ -448,7 +451,10 @@ class TestSdkDockerSelection(unittest.TestCase):
             patch("nanvix_zutil.script.check_docker") as check,
         ):
             ZScript.main()
-        check.assert_called_once_with(expected)
+        if sys.platform == "win32":
+            check.assert_not_called()
+        else:
+            check.assert_called_once_with(expected)
         self.assertEqual(Config().get(CFG_DOCKER_IMAGE), expected)
 
     def test_conflicting_cli_image_fails_without_override(self) -> None:

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,250 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# pyright: reportPrivateUsage=false
+
+"""Tests for SDK contracts, provenance, and release coordinates."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+from typing import cast
+
+from nanvix_zutil.sdk import (
+    SDK_LABEL_PREFIX,
+    SdkValidationError,
+    _release_asset,
+    consumer_release_tag,
+    sdk_consumer_release_tag,
+    validate_sdk_release,
+    verify_sdk_metadata,
+)
+
+
+def make_sdk_contract(
+    version: str = "v0.20.0-sdk.1",
+    digest: str = f"sha256:{'a' * 64}",
+) -> dict[str, object]:
+    """Build a valid SDK release fixture."""
+    image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+    return {
+        "schema_version": 1,
+        "sdk_version": version,
+        "provider_id": "c-clang",
+        "provider": "clang",
+        "role": "c",
+        "image": {"name": image, "digest": digest, "ref": f"{image}@{digest}"},
+        "target": {
+            "triple": "i686-unknown-nanvix",
+            "alias": "i686-nanvix",
+        },
+        "toolchain": {
+            "llvm_version": "22.1.8",
+            "llvm_commit": "b" * 40,
+            "port_branch": "nanvix/v22.1.8",
+        },
+        "libc": {
+            "nanvix_tag": "v0.20.0",
+            "nanvix_version": "0.20.0",
+            "nanvix_commit": "c" * 40,
+            "sysroot_sha256": "d" * 64,
+        },
+        "compat": {
+            "c_abi": "i686-nanvix-sysv-1",
+            "cxx_abi": "libc++",
+            "abi": "static-elf",
+            "min_nanvix_os": "0.20.0",
+        },
+        "features": {
+            "localization": True,
+            "filesystem": True,
+            "wide_chars": True,
+            "dynamic_loader": False,
+            "compiler_rt": "builtins-only",
+        },
+    }
+
+
+def labels_for(data: dict[str, object]) -> dict[str, str]:
+    """Flatten an embedded SDK manifest into OCI labels."""
+    result: dict[str, str] = {}
+
+    def flatten(prefix: str, value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in cast("dict[str, object]", value).items():
+                flatten(f"{prefix}.{key}" if prefix else str(key), child)
+            return
+        rendered = (
+            "true" if value is True else "false" if value is False else str(value)
+        )
+        result[f"{SDK_LABEL_PREFIX}{prefix}"] = rendered
+
+    flatten("", data)
+    return result
+
+
+class TestSdkContract(unittest.TestCase):
+    """SDK release schema and skew validation."""
+
+    def test_valid_contract(self) -> None:
+        contract = validate_sdk_release(make_sdk_contract())
+        self.assertEqual(contract.runtime_version, "0.20.0")
+        self.assertEqual(contract.revision, 1)
+        self.assertTrue(contract.image.ref.endswith(contract.image.digest))
+
+    def test_missing_field_rejected(self) -> None:
+        data = make_sdk_contract()
+        del data["provider_id"]
+        with self.assertRaises(SdkValidationError):
+            validate_sdk_release(data)
+
+    def test_missing_canonical_feature_rejected(self) -> None:
+        data = make_sdk_contract()
+        features = data["features"]
+        assert isinstance(features, dict)
+        del features["wide_chars"]
+        with self.assertRaises(SdkValidationError):
+            validate_sdk_release(data)
+
+    def test_boolean_schema_and_short_commits_rejected(self) -> None:
+        boolean_schema = make_sdk_contract()
+        boolean_schema["schema_version"] = True
+        with self.assertRaises(SdkValidationError):
+            validate_sdk_release(boolean_schema)
+
+        short_commit = make_sdk_contract()
+        toolchain = short_commit["toolchain"]
+        assert isinstance(toolchain, dict)
+        toolchain["llvm_commit"] = "abcdef0"
+        with self.assertRaises(SdkValidationError):
+            validate_sdk_release(short_commit)
+
+        short_libc = make_sdk_contract()
+        libc = short_libc["libc"]
+        assert isinstance(libc, dict)
+        libc["nanvix_commit"] = "abcdef0"
+        with self.assertRaises(SdkValidationError):
+            validate_sdk_release(short_libc)
+
+    def test_runtime_skew_rejected(self) -> None:
+        data = make_sdk_contract()
+        libc = data["libc"]
+        assert isinstance(libc, dict)
+        libc["nanvix_version"] = "0.20.1"
+        with self.assertRaises(SdkValidationError):
+            validate_sdk_release(data)
+
+    def test_mutable_image_rejected(self) -> None:
+        data = make_sdk_contract()
+        image = data["image"]
+        assert isinstance(image, dict)
+        image["ref"] = f"{image['name']}:v0.20.0-sdk.1"
+        with self.assertRaises(SdkValidationError):
+            validate_sdk_release(data)
+
+    def test_oci_mismatch_rejected(self) -> None:
+        contract = validate_sdk_release(make_sdk_contract())
+        embedded = contract.to_dict()
+        del embedded["image"]
+        labels = labels_for(embedded)
+        labels[f"{SDK_LABEL_PREFIX}compat.c_abi"] = "wrong"
+        with self.assertRaises(SdkValidationError):
+            verify_sdk_metadata(contract, embedded, labels, contract.image.digest)
+
+    def test_schema_one_derived_release_fields(self) -> None:
+        contract = validate_sdk_release(make_sdk_contract())
+        embedded = contract.to_dict()
+        del embedded["image"]
+        del embedded["provider_id"]
+        libc = embedded["libc"]
+        assert isinstance(libc, dict)
+        del libc["nanvix_version"]
+        labels = labels_for(embedded)
+        del labels[f"{SDK_LABEL_PREFIX}libc.sysroot_sha256"]
+        verify_sdk_metadata(contract, embedded, labels, contract.image.digest)
+
+    def test_present_derived_field_mismatch_is_rejected(self) -> None:
+        contract = validate_sdk_release(make_sdk_contract())
+        embedded = contract.to_dict()
+        embedded["provider_id"] = "wrong-provider"
+        labels = labels_for(
+            {
+                key: value
+                for key, value in contract.to_dict().items()
+                if key not in {"image", "provider_id"}
+            }
+        )
+        with self.assertRaises(SdkValidationError):
+            verify_sdk_metadata(
+                contract,
+                embedded,
+                labels,
+                contract.image.digest,
+            )
+
+    def test_release_contract_asset_requires_digest(self) -> None:
+        digest = f"sha256:{'a' * 64}"
+        release: dict[str, object] = {
+            "assets": [
+                {
+                    "name": "sdk-release.json",
+                    "browser_download_url": "https://example.invalid/sdk.json",
+                    "digest": digest,
+                }
+            ]
+        }
+        self.assertEqual(
+            _release_asset(release),
+            ("https://example.invalid/sdk.json", digest),
+        )
+        asset = release["assets"]
+        assert isinstance(asset, list)
+        item = cast("list[object]", asset)[0]
+        assert isinstance(item, dict)
+        del cast("dict[str, object]", item)["digest"]
+        with self.assertRaises(SdkValidationError):
+            _release_asset(release)
+
+    def test_embedded_mismatch_rejected(self) -> None:
+        contract = validate_sdk_release(make_sdk_contract())
+        embedded = copy.deepcopy(contract.to_dict())
+        del embedded["image"]
+        embedded["provider"] = "gcc"
+        with self.assertRaises(SdkValidationError):
+            verify_sdk_metadata(
+                contract,
+                embedded,
+                labels_for(
+                    {
+                        key: value
+                        for key, value in contract.to_dict().items()
+                        if key != "image"
+                    }
+                ),
+                contract.image.digest,
+            )
+
+
+class TestSdkReleaseNames(unittest.TestCase):
+    """SDK-only revisions produce unique exact consumer tags."""
+
+    def test_sdk_revision_changes_coordinate(self) -> None:
+        first = sdk_consumer_release_tag("1.3.1", "v0.20.0-sdk.1")
+        second = sdk_consumer_release_tag("1.3.1", "v0.20.0-sdk.2")
+        self.assertEqual(first, "1.3.1-nanvix-0.20.0-sdk.1")
+        self.assertNotEqual(first, second)
+
+    def test_legacy_coordinate_preserved(self) -> None:
+        self.assertEqual(
+            consumer_release_tag("1.3.1", "0.20.0"),
+            "1.3.1-nanvix-0.20.0",
+        )
+
+    def test_runtime_skew_rejected(self) -> None:
+        with self.assertRaises(SdkValidationError):
+            consumer_release_tag("1.3.1", "0.20.1", "v0.20.0-sdk.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_manifest_lock.py
+++ b/tests/test_sdk_manifest_lock.py
@@ -1,0 +1,132 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Tests for SDK manifest pins and lockfile provenance."""
+
+from __future__ import annotations
+
+import unittest
+
+from nanvix_zutil import paths
+from nanvix_zutil.lockfile import (
+    Lockfile,
+    LockfileMetadata,
+    read_lockfile,
+    write_lockfile,
+)
+from nanvix_zutil.manifest import ToolchainKind, load_manifest
+from nanvix_zutil.sdk import validate_sdk_release
+from tests.test_sdk import make_sdk_contract
+
+
+class TestSdkManifest(unittest.TestCase):
+    """Preferred, derived, legacy, and malformed SDK pin forms."""
+
+    def test_immutable_sdk_pin_and_exact_dependency_tag(self) -> None:
+        digest = f"sha256:{'a' * 64}"
+        paths.manifest_path().write_text(
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.20.0"\n'
+            "\n[toolchain]\n"
+            'kind = "nanvix-sdk"\n'
+            'provider = "c-clang"\n'
+            'sdk-version = "v0.20.0-sdk.1"\n'
+            'sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"\n'
+            f'sdk-digest = "{digest}"\n'
+            'build-image = "ghcr.io/nanvix/port-builder"\n'
+            f'build-digest = "sha256:{"b" * 64}"\n'
+            "\n[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        )
+        manifest = load_manifest()
+        self.assertEqual(manifest.toolchain.kind, ToolchainKind.SDK)
+        assert manifest.toolchain.sdk is not None
+        self.assertEqual(manifest.toolchain.sdk.digest, digest)
+        self.assertEqual(
+            manifest.toolchain.sdk.effective_build_ref,
+            f"ghcr.io/nanvix/port-builder@sha256:{'b' * 64}",
+        )
+        self.assertEqual(
+            manifest.dependencies[0].ref.value,
+            "1.3.1-nanvix-0.20.0-sdk.1",
+        )
+
+    def test_early_spelling_remains_readable(self) -> None:
+        digest = f"sha256:{'a' * 64}"
+        paths.manifest_path().write_text(
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.20.0"\n'
+            "\n[toolchain]\n"
+            'type = "sdk"\n'
+            'sdk-version = "v0.20.0-sdk.1"\n'
+            'provider-id = "c-clang"\n'
+            'image = "ghcr.io/nanvix/nanvix-sdk-c-clang"\n'
+            f'digest = "{digest}"\n'
+        )
+        pin = load_manifest().toolchain.sdk
+        assert pin is not None
+        self.assertEqual(pin.image_ref, f"{pin.image}@{digest}")
+
+    def test_missing_toolchain_is_legacy(self) -> None:
+        paths.manifest_path().write_text(
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.20.0"\n'
+        )
+        self.assertEqual(load_manifest().toolchain.kind, ToolchainKind.LEGACY)
+
+    def test_sdk_runtime_skew_fails(self) -> None:
+        paths.manifest_path().write_text(
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.20.1"\n'
+            "\n[toolchain]\n"
+            'type = "sdk"\n'
+            'version = "v0.20.0-sdk.1"\n'
+            'provider = "c-clang"\n'
+            f'image = "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:{"a" * 64}"\n'
+        )
+        with self.assertRaises(SystemExit) as context:
+            load_manifest()
+        self.assertEqual(context.exception.code, 2)
+
+
+class TestSdkLockfile(unittest.TestCase):
+    """SDK provenance is optional, round-trippable, and shallow-aware."""
+
+    def test_provenance_round_trip(self) -> None:
+        provenance = validate_sdk_release(make_sdk_contract()).provenance()
+        lock = Lockfile(
+            LockfileMetadata(
+                manifest_hash="sha256:manifest",
+                nanvix_zutil_version="0.15.0",
+                sdk=provenance,
+                shallow=True,
+            )
+        )
+        path = paths.nanvix_root() / "nanvix.lock"
+        write_lockfile(lock, path)
+        restored = read_lockfile(path)
+        self.assertEqual(restored.metadata.sdk, provenance)
+        self.assertTrue(restored.metadata.shallow)
+
+    def test_legacy_lock_remains_readable(self) -> None:
+        path = paths.nanvix_root() / "nanvix.lock"
+        path.write_text(
+            "[metadata]\n"
+            'manifest-hash = "sha256:x"\n'
+            'nanvix-zutil-version = "0.14.0"\n'
+        )
+        restored = read_lockfile(path)
+        self.assertIsNone(restored.metadata.sdk)
+        self.assertFalse(restored.metadata.shallow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_resolver.py
+++ b/tests/test_sdk_resolver.py
@@ -1,0 +1,250 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Strict SDK resolver tests."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from nanvix_zutil import paths
+from nanvix_zutil.buildroot import Dependency, Ref, RefKind
+from nanvix_zutil.lockfile import Lockfile, LockfileMetadata, ResolvedPackage
+from nanvix_zutil.manifest import Manifest, SdkPin, Toolchain, ToolchainKind
+from nanvix_zutil.resolver import BlockedResolution, resolve
+from nanvix_zutil.sdk import validate_sdk_release
+from tests.test_sdk import make_sdk_contract
+
+
+def release(tag: str, commit: str, release_id: int) -> dict[str, object]:
+    """Build minimal GitHub release metadata."""
+    return {
+        "tag_name": tag,
+        "target_commitish": commit,
+        "id": release_id,
+        "assets": [],
+    }
+
+
+class TestStrictSdkResolver(unittest.TestCase):
+    """Strict mode uses exact SDK tags and returns blocked results."""
+
+    def setUp(self) -> None:
+        self.commit_patcher = patch(
+            "nanvix_zutil.resolver.github.resolve_commit",
+            return_value="c" * 40,
+        )
+        self.commit_patcher.start()
+        self.addCleanup(self.commit_patcher.stop)
+        paths.manifest_path().write_text(
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.20.0"\n'
+        )
+        self.contract = validate_sdk_release(make_sdk_contract())
+        self.manifest = Manifest(
+            name="test",
+            version="1.0.0",
+            sysroot_ref=Ref(RefKind.TAG, "0.20.0"),
+            dependencies=[
+                Dependency(
+                    "zlib",
+                    "nanvix/zlib",
+                    Ref(RefKind.VERSION, "1.3.1-nanvix-0.20.0-sdk.1"),
+                )
+            ],
+            toolchain=Toolchain(
+                ToolchainKind.SDK,
+                SdkPin(
+                    self.contract.sdk_version,
+                    self.contract.provider_id,
+                    self.contract.image.name,
+                    self.contract.image.digest,
+                ),
+            ),
+        )
+
+    @patch("nanvix_zutil.resolver.github.resolve_release")
+    @patch("nanvix_zutil.resolver.resolve_sdk_release")
+    def test_missing_exact_release_is_blocked(
+        self,
+        mock_sdk: MagicMock,
+        mock_release: MagicMock,
+    ) -> None:
+        mock_sdk.return_value = self.contract
+        mock_release.side_effect = [
+            release("v0.20.0", "c" * 40, 1),
+            SystemExit(3),
+        ]
+        result = resolve(
+            self.manifest,
+            cache_dir=Path.cwd() / "cache",
+            strict=True,
+        )
+        self.assertIsInstance(result, BlockedResolution)
+        assert isinstance(result, BlockedResolution)
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.reason, "exact-sdk-release-missing")
+        self.assertEqual(result.requested_tag, "1.3.1-nanvix-0.20.0-sdk.1")
+
+    @patch("nanvix_zutil.resolver.github.resolve_release")
+    @patch("nanvix_zutil.resolver.resolve_sdk_release")
+    @patch("nanvix_zutil.resolver.download_lockfile_asset")
+    def test_exact_release_has_sdk_provenance(
+        self,
+        mock_lock: MagicMock,
+        mock_sdk: MagicMock,
+        mock_release: MagicMock,
+    ) -> None:
+        mock_sdk.return_value = self.contract
+        mock_release.side_effect = [
+            release("v0.20.0", "c" * 40, 1),
+            release("1.3.1-nanvix-0.20.0-sdk.1", "e" * 40, 2),
+        ]
+        mock_lock.return_value = Lockfile(
+            LockfileMetadata(
+                manifest_hash="sha256:dep",
+                nanvix_zutil_version="0.15.0",
+                sdk=self.contract.provenance(),
+                shallow=True,
+            )
+        )
+        result = resolve(
+            self.manifest,
+            cache_dir=Path.cwd() / "cache",
+            strict=True,
+            shallow=True,
+        )
+        self.assertNotIsInstance(result, BlockedResolution)
+        assert not isinstance(result, BlockedResolution)
+        self.assertEqual(result.metadata.sdk, self.contract.provenance())
+        self.assertTrue(result.metadata.shallow)
+        self.assertEqual(
+            result.packages[1].resolved_tag,
+            "1.3.1-nanvix-0.20.0-sdk.1",
+        )
+        mock_sdk.assert_called_once_with(
+            "v0.20.0-sdk.1",
+            provider_id="c-clang",
+            gh_token=None,
+            verify_image=True,
+        )
+
+    @patch("nanvix_zutil.resolver.github.resolve_release")
+    @patch("nanvix_zutil.resolver.resolve_sdk_release")
+    @patch("nanvix_zutil.resolver.download_lockfile_asset")
+    def test_missing_provenance_lock_is_blocked(
+        self,
+        mock_lock: MagicMock,
+        mock_sdk: MagicMock,
+        mock_release: MagicMock,
+    ) -> None:
+        mock_sdk.return_value = self.contract
+        mock_release.side_effect = [
+            release("v0.20.0", "c" * 40, 1),
+            release("1.3.1-nanvix-0.20.0-sdk.1", "e" * 40, 2),
+        ]
+        mock_lock.return_value = None
+        result = resolve(
+            self.manifest,
+            cache_dir=Path.cwd() / "cache",
+            strict=True,
+        )
+        self.assertIsInstance(result, BlockedResolution)
+        assert isinstance(result, BlockedResolution)
+        self.assertEqual(result.reason, "provenance-lock-missing")
+
+    def test_manual_tag_is_rejected_in_strict_mode(self) -> None:
+        self.manifest.dependencies[0].ref = Ref(RefKind.TAG, "fallback")
+        with (
+            patch(
+                "nanvix_zutil.resolver.resolve_sdk_release",
+                return_value=self.contract,
+            ),
+            patch(
+                "nanvix_zutil.resolver.github.resolve_release",
+                return_value=release("v0.20.0", "c" * 40, 1),
+            ),
+        ):
+            with self.assertRaises(SystemExit) as context:
+                resolve(
+                    self.manifest,
+                    cache_dir=Path.cwd() / "cache",
+                    strict=True,
+                )
+        self.assertEqual(context.exception.code, 2)
+
+    def test_runtime_tag_commit_skew_is_rejected(self) -> None:
+        with (
+            patch(
+                "nanvix_zutil.resolver.resolve_sdk_release",
+                return_value=self.contract,
+            ),
+            patch(
+                "nanvix_zutil.resolver.github.resolve_release",
+                return_value=release("v0.20.0", "dev", 1),
+            ),
+            patch(
+                "nanvix_zutil.resolver.github.resolve_commit",
+                return_value="d" * 40,
+            ),
+        ):
+            with self.assertRaises(SystemExit) as context:
+                resolve(
+                    self.manifest,
+                    cache_dir=Path.cwd() / "cache",
+                    strict=True,
+                )
+        self.assertEqual(context.exception.code, 2)
+
+    def test_non_sdk_transitive_coordinate_is_rejected(self) -> None:
+        inner = Lockfile(
+            LockfileMetadata(
+                manifest_hash="sha256:dep",
+                nanvix_zutil_version="0.15.0",
+                sdk=self.contract.provenance(),
+                shallow=True,
+            ),
+            packages=[
+                ResolvedPackage(
+                    name="bzip2",
+                    repo="nanvix/bzip2",
+                    kind="dependency",
+                    ref=Ref(RefKind.TAG, "legacy-tag"),
+                    resolved_tag="legacy-tag",
+                    resolved_commitish="f" * 40,
+                    release_id=3,
+                )
+            ],
+        )
+        with (
+            patch(
+                "nanvix_zutil.resolver.resolve_sdk_release",
+                return_value=self.contract,
+            ),
+            patch(
+                "nanvix_zutil.resolver.github.resolve_release",
+                side_effect=[
+                    release("v0.20.0", "c" * 40, 1),
+                    release("1.3.1-nanvix-0.20.0-sdk.1", "e" * 40, 2),
+                ],
+            ),
+            patch(
+                "nanvix_zutil.resolver.download_lockfile_asset",
+                return_value=inner,
+            ),
+        ):
+            with self.assertRaises(SystemExit) as context:
+                resolve(
+                    self.manifest,
+                    cache_dir=Path.cwd() / "cache",
+                    strict=True,
+                )
+        self.assertEqual(context.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -1,0 +1,820 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# pyright: reportPrivateUsage=false
+
+"""Tests for pure atomic standalone update commands."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import tomllib
+import unittest
+import zipfile
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import nanvix_zutil.updater as updater
+from nanvix_zutil.commands import update_nanvix, update_zutils
+from nanvix_zutil.lockfile import Lockfile, LockfileMetadata, read_lockfile
+from nanvix_zutil.updater import UpdateError, atomic_write_candidates
+from tests.test_sdk import make_sdk_contract
+
+_OLD_DIGEST = f"sha256:{'e' * 64}"
+_OLD_IMAGE_NAME = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+_OLD_IMAGE = f"{_OLD_IMAGE_NAME}@{_OLD_DIGEST}"
+
+
+def template_source(root: Path, target: str = "v0.15.0") -> Path:
+    """Create a complete local zutils templates source."""
+    source = root / "source-templates"
+    source.mkdir()
+    (source / ".zutils-version").write_text(f"{target}\n")
+    (source / "z").write_text('#!/usr/bin/env bash\nexec ./z.sh "$@"\n')
+    (source / "z.sh").write_text("#!/usr/bin/env bash\necho zutils\n")
+    (source / "z.ps1").write_text("Write-Output 'zutils'\n")
+    (source / ".gitignore").write_text(
+        "venv\n"
+        "cache\n"
+        ".nanvix-zutil-update.lock\n"
+        ".nanvix-zutil-update-journal.json\n"
+        ".*.nanvix-zutil-*\n"
+    )
+    (source / "nanvix-ci.yml").write_text(
+        "jobs:\n  ci:\n    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1\n"
+    )
+    return source
+
+
+def make_consumer(root: Path, *, newline: str = "\n") -> Path:
+    """Create a minimal canonical SDK consumer fixture."""
+    nanvix = root / ".nanvix"
+    workflow = root / ".github" / "workflows"
+    nanvix.mkdir(parents=True, exist_ok=True)
+    workflow.mkdir(parents=True, exist_ok=True)
+    manifest = newline.join(
+        (
+            "[package]",
+            'name = "test"',
+            'version = "1.0.0"',
+            'nanvix-version = "0.19.0"',
+            "",
+            "[toolchain]",
+            'kind = "nanvix-sdk"',
+            'provider = "c-clang"',
+            'sdk-version = "v0.19.0-sdk.2"',
+            f'sdk-image = "{_OLD_IMAGE_NAME}"',
+            f'sdk-digest = "{_OLD_DIGEST}"',
+            "",
+        )
+    )
+    (nanvix / "nanvix.toml").write_bytes(manifest.encode())
+    (nanvix / "z.py").write_text("from nanvix_zutil import ZScript\n")
+    (workflow / "nanvix-ci.yml").write_bytes(
+        (
+            f"jobs:{newline}"
+            f"  ci:{newline}"
+            f"    with:{newline}"
+            f"      docker-image: {_OLD_IMAGE}{newline}"
+        ).encode()
+    )
+    (root / ".zutils-version").write_bytes(f"v0.14.0{newline}".encode())
+    (root / "z").write_bytes(f"#!/usr/bin/env bash{newline}echo old{newline}".encode())
+    (root / "z.sh").write_bytes(
+        f"#!/usr/bin/env bash{newline}echo old{newline}".encode()
+    )
+    (root / "z.ps1").write_bytes(f"Write-Output 'old'{newline}".encode())
+    (nanvix / ".gitignore").write_bytes(f"old{newline}".encode())
+    (root / "z").chmod(0o755)
+    (root / "z.sh").chmod(0o755)
+    contract = root / "sdk-release.json"
+    contract.write_text(json.dumps(make_sdk_contract()))
+    return contract
+
+
+def nanvix_args(target: str | None, **overrides: object) -> argparse.Namespace:
+    """Build update-nanvix command arguments."""
+    values: dict[str, object] = {
+        "to": target,
+        "dry_run": False,
+        "check": False,
+        "output_format": "json",
+        "output": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def zutils_args(
+    target: str,
+    templates_dir: Path,
+    **overrides: object,
+) -> argparse.Namespace:
+    """Build update-zutils command arguments."""
+    values: dict[str, object] = {
+        "to": target,
+        "templates_dir": templates_dir,
+        "dry_run": False,
+        "check": False,
+        "output_format": "json",
+        "output": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class TestUpdateNanvix(unittest.TestCase):
+    """Coherent manifest/lock updates and blocked outcomes."""
+
+    def setUp(self) -> None:
+        self.contract_data = make_sdk_contract()
+        self.verify_patcher = patch(
+            "nanvix_zutil.commands.update_nanvix.verify_sdk_image"
+        )
+        self.resolve_patcher = patch("nanvix_zutil.commands.update_nanvix.resolve")
+        self.verify = self.verify_patcher.start()
+        self.resolve = self.resolve_patcher.start()
+        contract = update_nanvix.load_sdk_target(
+            json.dumps(self.contract_data), Path.cwd()
+        )
+        assert contract is not None
+        self.contract = contract
+        self.resolve.return_value = Lockfile(
+            LockfileMetadata(
+                manifest_hash="sha256:candidate",
+                nanvix_zutil_version="0.15.0",
+                sdk=contract.provenance(),
+            )
+        )
+
+    def tearDown(self) -> None:
+        self.resolve_patcher.stop()
+        self.verify_patcher.stop()
+
+    def test_full_sdk_update_and_noop(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        result, code = update_nanvix._run(nanvix_args(contract.name))
+        self.assertEqual(code, 0)
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(
+            result.changed_files,
+            (
+                ".github/workflows/nanvix-ci.yml",
+                ".nanvix/nanvix.lock",
+                ".nanvix/nanvix.toml",
+            ),
+        )
+        manifest = (root / ".nanvix/nanvix.toml").read_text()
+        self.assertIn('kind = "nanvix-sdk"', manifest)
+        self.assertIn('sdk-version = "v0.20.0-sdk.1"', manifest)
+        self.assertNotIn("NANVIX_SDK_IMAGE", (root / ".nanvix/z.py").read_text())
+        self.assertEqual(
+            read_lockfile(root / ".nanvix/nanvix.lock").metadata.sdk,
+            self.contract.provenance(),
+        )
+        self.assertIsNotNone(result.old)
+        assert result.new is not None
+        self.assertEqual(result.new["sdk_version"], "v0.20.0-sdk.1")
+        again, code = update_nanvix._run(nanvix_args(contract.name))
+        self.assertEqual(code, 0)
+        self.assertEqual(again.status, "up-to-date")
+
+    def test_check_and_dry_run_do_not_write(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        original = (root / ".nanvix/nanvix.toml").read_bytes()
+        checked, code = update_nanvix._run(nanvix_args(contract.name, check=True))
+        self.assertEqual((checked.status, code), ("outdated", 1))
+        dry, code = update_nanvix._run(nanvix_args(contract.name, dry_run=True))
+        self.assertEqual((dry.status, code), ("would-update", 0))
+        self.assertEqual((root / ".nanvix/nanvix.toml").read_bytes(), original)
+        self.assertFalse((root / ".nanvix/nanvix.lock").exists())
+
+    def test_crlf_manifest_and_workflow_are_preserved(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root, newline="\r\n")
+        update_nanvix._run(nanvix_args(contract.name))
+        for relative in (
+            ".nanvix/nanvix.toml",
+            ".github/workflows/nanvix-ci.yml",
+        ):
+            content = (root / relative).read_bytes()
+            self.assertIn(b"\r\n", content)
+            self.assertNotIn(b"\n", content.replace(b"\r\n", b""))
+
+    def test_transitional_marker_is_optional_and_checked(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        marker = root / ".nanvix/z.py"
+        marker.write_text(
+            f'NANVIX_SDK_IMAGE = "{_OLD_IMAGE}"\n' "from nanvix_zutil import ZScript\n"
+        )
+        result, _code = update_nanvix._run(nanvix_args(contract.name))
+        self.assertIn(".nanvix/z.py", result.changed_files)
+        self.assertIn(self.contract.image.ref, marker.read_text())
+
+    def test_dependencies_are_retargeted_before_strict_resolution(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        manifest_path = root / ".nanvix/nanvix.toml"
+        manifest_path.write_text(
+            manifest_path.read_text() + '\n[dependencies]\nzlib = "1.3.1"\n'
+        )
+        update_nanvix._run(nanvix_args(contract.name, dry_run=True))
+        candidate = self.resolve.call_args.args[0]
+        self.assertEqual(
+            candidate.dependencies[0].ref.value,
+            "1.3.1-nanvix-0.20.0-sdk.1",
+        )
+        self.assertTrue(self.resolve.call_args.kwargs["strict"])
+        self.assertEqual(
+            self.resolve.call_args.kwargs["manifest_content"],
+            update_nanvix._update_manifest(manifest_path.read_bytes(), self.contract),
+        )
+
+    def test_nested_transitional_toolchain_is_fully_canonicalized(self) -> None:
+        old = (
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.19.0"\n'
+            "\n[toolchain]\n"
+            'type = "sdk"\n'
+            "\n[toolchain.sdk]\n"
+            'version = "v0.19.0-sdk.2"\n'
+            'provider = "c-clang"\n'
+            f'image = "{_OLD_IMAGE}"\n'
+            "\n[dependencies]\n"
+            'zlib = "1.3.1"\n'
+        ).encode()
+        candidate = update_nanvix._update_manifest(old, self.contract)
+        data = tomllib.loads(candidate.decode())
+        self.assertNotIn("sdk", data["toolchain"])
+        self.assertEqual(
+            data["toolchain"]["kind"],
+            "nanvix-sdk",
+        )
+
+    def test_blocked_result_writes_nothing(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        original = (root / ".nanvix/nanvix.toml").read_bytes()
+        self.resolve.return_value = update_nanvix.BlockedResolution(
+            status="blocked",
+            package="zlib",
+            repo="nanvix/zlib",
+            requested_tag="1.3.1-nanvix-0.20.0-sdk.1",
+            sdk_version="v0.20.0-sdk.1",
+            reason="provenance-lock-missing",
+        )
+        result, code = update_nanvix._run(nanvix_args(contract.name))
+        self.assertEqual((result.status, code), ("blocked", 3))
+        self.assertEqual(result.changed_files, ())
+        assert result.blocker is not None
+        self.assertEqual(result.blocker["reason"], "provenance-lock-missing")
+        self.assertEqual((root / ".nanvix/nanvix.toml").read_bytes(), original)
+        self.assertFalse((root / ".nanvix/nanvix.lock").exists())
+
+    def test_changed_sdk_with_derived_build_image_is_blocked(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        manifest = root / ".nanvix/nanvix.toml"
+        manifest.write_text(
+            manifest.read_text()
+            + 'build-image = "ghcr.io/nanvix/derived-builder"\n'
+            + f'build-digest = "sha256:{"f" * 64}"\n'
+        )
+        original = manifest.read_bytes()
+        result, code = update_nanvix._run(nanvix_args(contract.name))
+        self.assertEqual((result.status, code), ("blocked", 3))
+        assert result.blocker is not None
+        self.assertEqual(
+            result.blocker["reason"],
+            "derived-build-image-update-required",
+        )
+        self.assertEqual(manifest.read_bytes(), original)
+
+    def test_default_and_explicit_tag_resolve_authoritative_release(self) -> None:
+        root = Path.cwd()
+        make_consumer(root)
+        with patch(
+            "nanvix_zutil.commands.update_nanvix.resolve_sdk_release",
+            return_value=self.contract,
+        ) as resolver:
+            self.resolve.return_value = Lockfile(
+                LockfileMetadata("sha256:x", "0.15.0", sdk=self.contract.provenance())
+            )
+            update_nanvix._run(nanvix_args(None, dry_run=True))
+            resolver.assert_called_with("latest", gh_token=None, verify_image=True)
+            update_nanvix._run(nanvix_args("v0.20.0-sdk.1", dry_run=True))
+            self.assertEqual(resolver.call_args.args[0], "v0.20.0-sdk.1")
+
+    def test_json_output_file(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "update-nanvix",
+                "--to",
+                contract.name,
+                "--dry-run",
+                "--output-format",
+                "json",
+                "--output",
+                "result.json",
+            ],
+        ):
+            with self.assertRaises(SystemExit) as context:
+                update_nanvix.main()
+        self.assertEqual(context.exception.code, 0)
+        payload: object = json.loads((root / "result.json").read_text())
+        self.assertIsInstance(payload, dict)
+        assert isinstance(payload, dict)
+        payload_data = cast("dict[str, object]", payload)
+        self.assertEqual(payload_data["status"], "would-update")
+        self.assertIn("old", payload_data)
+        self.assertIn("new", payload_data)
+
+    def test_interrupted_manifest_is_recovered_before_parsing(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        manifest = root / ".nanvix/nanvix.toml"
+        original = manifest.read_bytes()
+        manifest.write_text("not valid toml")
+        journal = root / ".nanvix/.nanvix-zutil-update-journal.json"
+        journal.write_text(
+            json.dumps(
+                {
+                    "state": "installing",
+                    "files": [
+                        {
+                            "path": ".nanvix/nanvix.toml",
+                            "mode": 0o644,
+                            "content": base64.b64encode(original).decode(),
+                        }
+                    ],
+                }
+            )
+        )
+        result, code = update_nanvix._run(nanvix_args(contract.name, dry_run=True))
+        self.assertEqual((result.status, code), ("would-update", 0))
+        self.assertFalse(journal.exists())
+        self.assertEqual(manifest.read_bytes(), original)
+
+
+class TestUpdateZutils(unittest.TestCase):
+    """Verified template updates preserve policies and exact allowlists."""
+
+    def test_update_and_noop_exact_allowlist(self) -> None:
+        root = Path.cwd()
+        make_consumer(root)
+        source = template_source(root)
+        result, code = update_zutils._run(zutils_args("v0.15.0", source))
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            result.changed_files,
+            (
+                ".nanvix/.gitignore",
+                ".zutils-version",
+                "z",
+                "z.ps1",
+                "z.sh",
+            ),
+        )
+        again, _code = update_zutils._run(zutils_args("0.15.0", source))
+        self.assertEqual(again.status, "up-to-date")
+        gitignore = (root / ".nanvix/.gitignore").read_text()
+        self.assertNotIn("nanvix.lock\n", gitignore)
+        self.assertIn(".nanvix-zutil-update.lock", gitignore)
+
+    def test_check_and_dry_run(self) -> None:
+        root = Path.cwd()
+        make_consumer(root)
+        source = template_source(root)
+        checked, code = update_zutils._run(zutils_args("v0.15.0", source, check=True))
+        self.assertEqual((checked.status, code), ("outdated", 1))
+        dry, code = update_zutils._run(zutils_args("v0.15.0", source, dry_run=True))
+        self.assertEqual((dry.status, code), ("would-update", 0))
+        self.assertEqual((root / ".zutils-version").read_text(), "v0.14.0\n")
+
+    def test_crlf_and_executable_modes_are_preserved(self) -> None:
+        root = Path.cwd()
+        make_consumer(root, newline="\r\n")
+        source = template_source(root)
+        old_mode = stat.S_IMODE((root / "z").stat().st_mode)
+        update_zutils._run(zutils_args("v0.15.0", source))
+        for relative in (".zutils-version", "z", "z.sh", "z.ps1"):
+            content = (root / relative).read_bytes()
+            self.assertIn(b"\r\n", content)
+            self.assertNotIn(b"\n", content.replace(b"\r\n", b""))
+        self.assertEqual(stat.S_IMODE((root / "z").stat().st_mode), old_mode)
+        self.assertTrue((root / "z").stat().st_mode & stat.S_IXUSR)
+
+    def test_new_shell_bootstrappers_are_executable(self) -> None:
+        root = Path.cwd()
+        make_consumer(root)
+        source = template_source(root)
+        (root / "z").unlink()
+        (root / "z.sh").unlink()
+        update_zutils._run(zutils_args("v0.15.0", source))
+        self.assertEqual(stat.S_IMODE((root / "z").stat().st_mode), 0o755)
+        self.assertEqual(stat.S_IMODE((root / "z.sh").stat().st_mode), 0o755)
+
+    def test_interrupted_pin_is_recovered_before_validation(self) -> None:
+        root = Path.cwd()
+        make_consumer(root)
+        source = template_source(root)
+        pin = root / ".zutils-version"
+        original = pin.read_bytes()
+        pin.write_text("broken")
+        journal = root / ".nanvix/.nanvix-zutil-update-journal.json"
+        journal.write_text(
+            json.dumps(
+                {
+                    "state": "installing",
+                    "files": [
+                        {
+                            "path": ".zutils-version",
+                            "mode": 0o644,
+                            "content": base64.b64encode(original).decode(),
+                        }
+                    ],
+                }
+            )
+        )
+        result, code = update_zutils._run(zutils_args("v0.15.0", source, dry_run=True))
+        self.assertEqual((result.status, code), ("would-update", 0))
+        self.assertEqual(pin.read_bytes(), original)
+        self.assertFalse(journal.exists())
+
+    def test_malformed_or_wrong_templates_fail(self) -> None:
+        root = Path.cwd()
+        make_consumer(root)
+        source = template_source(root, target="v0.14.0")
+        with self.assertRaises(UpdateError):
+            update_zutils._run(zutils_args("v0.15.0", source))
+        (source / "z.ps1").unlink()
+        with self.assertRaises(UpdateError):
+            update_zutils._run(zutils_args("v0.14.0", source))
+
+    def test_archive_modes_and_malformed_archive(self) -> None:
+        source = template_source(Path.cwd())
+        stream = io.BytesIO()
+        with zipfile.ZipFile(stream, "w") as archive:
+            for name in update_zutils._SOURCE_NAMES:
+                archive.writestr(f"templates/{name}", (source / name).read_bytes())
+        templates = update_zutils._templates_from_archive(stream.getvalue(), "v0.15.0")
+        self.assertEqual(set(templates), set(update_zutils._SOURCE_NAMES))
+        with self.assertRaises(UpdateError):
+            update_zutils._templates_from_archive(b"not-a-zip", "v0.15.0")
+
+    def test_default_source_uses_exact_release_archive(self) -> None:
+        source = template_source(Path.cwd())
+        stream = io.BytesIO()
+        with zipfile.ZipFile(stream, "w") as archive:
+            for name in update_zutils._SOURCE_NAMES:
+                archive.writestr(name, (source / name).read_bytes())
+        release: dict[str, object] = {
+            "tag_name": "v0.15.0",
+            "assets": [
+                {
+                    "name": "templates.zip",
+                    "browser_download_url": "https://example.invalid/templates.zip",
+                    "digest": (
+                        "sha256:" + hashlib.sha256(stream.getvalue()).hexdigest()
+                    ),
+                }
+            ],
+        }
+        with (
+            patch(
+                "nanvix_zutil.commands.update_zutils.github.resolve_release",
+                return_value=release,
+            ) as resolver,
+            patch(
+                "nanvix_zutil.commands.update_zutils._download_archive",
+                return_value=stream.getvalue(),
+            ) as download,
+            patch.dict(os.environ, {"GH_TOKEN": "read-token"}, clear=False),
+        ):
+            templates = update_zutils._resolve_templates("v0.15.0", None)
+        resolver.assert_called_once_with(
+            "nanvix/zutils", "v0.15.0", gh_token="read-token"
+        )
+        download.assert_called_once_with(
+            "https://example.invalid/templates.zip", "read-token"
+        )
+        self.assertEqual(templates[".zutils-version"], b"v0.15.0\n")
+
+    def test_release_tag_or_asset_skew_fails(self) -> None:
+        with self.assertRaises(UpdateError):
+            update_zutils._release_asset(
+                {"tag_name": "v0.14.0", "assets": []},
+                "v0.15.0",
+            )
+        with self.assertRaises(UpdateError):
+            update_zutils._verify_archive_digest(
+                b"archive",
+                f"sha256:{'0' * 64}",
+            )
+        with self.assertRaises(UpdateError):
+            update_zutils._release_asset(
+                {"tag_name": "v0.15.0", "assets": []},
+                "v0.15.0",
+            )
+
+    def test_zutils_source_allowlist(self) -> None:
+        root = Path.cwd()
+        (root / "templates").mkdir()
+        (root / "templates/.zutils-version").write_text("v0.15.0\n")
+        (root / "examples").mkdir()
+        maps = update_zutils._target_maps(root)
+        targets = {
+            relative.as_posix()
+            for target_map in maps
+            for relative in target_map.values()
+        }
+        self.assertIn("templates/z", targets)
+        self.assertIn("examples/bin-hello/.nanvix/.gitignore", targets)
+        self.assertIn("examples/lib-hello/z.ps1", targets)
+
+
+class TestAtomicUpdates(unittest.TestCase):
+    """Multi-file failures restore bytes and executable modes."""
+
+    def test_failure_rolls_back_bytes_and_modes(self) -> None:
+        root = Path.cwd()
+        first = root / "first"
+        second = root / "second"
+        first.write_bytes(b"old-first")
+        second.write_bytes(b"old-second")
+        first.chmod(0o755)
+        real_replace = os.replace
+        calls = 0
+
+        def fail_second(source: Path, target: Path) -> None:
+            nonlocal calls
+            if ".nanvix-zutil-update-journal" in str(target):
+                real_replace(source, target)
+                return
+            calls += 1
+            if calls == 2:
+                raise OSError("injected")
+            real_replace(source, target)
+
+        with patch("nanvix_zutil.updater.os.replace", side_effect=fail_second):
+            with self.assertRaises(UpdateError):
+                atomic_write_candidates(
+                    root,
+                    {Path("first"): b"new-first", Path("second"): b"new-second"},
+                    {},
+                )
+        self.assertEqual(first.read_bytes(), b"old-first")
+        self.assertEqual(second.read_bytes(), b"old-second")
+        self.assertEqual(stat.S_IMODE(first.stat().st_mode), 0o755)
+        self.assertTrue((root / ".nanvix/.nanvix-zutil-update.lock").exists())
+        self.assertFalse((root / ".nanvix/.nanvix-zutil-update-journal.json").exists())
+        self.assertFalse((root / ".nanvix-zutil-update.lock").exists())
+        self.assertFalse((root / ".nanvix-zutil-update-journal.json").exists())
+
+    def test_directory_fsync_failure_rolls_back_replaced_target(self) -> None:
+        root = Path.cwd()
+        first = root / "first"
+        second = root / "second"
+        first.write_bytes(b"old-first")
+        second.write_bytes(b"old-second")
+        calls = 0
+        real_fsync_directory = updater._fsync_directory
+
+        def fail_after_first_replace(path: Path) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("directory fsync failed")
+            real_fsync_directory(path)
+
+        with (
+            patch(
+                "nanvix_zutil.updater._fsync_directory",
+                side_effect=fail_after_first_replace,
+            ),
+            self.assertRaises(UpdateError),
+        ):
+            atomic_write_candidates(
+                root,
+                {Path("first"): b"new-first", Path("second"): b"new-second"},
+                {},
+            )
+        self.assertEqual(first.read_bytes(), b"old-first")
+        self.assertEqual(second.read_bytes(), b"old-second")
+        self.assertFalse((root / ".nanvix/.nanvix-zutil-update-journal.json").exists())
+
+    def test_rollback_sidecar_is_fsynced_before_replace(self) -> None:
+        root = Path.cwd()
+        target = root / "target"
+        target.write_bytes(b"new")
+        events: list[str] = []
+        real_replace = os.replace
+        real_fsync = os.fsync
+
+        def record_replace(source: Path, destination: Path) -> None:
+            events.append("replace")
+            real_replace(source, destination)
+
+        def record_fsync(descriptor: int) -> None:
+            events.append("fsync")
+            real_fsync(descriptor)
+
+        with (
+            patch("nanvix_zutil.updater.os.replace", side_effect=record_replace),
+            patch("nanvix_zutil.updater.os.fsync", side_effect=record_fsync),
+        ):
+            updater._restore_snapshot(target, b"old", 0o755)
+        self.assertEqual(target.read_bytes(), b"old")
+        self.assertLess(events.index("fsync"), events.index("replace"))
+
+    def test_concurrent_owner_blocks_and_context_exit_releases(self) -> None:
+        root = Path.cwd()
+        target = root / "target"
+        target.write_bytes(b"old")
+        lock = root / ".nanvix/.nanvix-zutil-update.lock"
+        with updater.update_transaction(root):
+            with self.assertRaises(UpdateError):
+                atomic_write_candidates(
+                    root,
+                    {Path("target"): b"new"},
+                    {},
+                )
+        changed = atomic_write_candidates(
+            root,
+            {Path("target"): b"new"},
+            {},
+        )
+        self.assertEqual(changed, ("target",))
+        self.assertEqual(target.read_bytes(), b"new")
+        self.assertTrue(lock.exists())
+        self.assertFalse((root / ".nanvix/.nanvix-zutil-update-journal.json").exists())
+        self.assertFalse((root / ".nanvix-zutil-update.lock").exists())
+
+    def test_lock_releases_when_owner_process_exits(self) -> None:
+        root = Path.cwd()
+        code = (
+            "import sys,time\n"
+            "from pathlib import Path\n"
+            "from nanvix_zutil.updater import update_transaction\n"
+            "with update_transaction(Path(sys.argv[1])):\n"
+            " print('locked', flush=True)\n"
+            " time.sleep(0.5)\n"
+        )
+        process = subprocess.Popen(
+            [sys.executable, "-c", code, str(root)],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        assert process.stdout is not None
+        self.assertEqual(process.stdout.readline().strip(), "locked")
+        with self.assertRaises(UpdateError):
+            with updater.update_transaction(root):
+                pass
+        self.assertEqual(process.wait(timeout=5), 0)
+        with updater.update_transaction(root):
+            pass
+
+    def test_zutils_source_uses_root_local_transient_state(self) -> None:
+        root = Path.cwd()
+        (root / "templates").mkdir()
+        (root / "templates/.zutils-version").write_text("v0.15.0\n")
+        (root / "examples").mkdir()
+        target = root / "target"
+        target.write_bytes(b"old")
+        changed = atomic_write_candidates(
+            root,
+            {Path("target"): b"new"},
+            {},
+        )
+        self.assertEqual(changed, ("target",))
+        self.assertTrue((root / ".nanvix-zutil-update.lock").exists())
+        self.assertFalse((root / ".nanvix-zutil-update-journal.json").exists())
+
+    def test_recovery_rejects_symlink_escape(self) -> None:
+        root = Path.cwd()
+        outside = root.parent
+        (root / "link").symlink_to(outside, target_is_directory=True)
+        journal = root / ".nanvix/.nanvix-zutil-update-journal.json"
+        journal.write_text(
+            json.dumps(
+                {
+                    "state": "installing",
+                    "files": [
+                        {
+                            "path": "link/escape",
+                            "mode": 0o644,
+                            "content": base64.b64encode(b"secret").decode(),
+                        }
+                    ],
+                }
+            )
+        )
+        with self.assertRaises(UpdateError):
+            with updater.update_transaction(root):
+                pass
+        self.assertTrue(journal.exists())
+        self.assertFalse((outside / "escape").exists())
+
+    def test_incomplete_rollback_retains_journal(self) -> None:
+        root = Path.cwd()
+        first = root / "first"
+        second = root / "second"
+        first.write_bytes(b"old-first")
+        second.write_bytes(b"old-second")
+        real_replace = os.replace
+        installs = 0
+
+        def fail_second(source: Path, target: Path) -> None:
+            nonlocal installs
+            if ".nanvix-zutil-update-journal" in str(target):
+                real_replace(source, target)
+                return
+            installs += 1
+            if installs == 2:
+                raise OSError("read-only destination")
+            real_replace(source, target)
+
+        with (
+            patch("nanvix_zutil.updater.os.replace", side_effect=fail_second),
+            patch(
+                "nanvix_zutil.updater._restore_snapshot",
+                side_effect=PermissionError("read-only rollback"),
+            ),
+            self.assertRaises(UpdateError) as context,
+        ):
+            atomic_write_candidates(
+                root,
+                {Path("first"): b"new-first", Path("second"): b"new-second"},
+                {},
+            )
+        self.assertIn("rollback is incomplete", str(context.exception))
+        self.assertTrue((root / ".nanvix/.nanvix-zutil-update-journal.json").exists())
+
+    def test_journal_write_is_atomic_and_fsynced(self) -> None:
+        root = Path.cwd()
+        journal = root / ".nanvix/journal.json"
+        with patch("nanvix_zutil.updater.os.fsync", wraps=os.fsync) as fsync:
+            updater._write_journal(
+                journal,
+                {"state": "installing", "files": []},
+            )
+        self.assertEqual(json.loads(journal.read_text())["state"], "installing")
+        self.assertGreaterEqual(fsync.call_count, 2)
+        self.assertEqual(
+            list(journal.parent.glob(f".{journal.name}.*.new")),
+            [],
+        )
+
+    def test_journal_is_retained_when_delete_fsync_fails(self) -> None:
+        root = Path.cwd()
+        journal = root / ".nanvix/journal.json"
+        data: dict[str, object] = {"state": "committed", "files": []}
+        journal.write_text(json.dumps(data))
+        with (
+            patch(
+                "nanvix_zutil.updater._fsync_directory",
+                side_effect=OSError("durability uncertain"),
+            ),
+            self.assertRaises(OSError),
+        ):
+            updater._remove_journal(journal, data)
+        self.assertTrue(journal.exists())
+        self.assertEqual(json.loads(journal.read_text())["state"], "committed")
+
+    def test_windows_lock_path_never_uses_kill(self) -> None:
+        root = Path.cwd()
+        with (
+            patch("nanvix_zutil.updater.os.name", "nt"),
+            patch(
+                "nanvix_zutil.updater._windows_lock",
+            ) as windows_lock,
+            patch("nanvix_zutil.updater._windows_unlock") as windows_unlock,
+            patch("nanvix_zutil.updater.os.kill") as kill,
+        ):
+            with updater.update_transaction(root):
+                pass
+        windows_lock.assert_called_once()
+        windows_unlock.assert_called_once()
+        kill.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -420,17 +420,31 @@ class TestUpdateZutils(unittest.TestCase):
             self.assertIn(b"\r\n", content)
             self.assertNotIn(b"\n", content.replace(b"\r\n", b""))
         self.assertEqual(stat.S_IMODE((root / "z").stat().st_mode), old_mode)
-        self.assertTrue((root / "z").stat().st_mode & stat.S_IXUSR)
+        if os.name != "nt":
+            self.assertTrue((root / "z").stat().st_mode & stat.S_IXUSR)
 
     def test_new_shell_bootstrappers_are_executable(self) -> None:
         root = Path.cwd()
         make_consumer(root)
         source = template_source(root)
+        probe = root / "mode-probe"
+        probe.write_bytes(b"probe")
+        probe.chmod(0o755)
+        expected_mode = stat.S_IMODE(probe.stat().st_mode)
+        probe.unlink()
         (root / "z").unlink()
         (root / "z.sh").unlink()
         update_zutils._run(zutils_args("v0.15.0", source))
-        self.assertEqual(stat.S_IMODE((root / "z").stat().st_mode), 0o755)
-        self.assertEqual(stat.S_IMODE((root / "z.sh").stat().st_mode), 0o755)
+        self.assertEqual(
+            stat.S_IMODE((root / "z").stat().st_mode),
+            expected_mode,
+        )
+        self.assertEqual(
+            stat.S_IMODE((root / "z.sh").stat().st_mode),
+            expected_mode,
+        )
+        if os.name != "nt":
+            self.assertTrue((root / "z").stat().st_mode & stat.S_IXUSR)
 
     def test_interrupted_pin_is_recovered_before_validation(self) -> None:
         root = Path.cwd()
@@ -516,7 +530,10 @@ class TestUpdateZutils(unittest.TestCase):
         download.assert_called_once_with(
             "https://example.invalid/templates.zip", "read-token"
         )
-        self.assertEqual(templates[".zutils-version"], b"v0.15.0\n")
+        self.assertEqual(
+            templates[".zutils-version"],
+            (source / ".zutils-version").read_bytes(),
+        )
 
     def test_release_tag_or_asset_skew_fails(self) -> None:
         with self.assertRaises(UpdateError):
@@ -561,6 +578,7 @@ class TestAtomicUpdates(unittest.TestCase):
         first.write_bytes(b"old-first")
         second.write_bytes(b"old-second")
         first.chmod(0o755)
+        first_mode = stat.S_IMODE(first.stat().st_mode)
         real_replace = os.replace
         calls = 0
 
@@ -583,7 +601,7 @@ class TestAtomicUpdates(unittest.TestCase):
                 )
         self.assertEqual(first.read_bytes(), b"old-first")
         self.assertEqual(second.read_bytes(), b"old-second")
-        self.assertEqual(stat.S_IMODE(first.stat().st_mode), 0o755)
+        self.assertEqual(stat.S_IMODE(first.stat().st_mode), first_mode)
         self.assertTrue((root / ".nanvix/.nanvix-zutil-update.lock").exists())
         self.assertFalse((root / ".nanvix/.nanvix-zutil-update-journal.json").exists())
         self.assertFalse((root / ".nanvix-zutil-update.lock").exists())
@@ -777,7 +795,7 @@ class TestAtomicUpdates(unittest.TestCase):
                 {"state": "installing", "files": []},
             )
         self.assertEqual(json.loads(journal.read_text())["state"], "installing")
-        self.assertGreaterEqual(fsync.call_count, 2)
+        self.assertGreaterEqual(fsync.call_count, 1 if os.name == "nt" else 2)
         self.assertEqual(
             list(journal.parent.glob(f".{journal.name}.*.new")),
             [],
@@ -798,6 +816,19 @@ class TestAtomicUpdates(unittest.TestCase):
             updater._remove_journal(journal, data)
         self.assertTrue(journal.exists())
         self.assertEqual(json.loads(journal.read_text())["state"], "committed")
+
+    def test_fsync_file_uses_read_write_descriptor(self) -> None:
+        path = Path.cwd() / "file"
+        path.write_bytes(b"data")
+        with (
+            patch("nanvix_zutil.updater.os.open", return_value=123) as opened,
+            patch("nanvix_zutil.updater.os.fsync") as fsync,
+            patch("nanvix_zutil.updater.os.close") as close,
+        ):
+            updater._fsync_file(path)
+        opened.assert_called_once_with(path, os.O_RDWR)
+        fsync.assert_called_once_with(123)
+        close.assert_called_once_with(123)
 
     def test_windows_lock_path_never_uses_kill(self) -> None:
         root = Path.cwd()


### PR DESCRIPTION
## Summary
- add canonical immutable SDK/derived-image manifest models and manifest-driven setup
- verify sdk-release.json against digest-pinned images, embedded manifests, and OCI labels
- persist SDK provenance in backward-compatible lockfiles
- add strict exact SDK-aware dependency resolution, blocked results, and unique sdk.N release tags
- add atomic update-nanvix manifest+lock mutation and full update-zutils bootstrap replacement
- preserve modes/line endings with crash-recoverable confined transactions
- migrate examples, CI fixtures, tests, and docs to the Nanvix SDK digest

Closes #288.

## Validation
- 649 tests passed, 6 skipped pending the first authoritative SDK GitHub Release
- strict pyright: 0 errors
- Black, shfmt, shellcheck, and yamllint
- SDK examples: 6 passed, 2 covered skips
- digest/embedded-manifest/OCI-label verification against v0.20.0-sdk.1

PSScriptAnalyzer was unavailable locally; Windows CI covers PowerShell/import behavior.