### PR TITLE
[update-nanvix] F: Remove caller image overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ SDK manifests pin a verified GitHub Release contract and immutable OCI digest.
 exact tag/contract with `--to`), verifies its image, strictly resolves exact
 dependency releases, and atomically writes `nanvix.toml` plus the
 provenance-bearing `nanvix.lock`. Missing dependency provenance emits a blocked
-JSON result and writes nothing. Transitional Python/workflow image markers are
-updated only when present.
+JSON result and writes nothing. Transitional Python image markers are updated
+when present; redundant reusable-workflow `docker-image` inputs are removed.
 
 Canonical `.nanvix/nanvix.lock` files are committed. Only update transaction
 state (`.nanvix-zutil-update.lock` and its journal/sidecars) is ignored.

--- a/src/nanvix_zutil/commands/update_nanvix.py
+++ b/src/nanvix_zutil/commands/update_nanvix.py
@@ -56,10 +56,8 @@ _SDK_ASSIGNMENT = re.compile(
     r'^(?P<prefix>\s*NANVIX_SDK_IMAGE\s*(?::\s*str\s*)?=\s*")[^"]*(?P<suffix>".*)$',
     re.MULTILINE,
 )
-_DOCKER_IMAGE = re.compile(
-    r"^(?P<prefix>\s*docker-image\s*:\s*)(?P<quote>[\"']?)"
-    r"(?P<value>[^\"'\s#]+)(?P=quote)(?P<suffix>\s*(?:#.*)?)$",
-    re.MULTILINE,
+_DOCKER_IMAGE_KEY = re.compile(
+    r"^(?P<indent>[ \t]*)docker-image[ \t]*:[ \t]*(?P<value>.*)$",
 )
 
 
@@ -123,6 +121,40 @@ def _replace_exact(
         text,
         count=1,
     )
+
+
+def _remove_docker_image_inputs(text: str) -> str | None:
+    """Remove inline or block-scalar caller image inputs from workflow YAML."""
+    lines = text.splitlines(keepends=True)
+    rendered: list[str] = []
+    removed = False
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        match = _DOCKER_IMAGE_KEY.match(line.rstrip("\r\n"))
+        if match is None:
+            rendered.append(line)
+            index += 1
+            continue
+
+        removed = True
+        marker = match.group("value").split("#", maxsplit=1)[0].strip()
+        base_indent = len(match.group("indent").expandtabs(8))
+        index += 1
+        if marker.startswith((">", "|")):
+            while index < len(lines):
+                candidate = lines[index].rstrip("\r\n")
+                if not candidate.strip():
+                    rendered.append(lines[index])
+                    index += 1
+                    continue
+                prefix_length = len(candidate) - len(candidate.lstrip(" \t"))
+                indent = len(candidate[:prefix_length].expandtabs(8))
+                if indent <= base_indent:
+                    break
+                index += 1
+
+    return "".join(rendered) if removed else None
 
 
 def _canonical_toolchain_block(
@@ -365,35 +397,22 @@ def _optional_marker_candidates(
         if not path.is_file():
             continue
         text = path.read_bytes().decode("utf-8")
-        matches = list(_DOCKER_IMAGE.finditer(text))
-        if not matches:
+        candidate_text = _remove_docker_image_inputs(text)
+        if candidate_text is None:
             continue
-        current_images = {match.group("value") for match in matches}
-        if len(current_images) != 1 or (
-            old_images and not current_images.issubset(old_images)
-        ):
-            raise UpdateError(f"{relative}: docker-image inputs disagree")
-        candidate = _DOCKER_IMAGE.sub(
-            lambda match: (
-                f'{match.group("prefix")}{match.group("quote")}{new_image}'
-                f'{match.group("quote")}{match.group("suffix")}'
-            ),
-            text,
-        ).encode("utf-8")
+        candidate = candidate_text.encode("utf-8")
         candidates[relative] = candidate
 
         def validate_workflow(
             value: bytes,
             label: str = relative.as_posix(),
-            expected: str = new_image,
-            count: int = len(matches),
         ) -> None:
-            images = [
-                match.group("value")
-                for match in _DOCKER_IMAGE.finditer(value.decode("utf-8"))
-            ]
-            if len(images) != count or any(image != expected for image in images):
-                raise UpdateError(f"{label}: invalid docker-image candidate")
+            rendered = value.decode("utf-8")
+            if any(
+                _DOCKER_IMAGE_KEY.match(line) is not None
+                for line in rendered.splitlines()
+            ):
+                raise UpdateError(f"{label}: redundant docker-image input remains")
 
         validators[relative] = validate_workflow
     return candidates, validators

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -84,7 +84,9 @@ def make_consumer(root: Path, *, newline: str = "\n") -> Path:
             f"jobs:{newline}"
             f"  ci:{newline}"
             f"    with:{newline}"
-            f"      docker-image: {_OLD_IMAGE}{newline}"
+            f"      docker-image: >-{newline}"
+            f"        {_OLD_IMAGE}{newline}"
+            f"      caller-event-name: pull_request{newline}"
         ).encode()
     )
     (root / ".zutils-version").write_bytes(f"v0.14.0{newline}".encode())
@@ -178,6 +180,10 @@ class TestUpdateNanvix(unittest.TestCase):
         self.assertIn('kind = "nanvix-sdk"', manifest)
         self.assertIn('sdk-version = "v0.20.0-sdk.1"', manifest)
         self.assertNotIn("NANVIX_SDK_IMAGE", (root / ".nanvix/z.py").read_text())
+        workflow = (root / ".github/workflows/nanvix-ci.yml").read_text()
+        self.assertNotIn("docker-image:", workflow)
+        self.assertNotIn(_OLD_IMAGE, workflow)
+        self.assertIn("caller-event-name: pull_request", workflow)
         self.assertEqual(
             read_lockfile(root / ".nanvix/nanvix.lock").metadata.sdk,
             self.contract.provenance(),


### PR DESCRIPTION
## Summary
Remove redundant reusable-workflow `docker-image` inputs during canonical SDK conversion, including YAML block scalars, instead of rewriting only the key line.

The first tier-1 cascade found that existing callers use `>-`: replacing the scalar marker left the old indented digest concatenated with the new value. Canonical manifests make the input unnecessary, so removing the complete node is safer and establishes one source of truth.

## Validation
- update command suite (34 passed)
- lint and strict type checking
- real zlib default-branch block-scalar migration probe
- CRLF preservation coverage