### PR TITLE
[setup] F: Resolve SDK metadata on Windows

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -414,10 +414,13 @@ class ZScript:
         sdk_releases: dict[str, dict[str, object]] = {}
         sdk_mode = self.manifest.toolchain.kind == ToolchainKind.SDK
         if sdk_mode and not self._offline:
+            # Windows resolves the digest-bound release tuple but cannot execute the
+            # Linux provider image; CI verifies that image on its Linux job.
             resolution = resolve(
                 self.manifest,
                 gh_token=self.config.get(CFG_GH_TOKEN),
                 strict=True,
+                verify_sdk_image=not is_windows(),
             )
             if isinstance(resolution, BlockedResolution):
                 log.fatal(

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -533,6 +533,10 @@ class TestSdkDockerSelection(unittest.TestCase):
         self.assertFalse(used_fallback)
         resolver.assert_called_once()
         self.assertTrue(resolver.call_args.kwargs["strict"])
+        self.assertEqual(
+            resolver.call_args.kwargs["verify_sdk_image"],
+            sys.platform != "win32",
+        )
         fallback.assert_not_called()
         fake_buildroot.install_dep.assert_called_once()
         release = fake_buildroot.install_dep.call_args.kwargs["_release"]


### PR DESCRIPTION
## Summary
Keep strict, digest-bound SDK Release and dependency resolution on Windows without trying to execute the Linux SDK provider image.

The canonical BusyBox pilot proved that GitHub-hosted Windows runners reject the Linux image during `setup`, even though the reusable CI's Linux metadata job has already verified that exact digest. Windows still validates the release contract and exact dependency coordinates.

## Validation
- targeted SDK setup resolver test
- lint and strict type checking
- canonical BusyBox Linux build/full suite already green; Windows CI will exercise this path