### PR TITLE
[templates] F: Preserve generated-output ignores

### DIFF
--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,9 +1,13 @@
+__pycache__
 venv
 cache
 sysroot
 buildroot
+out
+.yamllint.yml
+black.toml
 env.json
-__pycache__
+pyrightconfig.json
 .nanvix-zutil-update.lock
 .nanvix-zutil-update-journal.json
 .*.nanvix-zutil-*

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -377,6 +377,14 @@ class TestUpdateNanvix(unittest.TestCase):
 class TestUpdateZutils(unittest.TestCase):
     """Verified template updates preserve policies and exact allowlists."""
 
+    def test_shipped_gitignore_matches_canonical_config(self) -> None:
+        """Bootstrap updates must preserve every generated-artifact pattern."""
+        root = Path(__file__).resolve().parent.parent
+        self.assertEqual(
+            (root / "templates/.gitignore").read_bytes(),
+            (root / "src/nanvix_zutil/configs/.gitignore").read_bytes(),
+        )
+
     def test_update_and_noop_exact_allowlist(self) -> None:
         root = Path.cwd()
         make_consumer(root)


### PR DESCRIPTION
## Summary
Restore `out`, lint configuration, and type-check configuration patterns in the shipped `.nanvix/.gitignore` template and enforce byte-for-byte parity with the canonical runtime config.

The v0.15.0 rollout exposed the drift because complete bootstrap replacement correctly installed the release template, making previously generated local artifacts visible.

## Validation
- `tests/test_update_commands.py` (34 passed)
- lint and strict type checking