### PR TITLE
[update-nanvix] F: Preserve reusable input schemas

### DIFF
--- a/src/nanvix_zutil/commands/update_nanvix.py
+++ b/src/nanvix_zutil/commands/update_nanvix.py
@@ -137,8 +137,13 @@ def _remove_docker_image_inputs(text: str) -> str | None:
             index += 1
             continue
 
-        removed = True
         marker = match.group("value").split("#", maxsplit=1)[0].strip()
+        if not marker:
+            rendered.append(line)
+            index += 1
+            continue
+
+        removed = True
         base_indent = len(match.group("indent").expandtabs(8))
         index += 1
         if marker.startswith((">", "|")):

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -229,6 +229,25 @@ class TestUpdateNanvix(unittest.TestCase):
         self.assertIn(".nanvix/z.py", result.changed_files)
         self.assertIn(self.contract.image.ref, marker.read_text())
 
+    def test_workflow_call_input_definition_is_preserved(self) -> None:
+        """Only caller values, not reusable-workflow input schemas, are removed."""
+        workflow = (
+            "on:\n"
+            "  workflow_call:\n"
+            "    inputs:\n"
+            "      docker-image:\n"
+            "        type: string\n"
+            "jobs:\n"
+            "  ci:\n"
+            "    with:\n"
+            f"      docker-image: {_OLD_IMAGE}\n"
+        )
+        candidate = update_nanvix._remove_docker_image_inputs(workflow)
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertIn("      docker-image:\n        type: string\n", candidate)
+        self.assertNotIn(_OLD_IMAGE, candidate)
+
     def test_dependencies_are_retargeted_before_strict_resolution(self) -> None:
         root = Path.cwd()
         contract = make_consumer(root)


### PR DESCRIPTION
Preserve empty workflow_call docker-image input schema declarations while removing concrete caller values. Adds regression coverage and passes 35 updater tests, lint, and strict typing.