### PR TITLE
[sdk] E: Adopt authoritative SDK revision 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
+      image: ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35
     env:
       NANVIX_TOOLCHAIN: /opt/nanvix
       USER: runner

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -15,9 +15,9 @@ nanvix-version = "0.20.0"
 [toolchain]
 kind = "nanvix-sdk"
 provider = "c-clang"
-sdk-version = "v0.20.0-sdk.1"
+sdk-version = "v0.20.0-sdk.2"
 sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
-sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 ```
 
 ## `[package]`
@@ -41,9 +41,9 @@ as one typed coordinate:
 [toolchain]
 kind = "nanvix-sdk"
 provider = "c-clang"
-sdk-version = "v0.20.0-sdk.1"
+sdk-version = "v0.20.0-sdk.2"
 sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
-sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 ```
 
 The SDK version's runtime must equal `package.nanvix-version`. Optional
@@ -129,9 +129,9 @@ nanvix-version = "0.20.0"
 [toolchain]
 kind = "nanvix-sdk"
 provider = "c-clang"
-sdk-version = "v0.20.0-sdk.1"
+sdk-version = "v0.20.0-sdk.2"
 sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
-sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 
 [dependencies]
 zlib = "1.2.3"

--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -93,7 +93,7 @@ cd /path/to/consumer
 PYTHONPATH=~/nanvix/usr/lib/zutils/src \
   python3 -m nanvix_zutil setup \
     --offline \
-    --with-docker ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f \
+    --with-docker ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35 \
     --allow-local-docker-override \
     --with-nanvix ~/nanvix/build \
     --sysroot-path ~/nanvix/build/sysroot

--- a/examples/bin-hello/.nanvix/nanvix.toml
+++ b/examples/bin-hello/.nanvix/nanvix.toml
@@ -6,9 +6,9 @@ nanvix-version = "0.20.0"
 [toolchain]
 kind = "nanvix-sdk"
 provider = "c-clang"
-sdk-version = "v0.20.0-sdk.1"
+sdk-version = "v0.20.0-sdk.2"
 sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
-sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 
 [dependencies]
 lib-hello = { commitish = "HEAD" }

--- a/examples/bin-hello/README.md
+++ b/examples/bin-hello/README.md
@@ -24,7 +24,7 @@ bin-hello/
 One of:
 
 - **Native SDK** — Clang targeting `i686-unknown-nanvix` (default prefix: `/opt/nanvix/`)
-- **Docker** with the immutable `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f` image
+- **Docker** with the immutable `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35` image
 
 ## Running
 

--- a/examples/lib-hello/.nanvix/nanvix.toml
+++ b/examples/lib-hello/.nanvix/nanvix.toml
@@ -6,6 +6,6 @@ nanvix-version = "0.20.0"
 [toolchain]
 kind = "nanvix-sdk"
 provider = "c-clang"
-sdk-version = "v0.20.0-sdk.1"
+sdk-version = "v0.20.0-sdk.2"
 sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
-sdk-digest = "sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"

--- a/examples/lib-hello/README.md
+++ b/examples/lib-hello/README.md
@@ -23,7 +23,7 @@ lib-hello/
 
 One of:
 - **Native SDK** — Clang targeting `i686-unknown-nanvix` (default prefix: `/opt/nanvix/`)
-- **Docker** with the immutable `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f` image
+- **Docker** with the immutable `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35` image
 
 If you built the Nanvix toolchain locally (e.g. from `nanvix/nanvix`), point
 `NANVIX_TOOLCHAIN` at it:

--- a/templates/nanvix-ci.yml
+++ b/templates/nanvix-ci.yml
@@ -27,7 +27,7 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v{{WORKFLOW_VERSION}}
     with:
       caller-event-name: ${{ github.event_name }}
-      docker-image: ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f  # yamllint disable-line rule:line-length
+      docker-image: ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35  # yamllint disable-line rule:line-length
       nanvix-version-source: sdk
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -36,7 +36,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _LIB_HELLO = _REPO_ROOT / "examples" / "lib-hello"
 _BIN_HELLO = _REPO_ROOT / "examples" / "bin-hello"
-_DOCKER_IMAGE = "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+_DOCKER_IMAGE = "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 _NANVIX_VERSION = "0.20.0"
 _TIMEOUT = 300
 
@@ -83,7 +83,7 @@ def _can_run_docker_lifecycle() -> bool:
 def _has_authoritative_sdk_release() -> bool:
     """Return whether the pinned SDK completion release is published."""
     request = urllib.request.Request(
-        "https://api.github.com/repos/nanvix/sdk/releases/tags/v0.20.0-sdk.1",
+        "https://api.github.com/repos/nanvix/sdk/releases/tags/v0.20.0-sdk.2",
         headers={"Accept": "application/vnd.github+json"},
     )
     token = os.environ.get("GH_TOKEN")


### PR DESCRIPTION
## Summary
- move executable SDK examples to the authoritative `v0.20.0-sdk.2` contract
- pin release CI and shipped workflow templates to image digest `sha256:880ed7e...`
- enable the previously skipped SDK Release integration lifecycle
- refresh user-facing immutable coordinates

## Validation
- `uv run tasks.py lint`
- `uv run tasks.py typecheck`
- `uv run tasks.py test` (656 passed, 2 skipped)
- SDK example lifecycle (4 passed; test-only variants skipped as expected)