### PR TITLE
[release] F: Install Python venv support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install bootstrap runtime
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends python3-venv
+          rm -rf /var/lib/apt/lists/*
+
       - name: Install project and dev dependencies
         run: uv sync --python 3.12
 


### PR DESCRIPTION
## Summary
Install Ubuntu's split `python3-venv` runtime before running the complete test suite inside the immutable SDK container.

The first v0.15.0 release attempt exposed this release-only gap: PR/default CI runs integration tests on the host, while release CI runs every test inside the SDK image. The bootstrap wrappers correctly require `python3 -m venv`.

## Validation
- reproduced the failure in the exact SDK image
- installed `python3-venv` and ran both example bootstrappers successfully in that image
- `uv run tasks.py lint`