### PR TITLE
[sdk] F: Remove legacy compatibility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ __init__.py    ←  public library API (re-exports all public symbols)
   ├── config.py      ←  Config
   ├── docker.py      ←  DockerConfig, Mount
   ├── exitcodes.py   ←  EXIT_* constants
-  ├── github.py      ←  resolve_release, resolve_release_with_fallback
+  ├── github.py      ←  exact release resolution and downloads
   ├── lockfile.py    ←  Lockfile, ResolvedPackage, read_lockfile, write_lockfile
   ├── manifest.py    ←  Manifest, load_manifest
   ├── release.py     ←  package, ArchiveFormat, DEFAULT_FORMATS (.tar.gz, .zip)
@@ -88,7 +88,7 @@ nanvix/<project>/
 - **Type-checked with `pyright` in strict mode.** All code must pass strict type checking. Every public function must have a complete type signature.
 - **Formatted with `black`.** No configuration overrides.
 - **All public functions must have docstrings.**
-- **Deterministic exit codes 0–7:** 0=success, 1=general error, 2=invalid args, 3=missing dependency, 4=network error, 5=build failure, 6=test failure, 7=degraded setup.
+- **Deterministic exit codes 0–6:** 0=success, 1=general error, 2=invalid args, 3=missing dependency, 4=network error, 5=build failure, 6=test failure.
 - **`--json` mode** for all output — errors emit structured JSON with `level`, `code`, `message`, and optional `hint`.
 - **Confinement:** `nanvix_zutil` creates no files outside `.nanvix/` in consumer repos.
 - **Default branch is `dev`**, not `main`.

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ SDK manifests pin a verified GitHub Release contract and immutable OCI digest.
 exact tag/contract with `--to`), verifies its image, strictly resolves exact
 dependency releases, and atomically writes `nanvix.toml` plus the
 provenance-bearing `nanvix.lock`. Missing dependency provenance emits a blocked
-JSON result and writes nothing. Transitional Python image markers are updated
-when present; redundant reusable-workflow `docker-image` inputs are removed.
+JSON result and writes nothing. It updates canonical SDK revisions only;
+unrelated scripts and workflows are not migration targets.
 
 Canonical `.nanvix/nanvix.lock` files are committed. Only update transaction
 state (`.nanvix-zutil-update.lock` and its journal/sidecars) is ignored.

--- a/docs/design.md
+++ b/docs/design.md
@@ -134,10 +134,10 @@ Bootstraps the nanvix_zutil environment by installing a python venv.
 Sets up the build environment. By default, this will download the correct nanvix distribution (sourced from `nanvix.toml`) and build dependencies to `sysroot` and `buildroot`. The particular nanvix distribution parameters (target, machine, deployment mode, and memory size) can be overridden by supplying environment variables (listed below). The settings created here are stored at `.nanvix/env.json`.
 
 1. Download and verify nanvix artefacts (or source locally if `--with-nanvix`)
-2. Resolve and download dependencies against latest release matching the nanvix version.
+2. Strictly resolve and download exact SDK-revision dependency releases.
 3. Persist configuration for `.nanvix/env.json`.
 
-SDK manifests use strict resolution instead: zutils verifies the authoritative
+All manifests use strict SDK resolution: zutils verifies the authoritative
 `sdk-release.json` GitHub Release asset against the immutable Docker digest,
 embedded `/opt/nanvix/nanvix-sdk.json`, and OCI labels. Dependency coordinates
 are exact `<version>-nanvix-<runtime>-sdk.<revision>` tags. Missing exact
@@ -195,7 +195,6 @@ In addition to flags, which modify behaviors, certain operational values can be 
 | 4    | `EXIT_NETWORK_ERROR`  | Network operation failed           |
 | 5    | `EXIT_BUILD_FAILURE`  | Build step failed                  |
 | 6    | `EXIT_TEST_FAILURE`   | Tests failed                       |
-| 7    | `EXIT_DEGRADED_SETUP` | Setup completed with fallback deps |
 
 ### Container Paths
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -26,15 +26,14 @@ sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f
 |---|---|---|
 | `name` | yes | Package name (e.g. `"hello-world"`). |
 | `version` | yes | Package version string. |
-| `nanvix-version` | yes | Nanvix sysroot version — semver `X.Y.Z`, or `"latest"`. |
+| `nanvix-version` | yes | Nanvix runtime version — semver `X.Y.Z`. |
 
-`nanvix-version` is validated at parse time.  Tables and non-semver
-strings are rejected, with the exception of the literal `"latest"`,
-which resolves to the newest available sysroot release.
+`nanvix-version` is validated at parse time. Tables, non-semver strings, and
+`"latest"` are rejected because the value must match the immutable SDK runtime.
 
 ## `[toolchain]`
 
-The preferred SDK mode pins the release version, provider, and immutable image
+Every manifest must pin the SDK release version, provider, and immutable image
 as one typed coordinate:
 
 ```toml
@@ -46,11 +45,11 @@ sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
 sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 ```
 
-The SDK version's runtime must equal `package.nanvix-version`. Optional
+All five fields shown above are required, and alternate spellings, nested SDK
+tables, legacy kinds, embedded image digests, and omitted toolchain tables are
+rejected. The SDK version's runtime must equal `package.nanvix-version`. Optional
 `build-image` and `build-digest` fields select a different immutable image for
-builds; otherwise the SDK image is the effective build image. The early
-`type/version/image/digest` spelling remains readable for one transition
-release. Omitting `[toolchain]` selects legacy resolution.
+builds; otherwise the SDK image is the effective build image.
 
 ## `[dependencies]` and `[system-dependencies]`
 
@@ -61,38 +60,35 @@ name (e.g. `zlib`); the repo is inferred as `nanvix/<name>`.
 
 | Syntax | RefKind | Suffixed? | Resolution |
 |---|---|---|---|
-| `dep = "1.2.3"` | `VERSION` | yes | Tag `1.2.3-nanvix-{nv}` |
-| `dep = { version = "1.2.3" }` | `VERSION` | yes | Tag `1.2.3-nanvix-{nv}` |
-| `dep = { tag = "v1.0" }` | `TAG` | no | Tag `v1.0` (exact) |
-| `dep = { commitish = "abc1234" }` | `COMMITISH` | no | Search `target_commitish` |
-| `dep = { id = 12345678 }` | `ID` | no | `GET /releases/12345678` |
-| *(env override is a path)* | `LOCAL` | no | Filesystem path — no GitHub resolution |
+| `dep = "1.2.3"` | `VERSION` | yes | Tag `1.2.3-nanvix-{runtime}-sdk.N` |
+| `dep = { version = "1.2.3" }` | `VERSION` | yes | Tag `1.2.3-nanvix-{runtime}-sdk.N` |
 
-Only **one** specifier key is allowed per table.
+These are the only accepted manifest forms. `tag`, `commitish`, `id`, and local
+path dependency refs are rejected. Operational offline/local artifact overrides
+remain available through the setup CLI.
 
 ### Auto-suffix
 
 `VERSION` refs (plain string or `{ version = "..." }`) are automatically
-suffixed with `-nanvix-{nanvix-version}`.  For example, with
-`nanvix-version = "0.12.257"`:
+suffixed with the exact SDK release coordinate. For example, with
+`sdk-version = "v0.20.0-sdk.2"`:
 
 ```toml
 zlib = "1.2.3"
-# → resolves tag "1.2.3-nanvix-0.12.257"
+# → resolves tag "1.2.3-nanvix-0.20.0-sdk.2"
 ```
 
-Legacy mode retains its existing fallback behavior. SDK mode derives the exact
-tag `1.2.3-nanvix-0.20.0-sdk.1`; it never falls back. A missing release yields
-a machine-readable blocked result.
+Resolution derives the exact SDK-aware tag; it never falls
+back. A missing release yields a machine-readable blocked result.
 
 The generated `.nanvix/nanvix.lock` is canonical provenance and must be
-committed. Update lock/journal files are transient and remain ignored.
+committed. Its complete `[metadata.sdk]` table is mandatory; pre-SDK locks are
+rejected. Update lock/journal files are transient and remain ignored.
 
 ## CI resolver output
 
-`nanvix-zutil resolve` emits stable `key=value` lines. Legacy manifests retain
-the existing `nanvix_*` and `package_*` output exactly. SDK locks additionally
-emit:
+`nanvix-zutil resolve` emits stable `key=value` lines from strict SDK
+resolution. Alongside `nanvix_*` and `package_*`, it emits:
 
 ```text
 sdk_version
@@ -109,9 +105,6 @@ sdk_sysroot_sha256
 
 These values come from verified lockfile provenance and are suitable for
 appending directly to `$GITHUB_OUTPUT`.
-
-`TAG`, `COMMITISH`, `ID`, and `LOCAL` refs are never suffixed — they
-resolve exactly as written.
 
 Refs that already contain `-nanvix-` are rejected to prevent accidental
 double-suffixing.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,4 +171,3 @@ tar-copy strategy is used instead of bind mounts.
 | 4 | Network error | GitHub API unreachable or rate-limited |
 | 5 | Build failure | Compiler error in consumer code |
 | 6 | Test failure | Tests did not pass |
-| 7 | Degraded setup | Version fallback was used |

--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -11,10 +11,8 @@ etc.) without publishing a release.
 2. Files from `PATH/bin/` and `PATH/lib/` are copied on top of the
    downloaded sysroot, replacing matching artifacts.
 3. Sysroot verification runs against the overlaid result.
-4. If `PATH/deps/<name>/` directories exist for any ported dependency
-   (repos under the `nanvix/` organisation, such as `nanvix/zlib` or
-   `nanvix/cpython`), those are installed from local files instead of
-   downloading from GitHub.
+4. Published dependencies are still resolved against the exact SDK revision.
+   Local dependency directories are consumed only with `--offline`.
 
 ## Offline Mode
 
@@ -25,8 +23,8 @@ all artifacts to be available locally via `--with-nanvix`.  In offline mode:
   is not provided.
 - **All** dependencies (not just `nanvix/`-owned) are resolved from
   `PATH/deps/<name>/`.
-- Missing individual dependencies produce a warning rather than a fatal
-  error, allowing the port's own build logic to handle fallbacks.
+- Missing individual local dependencies produce a warning rather than a fatal
+  error so local development can provide them by other means.
 - A local sysroot must be provided via `--sysroot-path`.
 
 ## Sysroot Path Override
@@ -48,9 +46,6 @@ precedence over version-based resolution.
   │   ├── mkramfs.elf          # all modes
   │   ├── linuxd.elf           # multi-process only
   │   └── uservm.elf           # multi-process only
-  └── lib/
-      ├── libposix.a           # all modes
-      └── user.ld              # all modes
   ```
 
   `standalone` (default) and `single-process` require the same set.
@@ -71,8 +66,6 @@ cd /path/to/consumer   # e.g. usr/lib/zlib
 # Clean sysroot and re-run with local override
 rm -rf .nanvix/sysroot .nanvix/env.json
 .nanvix/venv/bin/nanvix-zutil setup \
-    --with-docker nanvix/toolchain:latest-minimal \
-    --allow-local-docker-override \
     --with-nanvix ~/src/nanvix/nanvix
 
 # Verify
@@ -109,9 +102,7 @@ The `z.sh` and `z.ps1` wrappers forward `--with-nanvix` directly to
 `nanvix-zutil`. Pass the flag to any subcommand that accepts it:
 
 ```bash
-./z setup --with-docker nanvix/toolchain:latest-minimal \
-    --allow-local-docker-override \
-    --with-nanvix ~/src/nanvix/nanvix
+./z setup --with-nanvix ~/src/nanvix/nanvix
 ./z build
 ```
 

--- a/examples/bin-hello/.nanvix/nanvix.toml
+++ b/examples/bin-hello/.nanvix/nanvix.toml
@@ -11,6 +11,6 @@ sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
 sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 
 [dependencies]
-lib-hello = { commitish = "HEAD" }
+lib-hello = "0.1.0"
 
 [system-dependencies]

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -11,7 +11,7 @@ Public re-exports:
 - :class:`~nanvix_zutil.buildroot.Dependency` — library dependency descriptor
 - :class:`~nanvix_zutil.sysroot.Sysroot` — runtime sysroot management
 - :class:`~nanvix_zutil.manifest.Manifest` — parsed TOML manifest
-- :class:`~nanvix_zutil.manifest.Toolchain` — typed legacy/SDK selection
+- :class:`~nanvix_zutil.manifest.Toolchain` — immutable SDK selection
 - :class:`~nanvix_zutil.manifest.SdkPin` — immutable manifest SDK coordinate
 - :class:`~nanvix_zutil.sdk.SdkRelease` — verified SDK release contract
 - :class:`~nanvix_zutil.sdk.SdkProvenance` — lockfile SDK provenance
@@ -29,7 +29,6 @@ Public re-exports:
 - :class:`~nanvix_zutil.commands.info.NanvixInfo` — resolved Nanvix release information
 - :func:`~nanvix_zutil.commands.info.get_nanvix_info` — query Nanvix release info
 - :func:`~nanvix_zutil.github.resolve_release` — resolve a release by version specifier
-- :func:`~nanvix_zutil.github.resolve_release_with_fallback` — resolve a release with fallback to best available
 - :func:`~nanvix_zutil.buildroot.suffix_dep` — suffix a dep's VERSION ref with a nanvix version
 - :func:`~nanvix_zutil.buildroot.extract_nanvix_version` — extract nanvix version from a suffixed tag
 - :func:`~nanvix_zutil.buildroot.extract_nanvix_version_base` — extract base version from a suffixed tag
@@ -77,7 +76,6 @@ from nanvix_zutil.docker import (
 )
 from nanvix_zutil.exitcodes import (
     EXIT_BUILD_FAILURE,
-    EXIT_DEGRADED_SETUP,
     EXIT_GENERAL_ERROR,
     EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
@@ -85,11 +83,7 @@ from nanvix_zutil.exitcodes import (
     EXIT_SUCCESS,
     EXIT_TEST_FAILURE,
 )
-from nanvix_zutil.github import (
-    resolve_commit,
-    resolve_release,
-    resolve_release_with_fallback,
-)
+from nanvix_zutil.github import resolve_commit, resolve_release
 from nanvix_zutil.helpers import (
     InitRdArgs,
     ensure_tool_installed,
@@ -121,7 +115,6 @@ from nanvix_zutil.sdk import (
     SdkProvenance,
     SdkRelease,
     SdkValidationError,
-    consumer_release_tag,
     parse_sdk_version,
     resolve_sdk_release,
     sdk_consumer_release_tag,
@@ -149,7 +142,6 @@ __all__ = [
     "Dependency",
     "DockerConfig",
     "EXIT_BUILD_FAILURE",
-    "EXIT_DEGRADED_SETUP",
     "EXIT_GENERAL_ERROR",
     "EXIT_INVALID_ARGS",
     "EXIT_MISSING_DEP",
@@ -182,7 +174,6 @@ __all__ = [
     "ensure_tool_installed",
     "extract_nanvix_version",
     "extract_nanvix_version_base",
-    "consumer_release_tag",
     "get_nanvix_info",
     "is_stale",
     "load_manifest",
@@ -194,7 +185,6 @@ __all__ = [
     "resolve",
     "resolve_commit",
     "resolve_release",
-    "resolve_release_with_fallback",
     "resolve_sdk_release",
     "run",
     "suffix_dep",

--- a/src/nanvix_zutil/commands/resolve.py
+++ b/src/nanvix_zutil/commands/resolve.py
@@ -12,7 +12,7 @@ import sys
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP, EXIT_SUCCESS
-from nanvix_zutil.manifest import ToolchainKind, load_manifest
+from nanvix_zutil.manifest import load_manifest
 from nanvix_zutil.paths import manifest_path
 from nanvix_zutil.resolver import BlockedResolution, resolve
 
@@ -68,7 +68,6 @@ def main() -> None:
         manifest,
         gh_token=gh_token,
         shallow=args.shallow,
-        strict=manifest.toolchain.kind == ToolchainKind.SDK,
     )
     if isinstance(lockfile, BlockedResolution):
         print(json.dumps(lockfile.to_dict(), sort_keys=True))
@@ -93,21 +92,20 @@ def main() -> None:
         "package_version": manifest.version,
     }
     sdk = lockfile.metadata.sdk
-    if sdk is not None:
-        result.update(
-            {
-                "sdk_version": sdk.sdk_version,
-                "sdk_provider_id": sdk.provider_id,
-                "sdk_provider": sdk.provider,
-                "sdk_image": sdk.image.name,
-                "sdk_digest": sdk.image.digest,
-                "sdk_image_ref": sdk.image.ref,
-                "sdk_c_abi": str(sdk.compat["c_abi"]),
-                "sdk_libc_tag": sdk.nanvix_tag,
-                "sdk_libc_commit": sdk.nanvix_commit,
-                "sdk_sysroot_sha256": sdk.sysroot_sha256,
-            }
-        )
+    result.update(
+        {
+            "sdk_version": sdk.sdk_version,
+            "sdk_provider_id": sdk.provider_id,
+            "sdk_provider": sdk.provider,
+            "sdk_image": sdk.image.name,
+            "sdk_digest": sdk.image.digest,
+            "sdk_image_ref": sdk.image.ref,
+            "sdk_c_abi": str(sdk.compat["c_abi"]),
+            "sdk_libc_tag": sdk.nanvix_tag,
+            "sdk_libc_commit": sdk.nanvix_commit,
+            "sdk_sysroot_sha256": sdk.sysroot_sha256,
+        }
+    )
 
     for key, value in result.items():
         print(f"{key}={value}")

--- a/src/nanvix_zutil/commands/update_nanvix.py
+++ b/src/nanvix_zutil/commands/update_nanvix.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import argparse
-import ast
 import json
 import os
 import re
@@ -52,13 +51,6 @@ _VERSION_LINE = re.compile(
     r'^(?P<prefix>\s*nanvix-version\s*=\s*")[^"]*(?P<suffix>".*)$',
     re.MULTILINE,
 )
-_SDK_ASSIGNMENT = re.compile(
-    r'^(?P<prefix>\s*NANVIX_SDK_IMAGE\s*(?::\s*str\s*)?=\s*")[^"]*(?P<suffix>".*)$',
-    re.MULTILINE,
-)
-_DOCKER_IMAGE_KEY = re.compile(
-    r"^(?P<indent>[ \t]*)docker-image[ \t]*:[ \t]*(?P<value>.*)$",
-)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -83,25 +75,14 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _paths(root: Path) -> tuple[list[Path], list[Path], list[Path]]:
-    """Return exact manifest and optional transitional-marker paths."""
+def _paths(root: Path) -> list[Path]:
+    """Return the canonical consumer manifest paths."""
     if is_zutils_source(root):
-        return (
-            [
-                Path("examples/bin-hello/.nanvix/nanvix.toml"),
-                Path("examples/lib-hello/.nanvix/nanvix.toml"),
-            ],
-            [
-                Path("examples/bin-hello/.nanvix/z.py"),
-                Path("examples/lib-hello/.nanvix/z.py"),
-            ],
-            [Path("templates/nanvix-ci.yml")],
-        )
-    return (
-        [Path(".nanvix/nanvix.toml")],
-        [Path(".nanvix/z.py")],
-        [Path(".github/workflows/nanvix-ci.yml")],
-    )
+        return [
+            Path("examples/bin-hello/.nanvix/nanvix.toml"),
+            Path("examples/lib-hello/.nanvix/nanvix.toml"),
+        ]
+    return [Path(".nanvix/nanvix.toml")]
 
 
 def _replace_exact(
@@ -123,51 +104,12 @@ def _replace_exact(
     )
 
 
-def _remove_docker_image_inputs(text: str) -> str | None:
-    """Remove inline or block-scalar caller image inputs from workflow YAML."""
-    lines = text.splitlines(keepends=True)
-    rendered: list[str] = []
-    removed = False
-    index = 0
-    while index < len(lines):
-        line = lines[index]
-        match = _DOCKER_IMAGE_KEY.match(line.rstrip("\r\n"))
-        if match is None:
-            rendered.append(line)
-            index += 1
-            continue
-
-        marker = match.group("value").split("#", maxsplit=1)[0].strip()
-        if not marker:
-            rendered.append(line)
-            index += 1
-            continue
-
-        removed = True
-        base_indent = len(match.group("indent").expandtabs(8))
-        index += 1
-        if marker.startswith((">", "|")):
-            while index < len(lines):
-                candidate = lines[index].rstrip("\r\n")
-                if not candidate.strip():
-                    rendered.append(lines[index])
-                    index += 1
-                    continue
-                prefix_length = len(candidate) - len(candidate.lstrip(" \t"))
-                indent = len(candidate[:prefix_length].expandtabs(8))
-                if indent <= base_indent:
-                    break
-                index += 1
-
-    return "".join(rendered) if removed else None
-
-
 def _canonical_toolchain_block(
     text: str,
     sdk: SdkRelease,
-    existing_pin: SdkPin | None = None,
+    existing_pin: SdkPin,
 ) -> str:
-    """Replace or append the canonical ``[toolchain]`` SDK table."""
+    """Replace the canonical ``[toolchain]`` SDK table."""
     newline = "\r\n" if "\r\n" in text else "\n"
     lines = text.splitlines(keepends=True)
     header = re.compile(r"^\s*\[([^\]]+)\]\s*(?:#.*)?(?:\r?\n)?$")
@@ -193,18 +135,13 @@ def _canonical_toolchain_block(
         f'sdk-image = "{sdk.image.name}"{newline}'
         f'sdk-digest = "{sdk.image.digest}"{newline}'
     )
-    if (
-        existing_pin is not None
-        and existing_pin.build_image is not None
-        and existing_pin.build_digest is not None
-    ):
+    if existing_pin.build_image is not None and existing_pin.build_digest is not None:
         block += (
             f'build-image = "{existing_pin.build_image}"{newline}'
             f'build-digest = "{existing_pin.build_digest}"{newline}'
         )
     if start is None:
-        separator = "" if text.endswith(("\n", "\r")) else newline
-        return f"{text}{separator}{newline}{block}"
+        raise UpdateError("nanvix.toml is missing its canonical [toolchain] table")
     if end < len(lines):
         block += newline
     lines[start:end] = [block]
@@ -214,7 +151,7 @@ def _canonical_toolchain_block(
 def _update_manifest(
     content: bytes,
     sdk: SdkRelease,
-    existing_pin: SdkPin | None = None,
+    existing_pin: SdkPin,
 ) -> bytes:
     """Create the complete canonical manifest candidate."""
     try:
@@ -232,7 +169,7 @@ def _update_manifest(
 
 def _sdk_pin(
     sdk: SdkRelease,
-    existing_pin: SdkPin | None = None,
+    existing_pin: SdkPin,
 ) -> SdkPin:
     """Build the typed manifest pin for a verified release."""
     return SdkPin(
@@ -240,8 +177,8 @@ def _sdk_pin(
         provider_id=sdk.provider_id,
         image=sdk.image.name,
         digest=sdk.image.digest,
-        build_image=existing_pin.build_image if existing_pin is not None else None,
-        build_digest=(existing_pin.build_digest if existing_pin is not None else None),
+        build_image=existing_pin.build_image,
+        build_digest=existing_pin.build_digest,
     )
 
 
@@ -281,7 +218,7 @@ def _candidate_manifest(
 def _validate_manifest_candidate(
     content: bytes,
     sdk: SdkRelease,
-    pin: SdkPin | None = None,
+    pin: SdkPin,
 ) -> None:
     """Validate the canonical manifest table before any target write."""
     try:
@@ -302,7 +239,7 @@ def _validate_manifest_candidate(
         "sdk-image": sdk.image.name,
         "sdk-digest": sdk.image.digest,
     }
-    if pin is not None and pin.build_image is not None and pin.build_digest is not None:
+    if pin.build_image is not None and pin.build_digest is not None:
         expected["build-image"] = pin.build_image
         expected["build-digest"] = pin.build_digest
     if data.get("toolchain") != expected:
@@ -314,9 +251,9 @@ def _tuple_from_manifest(manifest: Manifest) -> dict[str, object]:
     pin = manifest.toolchain.sdk
     return {
         "nanvix_version": str(manifest.sysroot_ref.value).removeprefix("v"),
-        "sdk_version": pin.version if pin is not None else None,
-        "sdk_image": pin.image_ref if pin is not None else None,
-        "build_image": pin.effective_build_ref if pin is not None else None,
+        "sdk_version": pin.version,
+        "sdk_image": pin.image_ref,
+        "build_image": pin.effective_build_ref,
     }
 
 
@@ -346,83 +283,6 @@ def _resolve_target(value: str | None, root: Path, gh_token: str | None) -> SdkR
     )
 
 
-def _optional_marker_candidates(
-    root: Path,
-    scripts: list[Path],
-    workflows: list[Path],
-    old_images: set[str],
-    new_image: str,
-) -> tuple[dict[Path, bytes], dict[Path, Callable[[bytes], None]]]:
-    """Update transitional image markers only where they already exist."""
-    candidates: dict[Path, bytes] = {}
-    validators: dict[Path, Callable[[bytes], None]] = {}
-    for relative in scripts:
-        path = root / relative
-        if not path.is_file():
-            continue
-        text = path.read_bytes().decode("utf-8")
-        try:
-            ast.parse(text, filename=relative.as_posix())
-        except SyntaxError as exc:
-            raise UpdateError(f"{relative}: invalid Python: {exc}") from exc
-        matches = list(_SDK_ASSIGNMENT.finditer(text))
-        if len(matches) > 1:
-            raise UpdateError(f"{relative}: multiple transitional SDK markers")
-        if not matches:
-            continue
-        current = matches[0].group(0)
-        prefix = len(matches[0].group("prefix"))
-        suffix = len(matches[0].group("suffix"))
-        current_image = current[prefix : len(current) - suffix]
-        if old_images and current_image not in old_images:
-            raise UpdateError(f"{relative}: SDK marker disagrees with the manifest")
-        candidate = _replace_exact(
-            _SDK_ASSIGNMENT,
-            text,
-            new_image,
-            relative.as_posix(),
-        ).encode("utf-8")
-        candidates[relative] = candidate
-
-        def validate_script(
-            value: bytes,
-            label: str = relative.as_posix(),
-            expected: str = new_image,
-        ) -> None:
-            rendered = value.decode("utf-8")
-            ast.parse(rendered, filename=label)
-            matches = list(_SDK_ASSIGNMENT.finditer(rendered))
-            if len(matches) != 1 or expected not in matches[0].group(0):
-                raise UpdateError(f"{label}: invalid transitional SDK marker")
-
-        validators[relative] = validate_script
-
-    for relative in workflows:
-        path = root / relative
-        if not path.is_file():
-            continue
-        text = path.read_bytes().decode("utf-8")
-        candidate_text = _remove_docker_image_inputs(text)
-        if candidate_text is None:
-            continue
-        candidate = candidate_text.encode("utf-8")
-        candidates[relative] = candidate
-
-        def validate_workflow(
-            value: bytes,
-            label: str = relative.as_posix(),
-        ) -> None:
-            rendered = value.decode("utf-8")
-            if any(
-                _DOCKER_IMAGE_KEY.match(line) is not None
-                for line in rendered.splitlines()
-            ):
-                raise UpdateError(f"{label}: redundant docker-image input remains")
-
-        validators[relative] = validate_workflow
-    return candidates, validators
-
-
 def _run_locked(
     args: argparse.Namespace,
     root: Path,
@@ -431,11 +291,10 @@ def _run_locked(
     """Resolve and apply an SDK update under a recovered transaction lock."""
     gh_token = os.environ.get("GH_TOKEN")
     sdk = _resolve_target(args.to, root, gh_token)
-    manifests, scripts, workflows = _paths(root)
+    manifests = _paths(root)
     candidates: dict[Path, bytes] = {}
     validators: dict[Path, Callable[[bytes], None]] = {}
     old_tuples: list[dict[str, object]] = []
-    old_images: set[str] = set()
     new_build_images: set[str] = set()
     new_tuple = _tuple_from_sdk(sdk)
 
@@ -445,8 +304,7 @@ def _run_locked(
         old_tuples.append(_tuple_from_manifest(current))
         current_pin = current.toolchain.sdk
         if (
-            current_pin is not None
-            and current_pin.build_image is not None
+            current_pin.build_image is not None
             and current_pin.version != sdk.sdk_version
         ):
             return (
@@ -465,8 +323,6 @@ def _run_locked(
                 ),
                 EXIT_MISSING_DEP,
             )
-        if current.toolchain.sdk is not None:
-            old_images.add(current.toolchain.sdk.effective_build_ref)
         manifest_bytes = _update_manifest(path.read_bytes(), sdk, current_pin)
         candidate_pin = _sdk_pin(sdk, current_pin)
         new_build_images.add(candidate_pin.effective_build_ref)
@@ -478,7 +334,6 @@ def _run_locked(
                 candidate_manifest,
                 gh_token=gh_token,
                 cache_dir=cache_dir,
-                strict=True,
                 verified_sdk_release=sdk,
                 manifest_content=manifest_bytes,
             )
@@ -533,16 +388,6 @@ def _run_locked(
         raise UpdateError("candidate manifests disagree on the effective build image")
     new_build_image = next(iter(new_build_images))
     new_tuple["build_image"] = new_build_image
-    marker_candidates, marker_validators = _optional_marker_candidates(
-        root,
-        scripts,
-        workflows,
-        old_images,
-        new_build_image,
-    )
-    candidates.update(marker_candidates)
-    validators.update(marker_validators)
-
     if args.dry_run or args.check:
         changed = tuple(
             sorted(

--- a/src/nanvix_zutil/exitcodes.py
+++ b/src/nanvix_zutil/exitcodes.py
@@ -28,6 +28,3 @@ EXIT_BUILD_FAILURE: int = 5
 
 EXIT_TEST_FAILURE: int = 6
 """One or more tests failed."""
-
-EXIT_DEGRADED_SETUP: int = 7
-"""Setup completed but one or more dependencies used fallback versions."""

--- a/src/nanvix_zutil/github.py
+++ b/src/nanvix_zutil/github.py
@@ -231,32 +231,6 @@ def _try_fetch_release_by_tag(
     return _fetch_release_by_url(repo, tag, url, headers, allow_404=True)
 
 
-def _find_best_release(
-    repo: str,
-    tag_prefix: str,
-    headers: dict[str, str],
-) -> dict[str, object] | None:
-    """Find the newest release whose tag starts with *tag_prefix*.
-
-    Scans releases in reverse-chronological order (GitHub API default)
-    and returns the first match. Because GitHub lists releases newest
-    first, the first match is the most recent.
-
-    Args:
-        repo: Repository in ``owner/name`` format.
-        tag_prefix: Tag prefix to match (e.g. ``"1.3.1-nanvix-"``).
-        headers: HTTP headers.
-
-    Returns:
-        The release metadata dictionary, or ``None`` if no match.
-    """
-    for release in _list_releases(repo, headers):
-        tag = release.get("tag_name")
-        if isinstance(tag, str) and tag.startswith(tag_prefix):
-            return release
-    return None
-
-
 def _list_releases(
     repo: str,
     headers: dict[str, str],
@@ -494,76 +468,6 @@ def resolve_commit(
     return sha
 
 
-def resolve_release_with_fallback(
-    repo: str,
-    version_specifier: str,
-    base_version: str,
-    gh_token: str | None = None,
-) -> tuple[dict[str, object], str | None]:
-    """Resolve a release, falling back to the best available on 404.
-
-    Tries to fetch the release by exact tag. If the tag does not exist
-    (HTTP 404), scans the repo's releases for the newest tag matching
-    ``{base_version}-nanvix-*``.
-
-    Args:
-        repo: Repository in ``owner/name`` format.
-        version_specifier: Exact tag to try first
-            (e.g. ``"1.3.1-nanvix-0.12.337"``).
-        base_version: The base package version without nanvix suffix
-            (e.g. ``"1.3.1"``). Used to construct the fallback prefix.
-        gh_token: Optional GitHub personal access token.
-
-    Returns:
-        A tuple of (release_dict, fallback_nanvix_version). The second
-        element is ``None`` when the exact tag was found, or the nanvix
-        version string from the fallback tag (e.g. ``"0.12.291"``) when
-        a fallback was used.
-
-    Raises:
-        SystemExit: If no matching release is found at all.
-    """
-    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
-    if gh_token:
-        headers["Authorization"] = f"Bearer {gh_token}"
-
-    # Try exact tag first.
-    result = _resolve_release(repo, version_specifier, headers, allow_missing=True)
-    if result is not None:
-        return result, None
-
-    # Fallback: scan for best available release matching the base version.
-    prefix = f"{base_version}-nanvix-"
-    best = _find_best_release(repo, prefix, headers)
-    if best is None:
-        log.fatal(
-            f"No release found for {repo}@{version_specifier} and no "
-            f"fallback release matching '{prefix}*' exists",
-            code=EXIT_MISSING_DEP,
-            hint=f"Ensure {repo} has at least one release tagged "
-            f"'{base_version}-nanvix-<version>'.",
-        )
-
-    tag = best.get("tag_name")
-    if not isinstance(tag, str):
-        log.fatal(
-            f"Fallback release for {repo} has no tag_name",
-            code=EXIT_NETWORK_ERROR,
-        )
-
-    from nanvix_zutil.buildroot import extract_nanvix_version
-
-    nanvix_ver = extract_nanvix_version(tag)
-    if nanvix_ver is None:
-        log.fatal(
-            f"Fallback release tag '{tag}' for {repo} does not contain "
-            f"a nanvix version suffix",
-            code=EXIT_NETWORK_ERROR,
-        )
-
-    return best, nanvix_ver
-
-
 @overload
 def download_release_asset(
     repo: str,
@@ -641,8 +545,8 @@ def download_release_asset(
     """
     dest.mkdir(parents=True, exist_ok=True)
 
-    # Preserve legacy flat-cache reuse when no exact pre-resolved release was
-    # supplied. Exact callers validate release/asset identity below.
+    # Reuse deterministic prefix-matched cache entries when no pre-resolved
+    # release was supplied. Exact callers validate release/asset identity below.
     if _release is None and match_prefix:
         # Collect all matching cached files and select deterministically to
         # avoid relying on filesystem iteration order.

--- a/src/nanvix_zutil/lockfile.py
+++ b/src/nanvix_zutil/lockfile.py
@@ -27,7 +27,11 @@ from nanvix_zutil.exitcodes import (
     EXIT_INVALID_ARGS,
     EXIT_MISSING_DEP,
 )
-from nanvix_zutil.sdk import SdkImage, SdkProvenance
+from nanvix_zutil.sdk import (
+    SdkProvenance,
+    SdkValidationError,
+    validate_sdk_release,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -98,14 +102,14 @@ class LockfileMetadata:
             (e.g. ``"sha256:a1b2c3d4..."``).
         nanvix_zutil_version: Version of ``nanvix-zutil`` that
             generated this lockfile.
-        sdk: Verified SDK provenance, or ``None`` for a legacy lock.
+        sdk: Verified SDK provenance.
         shallow: Whether transitive dependency discovery was intentionally
             omitted when this lock was generated.
     """
 
     manifest_hash: str
     nanvix_zutil_version: str
-    sdk: SdkProvenance | None = None
+    sdk: SdkProvenance
     shallow: bool = False
 
 
@@ -142,6 +146,42 @@ def get_zutil_version() -> str:
         return "unknown"
 
 
+def _validated_sdk_provenance(
+    sdk: SdkProvenance,
+    context: str,
+) -> SdkProvenance:
+    """Validate complete SDK provenance before it crosses a lockfile boundary."""
+    contract: dict[str, object] = {
+        "schema_version": sdk.schema_version,
+        "sdk_version": sdk.sdk_version,
+        "provider_id": sdk.provider_id,
+        "provider": sdk.provider,
+        "role": sdk.role,
+        "image": {
+            "name": sdk.image.name,
+            "digest": sdk.image.digest,
+            "ref": sdk.image.ref,
+        },
+        "target": sdk.target,
+        "toolchain": sdk.toolchain,
+        "libc": {
+            "nanvix_tag": sdk.nanvix_tag,
+            "nanvix_version": sdk.nanvix_version,
+            "nanvix_commit": sdk.nanvix_commit,
+            "sysroot_sha256": sdk.sysroot_sha256,
+        },
+        "compat": sdk.compat,
+        "features": sdk.features,
+    }
+    try:
+        return validate_sdk_release(contract).provenance()
+    except SdkValidationError as exc:
+        log.fatal(
+            f"{context}: invalid metadata.sdk: {exc}",
+            code=EXIT_INVALID_ARGS,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Write
 # ---------------------------------------------------------------------------
@@ -169,34 +209,36 @@ def serialize_lockfile(lockfile: Lockfile) -> bytes:
     if lockfile.metadata.shallow:
         meta_dict["shallow"] = True
     lines.append(tomli_w.dumps({"metadata": meta_dict}).rstrip())
-    if lockfile.metadata.sdk is not None:
-        sdk = lockfile.metadata.sdk
-        sdk_dict: dict[str, object] = {
-            "schema-version": sdk.schema_version,
-            "sdk-version": sdk.sdk_version,
-            "provider-id": sdk.provider_id,
-            "provider": sdk.provider,
-            "role": sdk.role,
-            "image-name": sdk.image.name,
-            "image-digest": sdk.image.digest,
-            "image-ref": sdk.image.ref,
-            "nanvix-tag": sdk.nanvix_tag,
-            "nanvix-version": sdk.nanvix_version,
-            "nanvix-commit": sdk.nanvix_commit,
-            "sysroot-sha256": sdk.sysroot_sha256,
-        }
+    sdk = _validated_sdk_provenance(
+        lockfile.metadata.sdk,
+        "Cannot serialize lockfile",
+    )
+    sdk_dict: dict[str, object] = {
+        "schema-version": sdk.schema_version,
+        "sdk-version": sdk.sdk_version,
+        "provider-id": sdk.provider_id,
+        "provider": sdk.provider,
+        "role": sdk.role,
+        "image-name": sdk.image.name,
+        "image-digest": sdk.image.digest,
+        "image-ref": sdk.image.ref,
+        "nanvix-tag": sdk.nanvix_tag,
+        "nanvix-version": sdk.nanvix_version,
+        "nanvix-commit": sdk.nanvix_commit,
+        "sysroot-sha256": sdk.sysroot_sha256,
+    }
+    lines.append("")
+    lines.append("[metadata.sdk]")
+    lines.append(tomli_w.dumps(sdk_dict).rstrip())
+    for name, values in (
+        ("target", sdk.target),
+        ("toolchain", sdk.toolchain),
+        ("compat", sdk.compat),
+        ("features", sdk.features),
+    ):
         lines.append("")
-        lines.append("[metadata.sdk]")
-        lines.append(tomli_w.dumps(sdk_dict).rstrip())
-        for name, values in (
-            ("target", sdk.target),
-            ("toolchain", sdk.toolchain),
-            ("compat", sdk.compat),
-            ("features", sdk.features),
-        ):
-            lines.append("")
-            lines.append(f"[metadata.sdk.{name}]")
-            lines.append(tomli_w.dumps(values).rstrip())
+        lines.append(f"[metadata.sdk.{name}]")
+        lines.append(tomli_w.dumps(values).rstrip())
     lines.append("")
 
     # [[package]] blocks
@@ -311,26 +353,18 @@ def read_lockfile(path: Path) -> Lockfile:
         )
 
     shallow_value = meta.get("shallow", False)
-    # Transitional writer 0.15.0 accidentally emitted shallow as a string;
-    # accept it when reading while all new writes use a TOML boolean.
-    if shallow_value == "true":
-        shallow_value = True
     if not isinstance(shallow_value, bool):
         log.fatal(
             f"Lockfile {path}: invalid metadata 'shallow'",
             code=EXIT_INVALID_ARGS,
         )
     raw_sdk = meta.get("sdk")
-    sdk = (
-        _parse_sdk_provenance(cast("dict[str, object]", raw_sdk), path)
-        if isinstance(raw_sdk, dict)
-        else None
-    )
-    if raw_sdk is not None and sdk is None:
+    if not isinstance(raw_sdk, dict):
         log.fatal(
-            f"Lockfile {path}: metadata.sdk must be a table",
+            f"Lockfile {path}: missing required [metadata.sdk] table",
             code=EXIT_INVALID_ARGS,
         )
+    sdk = _parse_sdk_provenance(cast("dict[str, object]", raw_sdk), path)
 
     metadata = LockfileMetadata(
         manifest_hash=manifest_hash,
@@ -365,64 +399,64 @@ def _parse_sdk_provenance(
     path: Path,
 ) -> SdkProvenance:
     """Parse verified SDK provenance from lockfile metadata."""
-
-    def text(key: str) -> str:
-        value = data.get(key)
-        if not isinstance(value, str) or not value:
-            log.fatal(
-                f"Lockfile {path}: metadata.sdk missing or invalid {key!r}",
-                code=EXIT_INVALID_ARGS,
-            )
-        return value
-
-    def object_table(key: str, *, required: bool = False) -> dict[str, object]:
-        value = data.get(key)
-        if value is None and not required:
-            return {}
-        if not isinstance(value, dict):
-            log.fatal(
-                f"Lockfile {path}: metadata.sdk {key!r} must be a table",
-                code=EXIT_INVALID_ARGS,
-            )
-        return dict(cast("dict[str, object]", value))
-
-    raw_compat = object_table("compat", required=True)
-    schema_version = data.get("schema-version", 1)
-    if (
-        not isinstance(schema_version, int)
-        or isinstance(schema_version, bool)
-        or schema_version != 1
-    ):
+    expected = {
+        "schema-version",
+        "sdk-version",
+        "provider-id",
+        "provider",
+        "role",
+        "image-name",
+        "image-digest",
+        "image-ref",
+        "nanvix-tag",
+        "nanvix-version",
+        "nanvix-commit",
+        "sysroot-sha256",
+        "target",
+        "toolchain",
+        "compat",
+        "features",
+    }
+    if set(data) != expected:
+        missing = sorted(expected - data.keys())
+        extra = sorted(data.keys() - expected)
+        details = [
+            *(f"missing {key}" for key in missing),
+            *(f"unexpected {key}" for key in extra),
+        ]
         log.fatal(
-            f"Lockfile {path}: unsupported metadata.sdk schema-version",
+            f"Lockfile {path}: metadata.sdk is incomplete:" f" {', '.join(details)}",
             code=EXIT_INVALID_ARGS,
         )
-    image = SdkImage(
-        name=text("image-name"),
-        digest=text("image-digest"),
-        ref=text("image-ref"),
-    )
-    if image.ref != f"{image.name}@{image.digest}":
+    contract: dict[str, object] = {
+        "schema_version": data["schema-version"],
+        "sdk_version": data["sdk-version"],
+        "provider_id": data["provider-id"],
+        "provider": data["provider"],
+        "role": data["role"],
+        "image": {
+            "name": data["image-name"],
+            "digest": data["image-digest"],
+            "ref": data["image-ref"],
+        },
+        "target": data["target"],
+        "toolchain": data["toolchain"],
+        "libc": {
+            "nanvix_tag": data["nanvix-tag"],
+            "nanvix_version": data["nanvix-version"],
+            "nanvix_commit": data["nanvix-commit"],
+            "sysroot_sha256": data["sysroot-sha256"],
+        },
+        "compat": data["compat"],
+        "features": data["features"],
+    }
+    try:
+        return validate_sdk_release(contract).provenance()
+    except SdkValidationError as exc:
         log.fatal(
-            f"Lockfile {path}: metadata.sdk image coordinate is inconsistent",
+            f"Lockfile {path}: invalid metadata.sdk: {exc}",
             code=EXIT_INVALID_ARGS,
         )
-    return SdkProvenance(
-        sdk_version=text("sdk-version"),
-        provider_id=text("provider-id"),
-        provider=text("provider"),
-        role=text("role"),
-        image=image,
-        nanvix_tag=text("nanvix-tag"),
-        nanvix_version=text("nanvix-version"),
-        nanvix_commit=text("nanvix-commit"),
-        sysroot_sha256=text("sysroot-sha256"),
-        compat=raw_compat,
-        schema_version=1,
-        target=object_table("target"),
-        toolchain=object_table("toolchain"),
-        features=object_table("features"),
-    )
 
 
 def _parse_package(data: dict[str, object], path: Path) -> ResolvedPackage:

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -4,18 +4,13 @@
 """TOML-based manifest parser for ``nanvix.toml``.
 
 Parses a structured TOML manifest that declares package metadata and
-dependencies.  ``nanvix-version`` must be a semver string (``X.Y.Z``)
-or the literal ``"latest"``.  Dependency version fields accept a plain
-string (``version`` specifier), or a table with one of ``version``,
-``tag``, ``commitish``, or ``id``.
+dependencies. ``nanvix-version`` must be a semver string (``X.Y.Z``).
+Dependency version fields accept a plain string or a ``{ version = "..." }``
+table.
 
-Only ``version`` specifier refs (plain string or ``{ version = "..." }``)
-are auto-suffixed with ``-nanvix-{sysroot_version}`` in legacy mode or
-``-nanvix-{runtime}-sdk.{revision}`` in SDK mode. ``tag``,
-``commitish``, and ``id`` specifiers are exact-match and never suffixed.
-Refs that already contain ``-nanvix-`` are rejected to prevent accidental
-duplication.  When the sysroot is ``"latest"``, auto-suffixing is
-deferred to the resolver (which resolves the actual version first).
+Dependency refs are auto-suffixed with
+``-nanvix-{runtime}-sdk.{revision}``. Refs that already contain ``-nanvix-``
+are rejected to prevent accidental duplication.
 """
 
 from __future__ import annotations
@@ -42,7 +37,6 @@ from nanvix_zutil.utils import SEMVER_RE
 class ToolchainKind(Enum):
     """Consumer toolchain selection mode."""
 
-    LEGACY = "legacy"
     SDK = "nanvix-sdk"
 
 
@@ -102,23 +96,18 @@ class SdkPin:
 
 @dataclass(frozen=True)
 class Toolchain:
-    """Typed manifest toolchain configuration."""
+    """Typed immutable SDK toolchain configuration."""
 
     kind: ToolchainKind
-    sdk: SdkPin | None = None
-
-    @classmethod
-    def legacy(cls) -> Toolchain:
-        """Return the transitional legacy toolchain selection."""
-        return cls(kind=ToolchainKind.LEGACY)
+    sdk: SdkPin
 
     @property
-    def effective_build_ref(self) -> str | None:
-        """Return the immutable build reference, if this is an SDK toolchain."""
-        return self.sdk.effective_build_ref if self.sdk is not None else None
+    def effective_build_ref(self) -> str:
+        """Return the immutable build reference."""
+        return self.sdk.effective_build_ref
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Manifest:
     """Parsed contents of a ``nanvix.toml`` manifest file.
 
@@ -128,23 +117,21 @@ class Manifest:
         sysroot_ref: Nanvix sysroot version reference.
         dependencies: Build-time dependencies as :class:`Dependency` objects.
         system_dependencies: Runtime dependencies as :class:`Dependency` objects.
-        toolchain: Typed legacy or immutable SDK toolchain selection.
+        toolchain: Immutable SDK toolchain selection.
     """
 
     name: str
     version: str
     sysroot_ref: Ref
+    toolchain: Toolchain
     dependencies: list[Dependency] = field(default_factory=lambda: [])
     system_dependencies: list[Dependency] = field(default_factory=lambda: [])
-    toolchain: Toolchain = field(default_factory=Toolchain.legacy)
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-# We are intentionally keeping the semver matching simple for now.
-_SPECIFIER_KEYS = frozenset({"version", "tag", "commitish", "id"})
 _URL_UNSAFE = set("/\\#?%")
 
 # Matches absolute Unix paths, Windows drive paths, and relative ./ or ../ paths.
@@ -210,7 +197,7 @@ def _validate_version_string(raw: str, context: str) -> str:
 
 
 def _parse_nanvix_version(raw: object) -> Ref:
-    """Parse ``nanvix-version``: semver ``X.Y.Z`` or ``"latest"``.
+    """Parse ``nanvix-version`` as semver ``X.Y.Z``.
 
     Args:
         raw: The raw TOML value for ``nanvix-version``.
@@ -223,18 +210,14 @@ def _parse_nanvix_version(raw: object) -> Ref:
             f"{manifest_path()}: 'nanvix-version' must be a plain string"
             f" (got {type(raw).__name__})",
             code=EXIT_INVALID_ARGS,
-            hint="Use 'nanvix-version = \"X.Y.Z\"' (semver) or"
-            " 'nanvix-version = \"latest\"'.",
+            hint="Use 'nanvix-version = \"X.Y.Z\"' (semver).",
         )
-    if raw == "latest":
-        # "latest" is a supported first-class sysroot specifier; no warning needed.
-        return Ref(kind=RefKind.TAG, value="latest")
     if not SEMVER_RE.match(raw):
         log.fatal(
-            f"{manifest_path()}: 'nanvix-version' must be semver X.Y.Z or 'latest' (got '{raw}')",
+            f"{manifest_path()}: 'nanvix-version' must be semver X.Y.Z"
+            f" (got '{raw}')",
             code=EXIT_INVALID_ARGS,
-            hint="Use a version like 'nanvix-version = \"0.12.257\"'"
-            " or 'nanvix-version = \"latest\"'.",
+            hint="Use a version like 'nanvix-version = \"0.20.0\"'.",
         )
     return Ref(kind=RefKind.TAG, value=raw)
 
@@ -246,12 +229,9 @@ def _parse_version_field(raw: object, context: str) -> Ref:
 
     - String → ``Ref(VERSION, value)`` — triggers auto-suffix
     - ``{ version = "..." }`` → ``Ref(VERSION, value)`` — triggers suffix
-    - ``{ tag = "..." }`` → ``Ref(TAG, value)`` — exact match
-    - ``{ commitish = "..." }`` → ``Ref(COMMITISH, value)`` — exact match
-    - ``{ id = N }`` → ``Ref(ID, N)`` — direct release fetch
 
     Returns:
-        A :class:`Ref` with the appropriate :class:`RefKind`.
+        A :class:`Ref` with :attr:`RefKind.VERSION`.
     """
     if isinstance(raw, str):
         value = _validate_version_string(raw, context)
@@ -259,64 +239,22 @@ def _parse_version_field(raw: object, context: str) -> Ref:
 
     if isinstance(raw, dict):
         raw_dict = cast("dict[str, object]", raw)
-
-        found = _SPECIFIER_KEYS & raw_dict.keys()
-        if len(found) > 1:
+        if set(raw_dict) != {"version"}:
             log.fatal(
-                f"{manifest_path()}: table for '{context}' has conflicting keys:"
-                f" {', '.join(sorted(found))}",
+                f"{manifest_path()}: table for '{context}' must contain"
+                " exactly the 'version' key",
                 code=EXIT_INVALID_ARGS,
-                hint="Use exactly one of 'version', 'tag', 'commitish', or 'id'.",
+                hint=f"Use '{context} = {{ version = \"1.2.3\" }}'.",
             )
 
-        if "version" in raw_dict:
-            ver_val: object = raw_dict["version"]
-            if not isinstance(ver_val, str):
-                log.fatal(
-                    f"{manifest_path()}: 'version' value for '{context}' must be a string",
-                    code=EXIT_INVALID_ARGS,
-                )
-            value = _validate_version_string(ver_val, f"{context}.version")
-            return Ref(kind=RefKind.VERSION, value=value)
-
-        if "tag" in raw_dict:
-            tag_val: object = raw_dict["tag"]
-            if not isinstance(tag_val, str):
-                log.fatal(
-                    f"{manifest_path()}: 'tag' value for '{context}' must be a string",
-                    code=EXIT_INVALID_ARGS,
-                )
-            value = _validate_version_string(tag_val, f"{context}.tag")
-            return Ref(kind=RefKind.TAG, value=value)
-
-        if "commitish" in raw_dict:
-            com_val: object = raw_dict["commitish"]
-            if not isinstance(com_val, str):
-                log.fatal(
-                    f"{manifest_path()}: 'commitish' value for '{context}' must be a string",
-                    code=EXIT_INVALID_ARGS,
-                )
-            value = _validate_version_string(com_val, f"{context}.commitish")
-            return Ref(kind=RefKind.COMMITISH, value=value)
-
-        if "id" in raw_dict:
-            id_val: object = raw_dict["id"]
-            if not isinstance(id_val, int):
-                log.fatal(
-                    f"{manifest_path()}: 'id' value for '{context}' must be an integer",
-                    code=EXIT_INVALID_ARGS,
-                )
-            return Ref(kind=RefKind.ID, value=id_val)
-
-        log.fatal(
-            f"{manifest_path()}: table for '{context}' must contain one of"
-            " 'version', 'tag', 'commitish', or 'id'",
-            code=EXIT_INVALID_ARGS,
-            hint=f"Use '{context} = {{ version = \"1.2.3\" }}',"
-            f" '{context} = {{ tag = \"...\" }}',"
-            f" '{context} = {{ commitish = \"...\" }}',"
-            f" or '{context} = {{ id = 12345 }}'.",
-        )
+        ver_val: object = raw_dict["version"]
+        if not isinstance(ver_val, str):
+            log.fatal(
+                f"{manifest_path()}: 'version' value for '{context}' must be a string",
+                code=EXIT_INVALID_ARGS,
+            )
+        value = _validate_version_string(ver_val, f"{context}.version")
+        return Ref(kind=RefKind.VERSION, value=value)
 
     log.fatal(
         f"{manifest_path()}: value for '{context}' must be a string or a table",
@@ -340,11 +278,7 @@ def _parse_dependencies(
 
         # Manifest values must not include the nanvix suffix — it is
         # derived automatically from nanvix-version.
-        if (
-            ref.kind == RefKind.VERSION
-            and isinstance(ref.value, str)
-            and "-nanvix-" in ref.value
-        ):
+        if isinstance(ref.value, str) and "-nanvix-" in ref.value:
             log.fatal(
                 f"{manifest_path()}: dependency '{name}' must not include the nanvix"
                 f" version in its ref (got '{ref.value}')",
@@ -359,108 +293,40 @@ def _parse_dependencies(
 
 
 def _parse_toolchain(raw: object, nanvix_version: str) -> Toolchain:
-    """Parse the optional typed ``[toolchain]`` table.
-
-    The canonical form uses ``kind = "nanvix-sdk"`` with ``sdk-*`` fields.
-    Early ``type/version/image`` and ``[toolchain.sdk]`` forms remain readable
-    for one transition release.
-    """
-    if raw is None:
-        return Toolchain.legacy()
+    """Parse the required canonical ``[toolchain]`` SDK table."""
     if not isinstance(raw, dict):
         log.fatal(
-            f"{manifest_path()}: [toolchain] must be a TOML table",
+            f"{manifest_path()}: missing or invalid required [toolchain] table",
             code=EXIT_INVALID_ARGS,
+            hint="Define kind, provider, sdk-version, sdk-image, and sdk-digest.",
         )
     table = cast("dict[str, object]", raw)
-    nested = table.get("sdk")
-    if nested is not None:
-        if not isinstance(nested, dict):
-            log.fatal(
-                f"{manifest_path()}: [toolchain.sdk] must be a TOML table",
-                code=EXIT_INVALID_ARGS,
-            )
-        values = cast("dict[str, object]", nested)
-        outer_keys = set(table) - {"type", "kind", "sdk"}
-        if outer_keys:
-            log.fatal(
-                f"{manifest_path()}: SDK pin fields must not be split between"
-                " [toolchain] and [toolchain.sdk]",
-                code=EXIT_INVALID_ARGS,
-            )
-    else:
-        values = {
-            key: value for key, value in table.items() if key not in {"type", "kind"}
-        }
-
-    if "type" in table and "kind" in table:
-        log.fatal(
-            f"{manifest_path()}: [toolchain] must not define both 'type' and 'kind'",
-            code=EXIT_INVALID_ARGS,
-        )
-    raw_kind = table.get("type", table.get("kind"))
-    if raw_kind is None:
-        kind = ToolchainKind.SDK if values else ToolchainKind.LEGACY
-    elif isinstance(raw_kind, str):
-        if raw_kind == "sdk":
-            raw_kind = ToolchainKind.SDK.value
-        try:
-            kind = ToolchainKind(raw_kind)
-        except ValueError:
-            log.fatal(
-                f"{manifest_path()}: unsupported toolchain type {raw_kind!r}",
-                code=EXIT_INVALID_ARGS,
-                hint="Use 'legacy' or 'nanvix-sdk'.",
-            )
-    else:
-        log.fatal(
-            f"{manifest_path()}: toolchain type must be a string",
-            code=EXIT_INVALID_ARGS,
-        )
-
-    if kind == ToolchainKind.LEGACY:
-        if values:
-            log.fatal(
-                f"{manifest_path()}: legacy [toolchain] must not contain SDK pin fields",
-                code=EXIT_INVALID_ARGS,
-            )
-        return Toolchain.legacy()
-
-    aliases = {
-        "version": "sdk-version",
-        "sdk_version": "sdk-version",
-        "provider": "provider_id",
-        "provider-id": "provider_id",
-        "provider_id": "provider_id",
-        "image": "sdk-image",
-        "digest": "sdk-digest",
-    }
-    normalized: dict[str, object] = {}
-    for key, value in values.items():
-        canonical = aliases.get(key, key)
-        if canonical in normalized:
-            log.fatal(
-                f"{manifest_path()}: duplicate SDK pin field {canonical!r}",
-                code=EXIT_INVALID_ARGS,
-            )
-        normalized[canonical] = value
     allowed = {
+        "kind",
+        "provider",
         "sdk-version",
-        "provider_id",
         "sdk-image",
         "sdk-digest",
         "build-image",
         "build-digest",
     }
-    unexpected = sorted(set(normalized) - allowed)
+    unexpected = sorted(set(table) - allowed)
     if unexpected:
         log.fatal(
-            f"{manifest_path()}: unexpected SDK pin fields: {', '.join(unexpected)}",
+            f"{manifest_path()}: unexpected [toolchain] fields:"
+            f" {', '.join(unexpected)}",
+            code=EXIT_INVALID_ARGS,
+            hint="Use only the canonical SDK field names.",
+        )
+    raw_kind = table.get("kind")
+    if raw_kind != ToolchainKind.SDK.value:
+        log.fatal(
+            f"{manifest_path()}: [toolchain] kind must be 'nanvix-sdk'",
             code=EXIT_INVALID_ARGS,
         )
 
     def required_string(key: str) -> str:
-        value = normalized.get(key)
+        value = table.get(key)
         if not isinstance(value, str) or not value:
             log.fatal(
                 f"{manifest_path()}: SDK toolchain requires non-empty {key!r}",
@@ -469,28 +335,23 @@ def _parse_toolchain(raw: object, nanvix_version: str) -> Toolchain:
         return value
 
     version = required_string("sdk-version")
-    provider_id = required_string("provider_id")
+    provider_id = required_string("provider")
     image = required_string("sdk-image")
-    digest_value = normalized.get("sdk-digest")
-    image_name, separator, embedded_digest = image.partition("@")
-    if separator:
-        if digest_value is not None and digest_value != embedded_digest:
-            log.fatal(
-                f"{manifest_path()}: SDK image digest and digest field disagree",
-                code=EXIT_INVALID_ARGS,
-            )
-        digest = embedded_digest
-    else:
-        digest = required_string("sdk-digest")
+    digest = required_string("sdk-digest")
+    if "@" in image:
+        log.fatal(
+            f"{manifest_path()}: canonical sdk-image must not include a digest",
+            code=EXIT_INVALID_ARGS,
+        )
     if _DIGEST_RE.fullmatch(digest) is None:
         log.fatal(
             f"{manifest_path()}: SDK digest must be sha256 followed by 64 lowercase hex digits",
             code=EXIT_INVALID_ARGS,
         )
     expected_image = f"ghcr.io/nanvix/nanvix-sdk-{provider_id}"
-    if image_name != expected_image:
+    if image != expected_image:
         log.fatal(
-            f"{manifest_path()}: SDK image {image_name!r} does not match"
+            f"{manifest_path()}: SDK image {image!r} does not match"
             f" provider {provider_id!r} (expected {expected_image!r})",
             code=EXIT_INVALID_ARGS,
         )
@@ -509,8 +370,8 @@ def _parse_toolchain(raw: object, nanvix_version: str) -> Toolchain:
             f"{manifest_path()}: unsupported SDK provider {provider_id!r}",
             code=EXIT_INVALID_ARGS,
         )
-    build_image_value = normalized.get("build-image")
-    build_digest_value = normalized.get("build-digest")
+    build_image_value = table.get("build-image")
+    build_digest_value = table.get("build-digest")
     if (build_image_value is None) != (build_digest_value is None):
         log.fatal(
             f"{manifest_path()}: build-image and build-digest must be specified together",
@@ -544,7 +405,7 @@ def _parse_toolchain(raw: object, nanvix_version: str) -> Toolchain:
         sdk=SdkPin(
             version=version,
             provider_id=provider_id,
-            image=image_name,
+            image=image,
             digest=digest,
             build_image=build_image,
             build_digest=build_digest,
@@ -561,9 +422,9 @@ def load_manifest(path: Path | None = None) -> Manifest:
     """Parse a ``nanvix.toml`` manifest file.
 
     Reads the TOML file, validates required keys, enforces semver for
-    ``nanvix-version``, parses dependency version fields (plain strings,
-    ``{ version }``, ``{ tag }``, ``{ commitish }``, ``{ id }``), and
-    auto-suffixes ``version`` refs with ``-nanvix-{sysroot_version}``.
+    ``nanvix-version``, requires a canonical immutable SDK toolchain, parses
+    dependency version fields (plain strings or ``{ version }``), and
+    auto-suffixes refs with the exact SDK release coordinate.
 
     Returns:
         A :class:`Manifest` instance.
@@ -651,17 +512,9 @@ def load_manifest(path: Path | None = None) -> Manifest:
         cast("dict[str, object]", sys_deps_raw), "system-dependencies"
     )
 
-    # Auto-suffix VERSION refs with the nanvix sysroot version.
-    # When the sysroot is "latest", suffixing is deferred to the resolver
-    # (which resolves the sysroot first and knows the actual version).
-    # Strip the leading "v" from the sysroot version to match the release
-    # tag format used by nanvix-zutil (e.g. "1.3.1-nanvix-0.12.291").
-    if sysroot_ref.value != "latest" and sysroot_ref.kind != RefKind.LOCAL:
-        version_suffix = (
-            toolchain.sdk.version.removeprefix("v")
-            if toolchain.kind == ToolchainKind.SDK and toolchain.sdk is not None
-            else sysroot_ref.value.removeprefix("v")
-        )
+    # Auto-suffix VERSION refs with the exact SDK revision.
+    if sysroot_ref.kind != RefKind.LOCAL:
+        version_suffix = toolchain.sdk.version.removeprefix("v")
         for dep in [*dependencies, *system_dependencies]:
             if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
                 if "-nanvix-" in dep.ref.value:

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -31,12 +31,11 @@ from typing import Literal, Sequence
 
 from nanvix_zutil import log
 from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR, EXIT_INVALID_ARGS
-from nanvix_zutil.sdk import consumer_release_tag, sdk_consumer_release_tag
+from nanvix_zutil.sdk import sdk_consumer_release_tag
 
 __all__ = [
     "ArchiveFormat",
     "DEFAULT_FORMATS",
-    "consumer_release_tag",
     "package",
     "sdk_consumer_release_tag",
 ]

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -16,20 +16,12 @@ import shutil
 import os
 from collections import deque
 from dataclasses import dataclass
-from dataclasses import replace as _dc_replace
 from pathlib import Path
-from typing import Literal, cast, overload
+from typing import cast
 
 from nanvix_zutil import github, log
-from nanvix_zutil.buildroot import (
-    Dependency,
-    Ref,
-    RefKind,
-    extract_nanvix_version_base,
-    parse_semver_tuple,
-    suffix_dep,
-)
-from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_NETWORK_ERROR
+from nanvix_zutil.buildroot import Dependency, RefKind
+from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS
 from nanvix_zutil.lockfile import (
     Lockfile,
     LockfileMetadata,
@@ -40,9 +32,9 @@ from nanvix_zutil.lockfile import (
     download_lockfile_asset,
     get_zutil_version,
 )
-from nanvix_zutil.manifest import Manifest, ToolchainKind, load_manifest
+from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.paths import manifest_path, nanvix_root
-from nanvix_zutil.sdk import SdkProvenance, SdkRelease, resolve_sdk_release
+from nanvix_zutil.sdk import SdkRelease, resolve_sdk_release
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -66,7 +58,7 @@ class _QueueItem:
 
 @dataclass(frozen=True)
 class BlockedResolution:
-    """Machine-readable strict-resolution failure."""
+    """Machine-readable exact SDK resolution failure."""
 
     status: str
     package: str
@@ -196,86 +188,17 @@ def _detect_cycles(packages: list[ResolvedPackage]) -> None:
             dfs(node)
 
 
-def _unsuffix_deps(deps: list[Dependency]) -> list[Dependency]:
-    """Return copies of *deps* with nanvix suffixes stripped from VERSION refs.
-
-    For deps whose ref kind is VERSION and whose value contains
-    ``-nanvix-``, strips the suffix so the dep can be re-suffixed with
-    a different version.
-    """
-    result: list[Dependency] = []
-    for dep in deps:
-        if (
-            dep.ref.kind == RefKind.VERSION
-            and isinstance(dep.ref.value, str)
-            and "-nanvix-" in dep.ref.value
-        ):
-            base = dep.ref.value.split("-nanvix-")[0]
-            result.append(
-                _dc_replace(
-                    dep,
-                    ref=Ref(kind=dep.ref.kind, value=base),
-                )
-            )
-        else:
-            result.append(dep)
-    return result
-
-
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 
-@overload
 def resolve(
     manifest: Manifest,
     gh_token: str | None = None,
     cache_dir: Path | None = None,
     *,
     shallow: bool = False,
-    strict: Literal[True],
-    verified_sdk_release: SdkRelease | None = None,
-    verify_sdk_image: bool = True,
-    manifest_content: bytes | None = None,
-) -> Lockfile | BlockedResolution: ...
-
-
-@overload
-def resolve(
-    manifest: Manifest,
-    gh_token: str | None = None,
-    cache_dir: Path | None = None,
-    *,
-    shallow: bool = False,
-    strict: Literal[False] = False,
-    verified_sdk_release: SdkRelease | None = None,
-    verify_sdk_image: bool = True,
-    manifest_content: bytes | None = None,
-) -> Lockfile: ...
-
-
-@overload
-def resolve(
-    manifest: Manifest,
-    gh_token: str | None = None,
-    cache_dir: Path | None = None,
-    *,
-    shallow: bool = False,
-    strict: bool,
-    verified_sdk_release: SdkRelease | None = None,
-    verify_sdk_image: bool = True,
-    manifest_content: bytes | None = None,
-) -> Lockfile | BlockedResolution: ...
-
-
-def resolve(
-    manifest: Manifest,
-    gh_token: str | None = None,
-    cache_dir: Path | None = None,
-    *,
-    shallow: bool = False,
-    strict: bool = False,
     verified_sdk_release: SdkRelease | None = None,
     verify_sdk_image: bool = True,
     manifest_content: bytes | None = None,
@@ -301,12 +224,10 @@ def resolve(
             confined per-process directory under ``.nanvix/cache``.
         shallow: When ``True``, skip transitive dependency discovery.
             Resolves only the sysroot and direct dependencies.
-        strict: Require exact SDK-aware coordinates and provenance-bearing
-            dependency locks.
         verified_sdk_release: Already verified SDK contract. Supplying this
             avoids redundant Docker verification.
         verify_sdk_image: Verify the selected SDK image when resolving the
-            contract. Enabled by default for strict resolution.
+            contract. Enabled by default.
         manifest_content: Candidate manifest bytes used to hash an atomic
             update before the target file is written.
 
@@ -317,12 +238,6 @@ def resolve(
         SystemExit: On cycle detection, version conflicts, or network
             errors.
     """
-    sdk_mode = manifest.toolchain.kind == ToolchainKind.SDK
-    if strict and not sdk_mode:
-        log.fatal(
-            "strict resolver mode requires an SDK [toolchain] pin",
-            code=EXIT_INVALID_ARGS,
-        )
     tmp_dir = (
         Path(cache_dir)
         if cache_dir
@@ -337,7 +252,6 @@ def resolve(
             gh_token,
             tmp_dir,
             shallow=shallow,
-            strict=strict,
             verified_sdk_release=verified_sdk_release,
             verify_sdk_image=verify_sdk_image,
             manifest_content=manifest_content,
@@ -353,7 +267,6 @@ def _resolve_inner(
     cache_dir: Path,
     *,
     shallow: bool,
-    strict: bool,
     verified_sdk_release: SdkRelease | None,
     verify_sdk_image: bool,
     manifest_content: bytes | None,
@@ -361,39 +274,34 @@ def _resolve_inner(
     """Inner resolver logic (separated for cleanup in ``resolve()``)."""
     resolved: dict[str, ResolvedPackage] = {}
     releases: dict[str, dict[str, object]] = {}
-    sdk_release: SdkRelease | None = None
-    sdk_provenance: SdkProvenance | None = None
 
     # 1. Resolve sysroot
-    sysroot_specifier = manifest.sysroot_ref.value
-    if strict:
-        sdk_pin = manifest.toolchain.sdk
-        assert sdk_pin is not None
-        sdk_release = verified_sdk_release or resolve_sdk_release(
-            sdk_pin.version,
-            provider_id=sdk_pin.provider_id,
-            gh_token=gh_token,
-            verify_image=verify_sdk_image,
+    sdk_pin = manifest.toolchain.sdk
+    sdk_release = verified_sdk_release or resolve_sdk_release(
+        sdk_pin.version,
+        provider_id=sdk_pin.provider_id,
+        gh_token=gh_token,
+        verify_image=verify_sdk_image,
+    )
+    if (
+        sdk_release.sdk_version != sdk_pin.version
+        or sdk_release.provider_id != sdk_pin.provider_id
+    ):
+        log.fatal(
+            "Trusted SDK release does not match the manifest coordinate",
+            code=EXIT_INVALID_ARGS,
         )
-        if (
-            sdk_release.sdk_version != sdk_pin.version
-            or sdk_release.provider_id != sdk_pin.provider_id
-        ):
-            log.fatal(
-                "Trusted SDK release does not match the manifest coordinate",
-                code=EXIT_INVALID_ARGS,
-            )
-        if (
-            sdk_release.image.name != sdk_pin.image_name
-            or sdk_release.image.digest != sdk_pin.digest
-            or sdk_release.image.ref != sdk_pin.image_ref
-        ):
-            log.fatal(
-                "Manifest SDK image pin does not match the verified SDK release",
-                code=EXIT_INVALID_ARGS,
-            )
-        sysroot_specifier = cast(str, sdk_release.libc["nanvix_tag"])
-        sdk_provenance = sdk_release.provenance()
+    if (
+        sdk_release.image.name != sdk_pin.image_name
+        or sdk_release.image.digest != sdk_pin.digest
+        or sdk_release.image.ref != sdk_pin.image_ref
+    ):
+        log.fatal(
+            "Manifest SDK image pin does not match the verified SDK release",
+            code=EXIT_INVALID_ARGS,
+        )
+    sysroot_specifier = cast(str, sdk_release.libc["nanvix_tag"])
+    sdk_provenance = sdk_release.provenance()
     try:
         sysroot_release = github.resolve_release(
             "nanvix/nanvix",
@@ -407,26 +315,25 @@ def _resolve_inner(
         )
         raise
     tag, commitish, rel_id = _extract_release_fields(sysroot_release)
-    if sdk_release is not None:
-        expected_tag = cast(str, sdk_release.libc["nanvix_tag"])
-        expected_commit = cast(str, sdk_release.libc["nanvix_commit"])
-        if tag != expected_tag:
-            log.fatal(
-                f"SDK runtime tag skew: expected {expected_tag}, resolved {tag}",
-                code=EXIT_INVALID_ARGS,
-            )
-        resolved_runtime_commit = github.resolve_commit(
-            "nanvix/nanvix",
-            expected_tag,
-            gh_token=gh_token,
+    expected_tag = cast(str, sdk_release.libc["nanvix_tag"])
+    expected_commit = cast(str, sdk_release.libc["nanvix_commit"])
+    if tag != expected_tag:
+        log.fatal(
+            f"SDK runtime tag skew: expected {expected_tag}, resolved {tag}",
+            code=EXIT_INVALID_ARGS,
         )
-        if resolved_runtime_commit != expected_commit:
-            log.fatal(
-                "SDK runtime commit does not match the Nanvix release",
-                code=EXIT_INVALID_ARGS,
-            )
-    # ref preserves the original specifier ("latest" or semver) — resolved_tag
-    # is the canonical pin used for deterministic artifact downloads.
+    resolved_runtime_commit = github.resolve_commit(
+        "nanvix/nanvix",
+        expected_tag,
+        gh_token=gh_token,
+    )
+    if resolved_runtime_commit != expected_commit:
+        log.fatal(
+            "SDK runtime commit does not match the Nanvix release",
+            code=EXIT_INVALID_ARGS,
+        )
+    # The ref preserves the runtime semver while resolved_tag is the canonical
+    # pin used for deterministic artifact downloads.
     sysroot_pkg = ResolvedPackage(
         name="nanvix",
         repo="nanvix/nanvix",
@@ -439,147 +346,22 @@ def _resolve_inner(
     resolved["nanvix"] = sysroot_pkg
     releases["nanvix"] = sysroot_release
 
-    # Deferred auto-suffix: when sysroot is "latest", load_manifest()
-    # skips suffixing because the real version isn't known yet.  Now
-    # that the sysroot is resolved, extract the version from its tag
-    # and apply the suffix to VERSION deps.  We build a shallow copy
-    # so the caller's Manifest is never mutated.
-    if manifest.sysroot_ref.value == "latest":
-        resolved_version = tag.removeprefix("v")
-        if not resolved_version:
-            log.fatal(
-                "Resolved sysroot release has no tag — cannot suffix VERSION deps.",
-                code=EXIT_NETWORK_ERROR,
-            )
-
-        original_deps = list(manifest.dependencies)
-        original_sys_deps = list(manifest.system_dependencies)
-
-        manifest = _dc_replace(
-            manifest,
-            dependencies=[
-                suffix_dep(d, resolved_version) for d in manifest.dependencies
-            ],
-            system_dependencies=[
-                suffix_dep(d, resolved_version) for d in manifest.system_dependencies
-            ],
-        )
-
-        # --- Fallback probe (only when sysroot is "latest") ---
-        # Probe each VERSION dep once.  Cache the release dict so the
-        # BFS can reuse it instead of making a second API call.
-        fallback_versions: list[str] = []
-        probe_cache: dict[str, dict[str, object]] = {}
-        all_probe_deps = list(manifest.dependencies) + list(
-            manifest.system_dependencies
-        )
-        for dep in all_probe_deps:
-            if dep.ref.kind != RefKind.VERSION or not isinstance(dep.ref.value, str):
-                continue
-            # dep.ref.value is already suffixed, e.g. "1.3.1-nanvix-0.12.337"
-            base_ver = extract_nanvix_version_base(dep.ref.value)
-            if base_ver is None:
-                continue
-            rel, fallback_ver = github.resolve_release_with_fallback(
-                dep.repo,
-                dep.ref.value,
-                base_ver,
-                gh_token=gh_token,
-            )
-            if fallback_ver is not None:
-                fallback_versions.append(fallback_ver)
-            else:
-                # Exact tag matched — cache for BFS reuse.
-                probe_cache[dep.name] = rel
-
-        if fallback_versions:
-            # Tags will change after re-suffix — cached releases are
-            # stale, so discard them.
-            probe_cache.clear()
-
-            min_ver = min(fallback_versions, key=parse_semver_tuple)
-            log.warning(
-                f"nanvix v{resolved_version} is latest but dependencies "
-                f"only available up to v{min_ver}; falling back to "
-                f"v{min_ver}"
-            )
-
-            # Re-resolve sysroot at the downgraded version.
-            try:
-                sysroot_release = github.resolve_release(
-                    "nanvix/nanvix",
-                    min_ver,
-                    gh_token=gh_token,
-                    semver=True,
-                )
-            except SystemExit:
-                log.note(f"while re-resolving sysroot at downgraded version v{min_ver}")
-                raise
-            tag, commitish, rel_id = _extract_release_fields(sysroot_release)
-            sysroot_pkg = ResolvedPackage(
-                name="nanvix",
-                repo="nanvix/nanvix",
-                kind="sysroot",
-                ref=manifest.sysroot_ref,
-                resolved_tag=tag,
-                resolved_commitish=commitish,
-                release_id=rel_id,
-            )
-            resolved["nanvix"] = sysroot_pkg
-            releases["nanvix"] = sysroot_release
-
-            # Re-suffix deps with downgraded version.
-            resolved_version = min_ver
-            manifest = _dc_replace(
-                manifest,
-                dependencies=[
-                    suffix_dep(d, resolved_version)
-                    for d in _unsuffix_deps(original_deps)
-                ],
-                system_dependencies=[
-                    suffix_dep(d, resolved_version)
-                    for d in _unsuffix_deps(original_sys_deps)
-                ],
-            )
-
-        # Pre-populate resolved/releases from the probe cache so the
-        # BFS skips these deps instead of re-fetching them.
-        all_deps_after = list(manifest.dependencies) + list(
-            manifest.system_dependencies
-        )
-        for dep in all_deps_after:
-            if dep.name in probe_cache:
-                rel = probe_cache[dep.name]
-                d_tag, d_commitish, d_rel_id = _extract_release_fields(rel)
-                resolved[dep.name] = ResolvedPackage(
-                    name=dep.name,
-                    repo=dep.repo,
-                    kind="dependency",
-                    ref=dep.ref,
-                    resolved_tag=d_tag,
-                    resolved_commitish=d_commitish,
-                    release_id=d_rel_id,
-                )
-                releases[dep.name] = rel
-
     # 2. Seed queue with direct deps
     queue: deque[_QueueItem] = deque()
     all_deps = list(manifest.dependencies) + list(manifest.system_dependencies)
-    if strict:
-        assert sdk_release is not None
-        for dep in all_deps:
-            if (
-                dep.ref.kind != RefKind.VERSION
-                or not isinstance(dep.ref.value, str)
-                or not dep.ref.value.endswith(
-                    f"-nanvix-{sdk_release.sdk_version.removeprefix('v')}"
-                )
-            ):
-                log.fatal(
-                    f"Strict SDK dependency '{dep.name}' must use a version"
-                    " specifier so its exact SDK-aware release tag is derived",
-                    code=EXIT_INVALID_ARGS,
-                )
+    for dep in all_deps:
+        if (
+            dep.ref.kind != RefKind.VERSION
+            or not isinstance(dep.ref.value, str)
+            or not dep.ref.value.endswith(
+                f"-nanvix-{sdk_release.sdk_version.removeprefix('v')}"
+            )
+        ):
+            log.fatal(
+                f"SDK dependency '{dep.name}' must use a version"
+                " specifier so its exact SDK-aware release tag is derived",
+                code=EXIT_INVALID_ARGS,
+            )
     for dep in all_deps:
         queue.append(_QueueItem(dep=dep))
 
@@ -587,19 +369,17 @@ def _resolve_inner(
     while queue:
         item = queue.popleft()
         dep = item.dep
-        if strict:
-            assert sdk_release is not None
-            expected_suffix = f"-nanvix-{sdk_release.sdk_version.removeprefix('v')}"
-            if (
-                dep.ref.kind != RefKind.VERSION
-                or not isinstance(dep.ref.value, str)
-                or not dep.ref.value.endswith(expected_suffix)
-            ):
-                log.fatal(
-                    f"Strict SDK dependency '{dep.name}' does not use exact"
-                    f" SDK-aware coordinate '*{expected_suffix}'",
-                    code=EXIT_INVALID_ARGS,
-                )
+        expected_suffix = f"-nanvix-{sdk_release.sdk_version.removeprefix('v')}"
+        if (
+            dep.ref.kind != RefKind.VERSION
+            or not isinstance(dep.ref.value, str)
+            or not dep.ref.value.endswith(expected_suffix)
+        ):
+            log.fatal(
+                f"SDK dependency '{dep.name}' does not use exact"
+                f" SDK-aware coordinate '*{expected_suffix}'",
+                code=EXIT_INVALID_ARGS,
+            )
 
         if dep.name in resolved:
             # Version conflict detection: same name, different release
@@ -630,8 +410,7 @@ def _resolve_inner(
             )
         except SystemExit as exc:
             requester = item.required_by or "manifest"
-            if strict and exc.code == 3:
-                assert sdk_release is not None
+            if exc.code == 3:
                 return BlockedResolution(
                     status="blocked",
                     package=dep.name,
@@ -662,73 +441,67 @@ def _resolve_inner(
         resolved[dep.name] = pkg
         releases[dep.name] = dep_release
 
-        # Strict SDK resolution always verifies the dependency's shallow lock
+        # SDK resolution always verifies the dependency's shallow lock
         # provenance, even when this resolver invocation is itself shallow.
-        if strict or not shallow:
-            inner_lock = download_lockfile_asset(
-                dep_release, cache_dir, gh_token=gh_token, dep_name=dep.name
+        inner_lock = download_lockfile_asset(
+            dep_release, cache_dir, gh_token=gh_token, dep_name=dep.name
+        )
+        if inner_lock is None:
+            return BlockedResolution(
+                status="blocked",
+                package=dep.name,
+                repo=dep.repo,
+                requested_tag=str(dep.ref.value),
+                sdk_version=sdk_release.sdk_version,
+                reason="provenance-lock-missing",
             )
-            if inner_lock is None and strict:
-                assert sdk_release is not None
-                return BlockedResolution(
-                    status="blocked",
-                    package=dep.name,
-                    repo=dep.repo,
-                    requested_tag=str(dep.ref.value),
-                    sdk_version=sdk_release.sdk_version,
-                    reason="provenance-lock-missing",
-                )
-            if inner_lock is not None:
-                if strict and inner_lock.metadata.sdk != sdk_provenance:
-                    log.fatal(
-                        f"Dependency '{dep.name}' lock provenance does not match"
-                        " the selected SDK",
-                        code=EXIT_INVALID_ARGS,
+        if inner_lock.metadata.sdk != sdk_provenance:
+            log.fatal(
+                f"Dependency '{dep.name}' lock provenance does not match"
+                " the selected SDK",
+                code=EXIT_INVALID_ARGS,
+            )
+        if shallow:
+            continue
+        for trans_pkg in inner_lock.packages:
+            if trans_pkg.kind == "sysroot":
+                continue
+            if trans_pkg.name not in resolved:
+                pkg.dependencies.append(trans_pkg.name)
+                queue.append(
+                    _QueueItem(
+                        dep=Dependency(
+                            name=trans_pkg.name,
+                            repo=trans_pkg.repo,
+                            ref=trans_pkg.ref,
+                        ),
+                        transitive=True,
+                        required_by=dep.name,
                     )
-                if shallow:
-                    continue
-                for trans_pkg in inner_lock.packages:
-                    if trans_pkg.kind == "sysroot":
-                        continue
-                    if trans_pkg.name not in resolved:
-                        pkg.dependencies.append(trans_pkg.name)
-                        queue.append(
-                            _QueueItem(
-                                dep=Dependency(
-                                    name=trans_pkg.name,
-                                    repo=trans_pkg.repo,
-                                    ref=trans_pkg.ref,
-                                ),
-                                transitive=True,
-                                required_by=dep.name,
-                            )
-                        )
-                    else:
-                        # Already resolved — check for version conflicts
-                        existing = resolved[trans_pkg.name]
-                        if (existing.ref.kind, existing.ref.value) != (
-                            trans_pkg.ref.kind,
-                            trans_pkg.ref.value,
-                        ):
-                            existing_requesters = (
-                                existing.required_by
-                                if existing.required_by
-                                else ["manifest"]
-                            )
-                            log.fatal(
-                                f"Version conflict for '{trans_pkg.name}': "
-                                f"{', '.join(existing_requesters)} require "
-                                f"'{existing.ref.value}' but "
-                                f"{dep.name} requires "
-                                f"'{trans_pkg.ref.value}'",
-                                code=EXIT_INVALID_ARGS,
-                                hint="Resolve the conflict by pinning "
-                                "a single version.",
-                            )
-                        # Track additional requester
-                        if dep.name not in existing.required_by:
-                            existing.required_by.append(dep.name)
-                        pkg.dependencies.append(trans_pkg.name)
+                )
+            else:
+                # Already resolved — check for version conflicts
+                existing = resolved[trans_pkg.name]
+                if (existing.ref.kind, existing.ref.value) != (
+                    trans_pkg.ref.kind,
+                    trans_pkg.ref.value,
+                ):
+                    existing_requesters = (
+                        existing.required_by if existing.required_by else ["manifest"]
+                    )
+                    log.fatal(
+                        f"Version conflict for '{trans_pkg.name}': "
+                        f"{', '.join(existing_requesters)} require "
+                        f"'{existing.ref.value}' but "
+                        f"{dep.name} requires "
+                        f"'{trans_pkg.ref.value}'",
+                        code=EXIT_INVALID_ARGS,
+                        hint="Resolve the conflict by pinning a single version.",
+                    )
+                # Track additional requester
+                if dep.name not in existing.required_by:
+                    existing.required_by.append(dep.name)
+                pkg.dependencies.append(trans_pkg.name)
 
     # 4. Detect cycles
     _detect_cycles(list(resolved.values()))
@@ -760,11 +533,6 @@ def is_stale(lockfile: Lockfile, *, shallow: bool | None = None) -> bool:
     Compares the ``manifest_hash`` stored in the lockfile metadata
     against the current hash of the manifest file.
 
-    Note: when ``nanvix-version = "latest"`` the manifest hash is
-    stable, so this function will always return ``False`` even if
-    upstream has published a new release.  Re-run ``./z lock``
-    explicitly to pick up new versions.
-
     Args:
         lockfile: The lockfile to check.
         shallow: Expected shallow-lock mode. When supplied, a lock generated
@@ -778,18 +546,9 @@ def is_stale(lockfile: Lockfile, *, shallow: bool | None = None) -> bool:
     current_hash = compute_manifest_hash(manifest_path())
     if lockfile.metadata.manifest_hash != current_hash:
         return True
-    if (
-        lockfile.metadata.sdk is None
-        and b"[toolchain]" not in manifest_path().read_bytes()
-    ):
-        return False
     manifest = load_manifest()
     sdk_pin = manifest.toolchain.sdk
     provenance = lockfile.metadata.sdk
-    if sdk_pin is None:
-        return provenance is not None
-    if provenance is None:
-        return True
     return (
         provenance.sdk_version != sdk_pin.version
         or provenance.provider_id != sdk_pin.provider_id

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -36,9 +36,6 @@ from nanvix_zutil.buildroot import (
     Buildroot,
     Dependency,
     RefKind,
-    extract_nanvix_version,
-    extract_nanvix_version_base,
-    suffix_dep,
 )
 from nanvix_zutil.cli import build_parser
 from nanvix_zutil.config import CFG_DOCKER_IMAGE, CFG_GH_TOKEN, CFG_SYSROOT, Config
@@ -50,18 +47,13 @@ from nanvix_zutil.docker import (
     Mount,
     is_windows,
 )
-from nanvix_zutil.exitcodes import (
-    EXIT_DEGRADED_SETUP,
-    EXIT_INVALID_ARGS,
-    EXIT_MISSING_DEP,
-)
-from nanvix_zutil.github import resolve_release, resolve_release_with_fallback
+from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_MISSING_DEP
 from nanvix_zutil.helpers import (
     check_docker,
     sync_configs,
 )
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
-from nanvix_zutil.manifest import Manifest, ToolchainKind, load_manifest
+from nanvix_zutil.manifest import Manifest, load_manifest
 from nanvix_zutil.paths import buildroot as _buildroot_dir
 from nanvix_zutil.paths import nanvix_root, out_dir, repo_root
 from nanvix_zutil.paths import sysroot as _sysroot_dir
@@ -101,22 +93,6 @@ class ZScript:
         docker: Active :class:`~nanvix_zutil.DockerConfig`, or ``None``
             when Docker mode is not in use.
     """
-
-    SYSROOT_REQUIRED_FILES: tuple[str, ...] = (
-        "lib/libposix.a",
-        "lib/user.ld",
-        "bin/nanvixd.elf",
-        "bin/kernel.elf",
-        "bin/mkramfs.elf",
-    )
-
-    SYSROOT_REQUIRED_FILES_WINDOWS: tuple[str, ...] = (
-        "lib/libposix.a",
-        "lib/user.ld",
-        "bin/nanvixd.exe",
-        "bin/kernel.elf",
-        "bin/mkramfs.exe",
-    )
 
     SDK_RUNTIME_REQUIRED_FILES: tuple[str, ...] = (
         "bin/nanvixd.elf",
@@ -202,14 +178,10 @@ class ZScript:
         Subclasses can extend by overriding the class attributes or
         this method.
         """
-        if self.manifest.toolchain.kind == ToolchainKind.SDK and is_windows():
+        if is_windows():
             files = list(self.SDK_RUNTIME_REQUIRED_FILES_WINDOWS)
-        elif self.manifest.toolchain.kind == ToolchainKind.SDK:
-            files = list(self.SDK_RUNTIME_REQUIRED_FILES)
-        elif is_windows():
-            files = list(self.SYSROOT_REQUIRED_FILES_WINDOWS)
         else:
-            files = list(self.SYSROOT_REQUIRED_FILES)
+            files = list(self.SDK_RUNTIME_REQUIRED_FILES)
         if self.config.deployment_mode == "multi-process":
             files.extend(self.SYSROOT_MULTI_PROCESS_FILES)
         if self.config.deployment_mode == "standalone":
@@ -227,7 +199,6 @@ class ZScript:
         self.sysroot: Sysroot | None = None
         self.buildroot: Buildroot | None = None
         self.docker: DockerConfig | None = None
-        self._used_fallback: bool = False
         self._offline: bool = False
         self._with_nanvix_path: str | None = None
         self._cli_sysroot_path: str | None = None
@@ -312,7 +283,7 @@ class ZScript:
     # Lifecycle hooks — auto-implemented
     # ------------------------------------------------------------------
 
-    def setup(self) -> bool:
+    def setup(self) -> None:
         """Prepare the build environment.
 
         The base implementation automatically downloads the Nanvix sysroot
@@ -322,19 +293,10 @@ class ZScript:
         Subclasses may override this to perform additional setup steps.
         Call ``super().setup()`` to retain the automatic download behaviour::
 
-            def setup(self) -> bool:
-                failed = super().setup()
+            def setup(self) -> None:
+                super().setup()
                 # extra verification or configuration here
-                return failed
-
-        Returns:
-            ``True`` if any dependency was resolved via version fallback, or any
-            other failure condition
-            ``False`` if all dependencies matched their exact requested
-            versions.
         """
-        self._used_fallback = False
-
         # Resolve sysroot: --sysroot-path takes precedence.
         sysroot_path = self._cli_sysroot_path
 
@@ -392,34 +354,15 @@ class ZScript:
 
         self.sysroot.verify(self.sysroot_required_files())
 
-        # Deferred auto-suffix: when sysroot is "latest", load_manifest()
-        # skips suffixing because the real version isn't known yet.  Now
-        # that the sysroot is resolved, suffix VERSION deps before
-        # passing them to install_dep().
         deps: list[Dependency] = list(self.manifest.dependencies)
-        if self.manifest.sysroot_ref.value == "latest":
-            if self.sysroot.tag:
-                resolved_version = self.sysroot.tag.removeprefix("v")
-                deps = [suffix_dep(d, resolved_version) for d in deps]
-            elif not self._offline:
-                log.fatal(
-                    "Sysroot resolved to 'latest' but no tag is available"
-                    " — delete .nanvix/sysroot and re-run 'nanvix-zutil setup'.",
-                    code=EXIT_MISSING_DEP,
-                )
-            # In offline mode with no tag, deps remain un-suffixed.
-            # This is acceptable because offline resolution uses local
-            # paths (deps/<name>/) which are version-agnostic.
 
         sdk_releases: dict[str, dict[str, object]] = {}
-        sdk_mode = self.manifest.toolchain.kind == ToolchainKind.SDK
-        if sdk_mode and not self._offline:
+        if not self._offline:
             # Windows resolves the digest-bound release tuple but cannot execute the
             # Linux provider image; CI verifies that image on its Linux job.
             resolution = resolve(
                 self.manifest,
                 gh_token=self.config.get(CFG_GH_TOKEN),
-                strict=True,
                 verify_sdk_image=not is_windows(),
             )
             if isinstance(resolution, BlockedResolution):
@@ -475,7 +418,7 @@ class ZScript:
                 # When --with-nanvix is active, try local artifacts first.
                 # In offline mode, try for ALL deps (not just nanvix-owned).
                 # In online mode, only try for nanvix-owned deps.
-                if nanvix_local and (self._offline or not sdk_mode):
+                if nanvix_local and self._offline:
                     should_try_local = self._offline or dep.repo.startswith("nanvix/")
                     if should_try_local and self.buildroot.install_local_nanvix(
                         dep, Path(nanvix_local)
@@ -492,41 +435,11 @@ class ZScript:
                     continue
 
                 try:
-                    # Resolve release with version fallback for nanvix-suffixed
-                    # deps, then pass the pre-resolved release and enable
-                    # cross-mode asset fallback in install_dep().
-                    release: dict[str, object] | None = None
-                    base_version = extract_nanvix_version_base(str(dep.ref.value))
-                    if sdk_mode:
-                        release = sdk_releases.get(dep.name)
-                        if release is None:
-                            log.fatal(
-                                f"Strict SDK release missing for '{dep.name}'",
-                                code=EXIT_MISSING_DEP,
-                            )
-                    elif base_version is not None:
-                        release, fb_ver = resolve_release_with_fallback(
-                            repo=dep.repo,
-                            version_specifier=str(dep.ref.value),
-                            base_version=base_version,
-                            gh_token=self.config.get(CFG_GH_TOKEN),
-                        )
-                        # Log when version fallback was used.
-                        # fb_ver is None when the exact tag was found;
-                        # non-None means a fallback release was used.
-                        if fb_ver is not None:
-                            self._used_fallback = True
-                            requested_ver = extract_nanvix_version(str(dep.ref.value))
-                            log.warning(
-                                f"Version fallback for {dep.name}: "
-                                f"requested nanvix-{requested_ver}, "
-                                f"resolved nanvix-{fb_ver}"
-                            )
-                    else:
-                        release = resolve_release(
-                            repo=dep.repo,
-                            version_specifier=dep.ref.value,
-                            gh_token=self.config.get(CFG_GH_TOKEN),
+                    release = sdk_releases.get(dep.name)
+                    if release is None:
+                        log.fatal(
+                            f"Exact SDK release missing for '{dep.name}'",
+                            code=EXIT_MISSING_DEP,
                         )
 
                     self.buildroot.install_dep(
@@ -546,7 +459,6 @@ class ZScript:
 
         self.config.save()
         sync_configs()
-        return self._used_fallback
 
     def install_artifacts(self, output: str) -> None:
         """Export build artifacts to a target directory.
@@ -590,7 +502,6 @@ class ZScript:
             self.manifest,
             gh_token=self.config.get(CFG_GH_TOKEN),
             shallow=shallow,
-            strict=self.manifest.toolchain.kind == ToolchainKind.SDK,
         )
         if isinstance(lockfile, BlockedResolution):
             log.fatal(
@@ -611,15 +522,6 @@ class ZScript:
         """
         lock_path = nanvix_root() / "nanvix.lock"
         lockfile = read_lockfile(lock_path)
-
-        # Warn when "latest" lockfile may silently be stale.
-        sysroot_pkg = next((p for p in lockfile.packages if p.name == "nanvix"), None)
-        if sysroot_pkg is not None and sysroot_pkg.ref.value == "latest":
-            log.warning(
-                "'nanvix-version = \"latest\"' — lockfile staleness cannot"
-                " be detected by hash; re-run 'nanvix-zutil lock' to pick up new"
-                " releases."
-            )
 
         if is_stale(lockfile):
             log.fatal(
@@ -759,7 +661,6 @@ class ZScript:
             if args.subcommand == "setup":
                 if (
                     requested_image is not None
-                    and manifest_image is not None
                     and requested_image != manifest_image
                     and not allow_override
                 ):
@@ -771,15 +672,13 @@ class ZScript:
                         " --allow-local-docker-override for an intentional"
                         " local-development override.",
                     )
-                image = requested_image or manifest_image or persisted_image
+                image = requested_image or manifest_image
             else:
                 image = persisted_image
 
             if image is None:
                 log.fatal(
-                    "No Docker image configured. SDK manifests must define an"
-                    " immutable build image; legacy manifests must run"
-                    " 'setup --with-docker IMAGE'.",
+                    "No Docker image configured. Run setup first.",
                     code=EXIT_INVALID_ARGS,
                 )
 
@@ -804,9 +703,7 @@ class ZScript:
         subcommand: str | None = args.subcommand
 
         # Fail fast on env.json / nanvix.toml sysroot version drift so
-        # users don't build against a stale sysroot. `sysroot_ref` is
-        # always TAG (semver or "latest") or LOCAL; "latest" is
-        # resolved against GitHub so we can compare a concrete tag.
+        # users don't build against a stale sysroot.
         # See https://github.com/nanvix/zutils/issues/263.
         if subcommand is not None and subcommand != "setup":
             pinned = instance.manifest.sysroot_ref
@@ -819,19 +716,7 @@ class ZScript:
                 cached = instance.config.get("sysroot_tag")
                 if isinstance(cached, str) and cached:
                     expected = pinned.value
-                    if expected == "latest" and not instance._offline:
-                        release = resolve_release(
-                            repo="nanvix/nanvix",
-                            version_specifier="latest",
-                            gh_token=instance.config.get(CFG_GH_TOKEN),
-                            semver=True,
-                        )
-                        tag_name = release.get("tag_name")
-                        if isinstance(tag_name, str):
-                            expected = tag_name
-                    if expected != "latest" and cached.removeprefix(
-                        "v"
-                    ) != expected.removeprefix("v"):
+                    if cached.removeprefix("v") != expected.removeprefix("v"):
                         log.fatal(
                             f"Sysroot is stale: env.json={cached!r}, expected={expected!r}."
                             f" (nanvix.toml={pinned.value!r})."
@@ -864,22 +749,7 @@ class ZScript:
 
         handler = dispatch.get(subcommand) if subcommand is not None else None
         if callable(handler) and subcommand is not None:
-            handler_result = handler()
-
-            if subcommand == "setup":
-                if instance._used_fallback:
-                    log.fatal(
-                        f"{subcommand.capitalize()} complete with fallback dependencies",
-                        code=EXIT_DEGRADED_SETUP,
-                    )
-                # NOTE: This is semantically backwards,
-                # but we're going to be making setup standalone soon.
-                # Leave it so we don't have to modify downstreams.
-                elif handler_result is True:
-                    log.fatal(
-                        "Setup override returned True, indicating failure.",
-                        code=EXIT_DEGRADED_SETUP,
-                    )
+            handler()
             log.success(f"{subcommand.capitalize()} complete")
         else:
             log.fatal(f"Unknown subcommand: {subcommand}", code=EXIT_INVALID_ARGS)

--- a/src/nanvix_zutil/sdk.py
+++ b/src/nanvix_zutil/sdk.py
@@ -169,22 +169,6 @@ def sdk_consumer_release_tag(package_version: str, sdk_version: str) -> str:
     return f"{package_version}-nanvix-{runtime}-sdk.{revision}"
 
 
-def consumer_release_tag(
-    package_version: str,
-    nanvix_version: str,
-    sdk_version: str | None = None,
-) -> str:
-    """Build a legacy or SDK-aware consumer dependency release tag."""
-    if sdk_version is None:
-        return f"{package_version}-nanvix-{nanvix_version.removeprefix('v')}"
-    runtime, _revision = parse_sdk_version(sdk_version)
-    if runtime != nanvix_version.removeprefix("v"):
-        raise SdkValidationError(
-            f"SDK runtime {runtime} does not match Nanvix {nanvix_version}"
-        )
-    return sdk_consumer_release_tag(package_version, sdk_version)
-
-
 def _object(value: object, path: str) -> dict[str, object]:
     """Return *value* as an object or raise a path-specific validation error."""
     if not isinstance(value, dict):

--- a/templates/nanvix-ci.yml
+++ b/templates/nanvix-ci.yml
@@ -27,7 +27,6 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v{{WORKFLOW_VERSION}}
     with:
       caller-event-name: ${{ github.event_name }}
-      docker-image: ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35  # yamllint disable-line rule:line-length
       nanvix-version-source: sdk
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/tests/test_cli_lock.py
+++ b/tests/test_cli_lock.py
@@ -21,7 +21,7 @@ from nanvix_zutil.lockfile import (
     write_lockfile,
 )
 from nanvix_zutil.script import ZScript
-from tests.testutils import write_manifest
+from tests.testutils import MINIMAL_MANIFEST, make_sdk_provenance, write_manifest
 
 
 def _make_mock_lockfile(manifest_path: Path) -> Lockfile:
@@ -32,6 +32,7 @@ def _make_mock_lockfile(manifest_path: Path) -> Lockfile:
         metadata=LockfileMetadata(
             manifest_hash=compute_manifest_hash(manifest_path),
             nanvix_zutil_version="0.2.2",
+            sdk=make_sdk_provenance(),
         ),
         packages=[
             ResolvedPackage(
@@ -143,10 +144,11 @@ class TestLockCheck(unittest.TestCase):
 
         # Modify the manifest to make the lockfile stale
         manifest_path.write_text(
-            "[package]\n"
-            'name = "test"\n'
-            'version = "0.2.0"\n'
-            'nanvix-version = "0.2.0"\n'
+            MINIMAL_MANIFEST.replace(
+                'version = "0.1.0"',
+                'version = "0.2.0"',
+                1,
+            )
         )
 
         script = ZScript()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -5,7 +5,6 @@
 
 """Tests for nanvix_zutil.github."""
 
-import collections.abc
 import json
 import os
 import tempfile
@@ -1356,109 +1355,6 @@ class TestResolveReleaseSemverGating(unittest.TestCase):
         assert result is not None
         self.assertEqual(result["tag_name"], "v1.2.3")
         self.assertIn("/releases/tags/v1.2.3", captured[0].full_url)
-
-
-class TestFindBestRelease(unittest.TestCase):
-    """Tests for _find_best_release()."""
-
-    def test_finds_matching_release(self) -> None:
-        """First release whose tag matches the prefix is returned."""
-        releases = [
-            {"tag_name": "1.3.1-nanvix-0.12.320"},
-            {"tag_name": "1.3.1-nanvix-0.12.291"},
-            {"tag_name": "1.2.0-nanvix-0.12.291"},
-        ]
-        with patch.object(github_mod, "_list_releases", return_value=iter(releases)):
-            result = github_mod._find_best_release("nanvix/zlib", "1.3.1-nanvix-", {})
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["tag_name"], "1.3.1-nanvix-0.12.320")
-
-    def test_returns_none_when_no_match(self) -> None:
-        """Returns None when no tags match the prefix."""
-        releases = [
-            {"tag_name": "2.0.0-nanvix-0.12.320"},
-            {"tag_name": "1.2.0-nanvix-0.12.291"},
-        ]
-        with patch.object(github_mod, "_list_releases", return_value=iter(releases)):
-            result = github_mod._find_best_release("nanvix/zlib", "1.3.1-nanvix-", {})
-        self.assertIsNone(result)
-
-    def test_short_circuits_on_first_match(self) -> None:
-        """Generator stops iterating after the first match."""
-        call_count = 0
-
-        def counting_gen(
-            repo: str, headers: dict[str, str]
-        ) -> collections.abc.Generator[dict[str, object], None, None]:
-            nonlocal call_count
-            items: list[dict[str, object]] = [
-                {"tag_name": "1.3.1-nanvix-0.12.320"},
-                {"tag_name": "1.3.1-nanvix-0.12.291"},
-            ]
-            for rel in items:
-                call_count += 1
-                yield rel
-
-        with patch.object(github_mod, "_list_releases", side_effect=counting_gen):
-            result = github_mod._find_best_release("nanvix/zlib", "1.3.1-nanvix-", {})
-        self.assertIsNotNone(result)
-        # The generator yielded 1 item and then the function returned.
-        # Python generators only advance when next() is called, and
-        # _find_best_release returns on the first match before calling
-        # next() again.  So call_count should be 1.
-        self.assertEqual(call_count, 1)
-
-
-class TestResolveReleaseWithFallback(unittest.TestCase):
-    """Tests for resolve_release_with_fallback()."""
-
-    @patch.object(github_mod, "_find_best_release")
-    @patch.object(github_mod, "_resolve_release")
-    def test_exact_tag_found_no_fallback(
-        self, mock_resolve: MagicMock, mock_best: MagicMock
-    ) -> None:
-        """When the exact tag exists, returns (release, None)."""
-        release: dict[str, object] = {"tag_name": "1.3.1-nanvix-0.12.337"}
-        mock_resolve.return_value = release
-
-        result, fallback_ver = github_mod.resolve_release_with_fallback(
-            "nanvix/zlib", "1.3.1-nanvix-0.12.337", "1.3.1"
-        )
-        self.assertEqual(result, release)
-        self.assertIsNone(fallback_ver)
-        mock_best.assert_not_called()
-
-    @patch.object(github_mod, "_find_best_release")
-    @patch.object(github_mod, "_resolve_release")
-    def test_404_triggers_fallback(
-        self, mock_resolve: MagicMock, mock_best: MagicMock
-    ) -> None:
-        """When exact tag 404s, scans releases and returns fallback."""
-        mock_resolve.return_value = None  # allow_missing=True returns None
-        fallback_release: dict[str, object] = {"tag_name": "1.3.1-nanvix-0.12.291"}
-        mock_best.return_value = fallback_release
-
-        result, fallback_ver = github_mod.resolve_release_with_fallback(
-            "nanvix/zlib", "1.3.1-nanvix-0.12.337", "1.3.1"
-        )
-        self.assertEqual(result, fallback_release)
-        self.assertEqual(fallback_ver, "0.12.291")
-
-    @patch.object(github_mod, "_find_best_release")
-    @patch.object(github_mod, "_resolve_release")
-    def test_no_fallback_release_exits(
-        self, mock_resolve: MagicMock, mock_best: MagicMock
-    ) -> None:
-        """When both exact and scan fail, exits with code 3."""
-        mock_resolve.return_value = None
-        mock_best.return_value = None
-
-        with self.assertRaises(SystemExit) as ctx:
-            github_mod.resolve_release_with_fallback(
-                "nanvix/zlib", "1.3.1-nanvix-0.12.337", "1.3.1"
-            )
-        self.assertEqual(ctx.exception.code, 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,10 +30,9 @@ class _MockConsumer(ZScript):
         super().__init__()
         self.called: list[str] = []
 
-    def setup(self) -> bool:
+    def setup(self) -> None:
         """Record setup hook invocation."""
         self.called.append("setup")
-        return False
 
     def build(self) -> None:
         """Record build hook invocation."""
@@ -70,10 +69,6 @@ class TestIntegrationLifecycle(unittest.TestCase):
         """Run _MockConsumer.main() with *subcommand* and return the instance."""
         fake_script = str(repo_root() / ".nanvix" / "z.py")
         argv = [fake_script, subcommand] + (extra_argv or [])
-
-        # setup requires --with-docker IMAGE on the CLI.
-        if subcommand == "setup" and "--with-docker" not in argv:
-            argv += ["--with-docker", "test/image:tag"]
 
         # build/clean need a persisted Docker image.
         _DOCKER_COMMANDS = {"build", "clean"}

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -19,6 +19,7 @@ from nanvix_zutil.lockfile import (
     read_lockfile,
     write_lockfile,
 )
+from tests.testutils import make_sdk_provenance
 
 
 def _make_sample_lockfile() -> Lockfile:
@@ -27,6 +28,7 @@ def _make_sample_lockfile() -> Lockfile:
         metadata=LockfileMetadata(
             manifest_hash="sha256:abc123",
             nanvix_zutil_version="0.2.2",
+            sdk=make_sdk_provenance(),
         ),
         packages=[
             ResolvedPackage(
@@ -119,6 +121,7 @@ class TestLockfileRoundTrip(unittest.TestCase):
             metadata=LockfileMetadata(
                 manifest_hash="sha256:def456",
                 nanvix_zutil_version="0.2.2",
+                sdk=make_sdk_provenance(),
             ),
             packages=[
                 ResolvedPackage(
@@ -157,6 +160,7 @@ class TestLockfileRoundTrip(unittest.TestCase):
             metadata=LockfileMetadata(
                 manifest_hash="sha256:id_test",
                 nanvix_zutil_version="0.2.2",
+                sdk=make_sdk_provenance(),
             ),
             packages=[
                 ResolvedPackage(
@@ -268,24 +272,10 @@ class TestDownloadLockfileAsset(unittest.TestCase):
     def test_downloads_and_parses_lockfile(self, mock_download: MagicMock) -> None:
         # Build a minimal valid lockfile and write it to a temp file
         # that the mock will return as the download path.
-        lockfile_content = (
-            "[metadata]\n"
-            'manifest-hash = "sha256:abc"\n'
-            'nanvix-zutil-version = "0.2.2"\n'
-            "\n"
-            "[[package]]\n"
-            'name = "nanvix"\n'
-            'repo = "nanvix/nanvix"\n'
-            'kind = "sysroot"\n'
-            'ref-kind = "tag"\n'
-            'ref-value = "0.1.0"\n'
-            'resolved-tag = "v0.1.0"\n'
-            'resolved-commitish = "aaa"\n'
-            "release-id = 1\n"
-            "dependencies = []\n"
-        )
         out_path = Path(self._tmpdir.name) / "nanvix.lock"
-        out_path.write_text(lockfile_content)
+        lockfile = _make_sample_lockfile()
+        lockfile.metadata.manifest_hash = "sha256:abc"
+        write_lockfile(lockfile, out_path)
         mock_download.return_value = out_path
 
         release: dict[str, object] = {
@@ -301,7 +291,7 @@ class TestDownloadLockfileAsset(unittest.TestCase):
         self.assertIsNotNone(result)
         assert result is not None
         self.assertEqual(result.metadata.manifest_hash, "sha256:abc")
-        self.assertEqual(len(result.packages), 1)
+        self.assertEqual(len(result.packages), 2)
         self.assertEqual(result.packages[0].name, "nanvix")
 
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -25,22 +25,6 @@ class TestLoadManifestFileNotFound(unittest.TestCase):
 class TestLoadManifestBasic(unittest.TestCase):
     """load_manifest parses a well-formed nanvix.toml."""
 
-    def test_single_dependency_commitish(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '{ commitish = "b7a6a3c" }'}))
-
-        m = load_manifest()
-
-        self.assertEqual(m.name, "myapp")
-        self.assertEqual(m.version, "1.0.0")
-        self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
-        self.assertEqual(m.sysroot_ref.value, "0.12.257")
-        self.assertEqual(len(m.dependencies), 1)
-        self.assertEqual(m.dependencies[0].name, "zlib")
-        self.assertEqual(m.dependencies[0].repo, "nanvix/zlib")
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.COMMITISH)
-        self.assertEqual(m.dependencies[0].ref.value, "b7a6a3c")
-
     def test_single_dependency_version_string(self) -> None:
         path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="1.2.3", deps={"zlib": '"4.5.6"'}))
@@ -50,7 +34,7 @@ class TestLoadManifestBasic(unittest.TestCase):
         self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
         self.assertEqual(m.sysroot_ref.value, "1.2.3")
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
-        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.2.3")
+        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.2.3-sdk.1")
 
     def test_single_dependency_version_table(self) -> None:
         path = paths.manifest_path()
@@ -61,32 +45,14 @@ class TestLoadManifestBasic(unittest.TestCase):
         m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
-        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.2.3")
-
-    def test_single_dependency_tag(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '{ tag = "675d8f2-nanvix-e63706b" }'}))
-
-        m = load_manifest()
-
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.TAG)
-        self.assertEqual(m.dependencies[0].ref.value, "675d8f2-nanvix-e63706b")
-
-    def test_single_dependency_id(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": "{ id = 12345678 }"}))
-
-        m = load_manifest()
-
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.ID)
-        self.assertEqual(m.dependencies[0].ref.value, 12345678)
+        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.2.3-sdk.1")
 
     def test_mixed_dependencies(self) -> None:
         path = paths.manifest_path()
         path.write_text(
             make_toml(
                 nanvix_version="1.0.0",
-                deps={"zlib": '{ commitish = "aaa" }', "openssl": '"2.0.0"'},
+                deps={"zlib": '"1.2.3"', "openssl": '"2.0.0"'},
             )
         )
 
@@ -94,10 +60,10 @@ class TestLoadManifestBasic(unittest.TestCase):
 
         self.assertEqual(m.sysroot_ref.value, "1.0.0")
         self.assertEqual(len(m.dependencies), 2)
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.COMMITISH)
-        self.assertEqual(m.dependencies[0].ref.value, "aaa")
+        self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
+        self.assertEqual(m.dependencies[0].ref.value, "1.2.3-nanvix-1.0.0-sdk.1")
         self.assertEqual(m.dependencies[1].ref.kind, RefKind.VERSION)
-        self.assertEqual(m.dependencies[1].ref.value, "2.0.0-nanvix-1.0.0")
+        self.assertEqual(m.dependencies[1].ref.value, "2.0.0-nanvix-1.0.0-sdk.1")
 
     def test_no_dependencies_section(self) -> None:
         path = paths.manifest_path()
@@ -155,24 +121,21 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 2)
 
-    def test_latest_nanvix_version_accepted(self) -> None:
+    def test_latest_nanvix_version_rejected_for_sdk(self) -> None:
         path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="latest"))
 
-        m = load_manifest()
+        with self.assertRaises(SystemExit) as context:
+            load_manifest()
+        self.assertEqual(context.exception.code, 2)
 
-        self.assertEqual(m.sysroot_ref.kind, RefKind.TAG)
-        self.assertEqual(m.sysroot_ref.value, "latest")
-
-    def test_latest_sysroot_skips_dep_suffix(self) -> None:
+    def test_latest_sysroot_with_dependency_is_rejected(self) -> None:
         path = paths.manifest_path()
         path.write_text(make_toml(nanvix_version="latest", deps={"zlib": '"1.3.1"'}))
 
-        m = load_manifest()
-
-        self.assertEqual(m.sysroot_ref.value, "latest")
-        # Dep should NOT be suffixed — deferred to resolver
-        self.assertEqual(m.dependencies[0].ref.value, "1.3.1")
+        with self.assertRaises(SystemExit) as context:
+            load_manifest()
+        self.assertEqual(context.exception.code, 2)
 
     def test_nanvix_version_table_exits_2(self) -> None:
         path = paths.manifest_path()
@@ -197,18 +160,18 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 2)
 
-    def test_empty_commitish_exits_2(self) -> None:
+    def test_commitish_ref_exits_2(self) -> None:
         path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '{ commitish = "" }'}))
+        path.write_text(make_toml(deps={"zlib": '{ commitish = "b7a6a3c" }'}))
 
         with self.assertRaises(SystemExit) as ctx:
             load_manifest()
 
         self.assertEqual(ctx.exception.code, 2)
 
-    def test_non_string_commitish_exits_2(self) -> None:
+    def test_tag_ref_exits_2(self) -> None:
         path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": "{ commitish = 123 }"}))
+        path.write_text(make_toml(deps={"zlib": '{ tag = "v1.0.0" }'}))
 
         with self.assertRaises(SystemExit) as ctx:
             load_manifest()
@@ -224,9 +187,9 @@ class TestLoadManifestInvalidVersion(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 2)
 
-    def test_non_integer_id_exits_2(self) -> None:
+    def test_id_ref_exits_2(self) -> None:
         path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '{ id = "abc" }'}))
+        path.write_text(make_toml(deps={"zlib": "{ id = 123 }"}))
 
         with self.assertRaises(SystemExit) as ctx:
             load_manifest()
@@ -254,7 +217,7 @@ class TestLoadManifestLatestWarning(unittest.TestCase):
             m = load_manifest()
 
         mock_log.warning.assert_called()
-        self.assertEqual(m.dependencies[0].ref.value, "latest-nanvix-0.12.257")
+        self.assertEqual(m.dependencies[0].ref.value, "latest-nanvix-0.12.257-sdk.1")
 
 
 class TestLoadManifestPackageValidation(unittest.TestCase):
@@ -320,7 +283,7 @@ class TestLoadManifestMalformedToml(unittest.TestCase):
 
 
 class TestLoadManifestAutoSuffix(unittest.TestCase):
-    """Only VERSION refs are auto-suffixed with the nanvix version."""
+    """Manifest dependency refs are auto-suffixed with the SDK version."""
 
     def test_version_string_dep_suffixed(self) -> None:
         path = paths.manifest_path()
@@ -329,7 +292,7 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
         m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
-        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.0.0")
+        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.0.0-sdk.1")
 
     def test_version_table_dep_suffixed(self) -> None:
         path = paths.manifest_path()
@@ -340,34 +303,7 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
         m = load_manifest()
 
         self.assertEqual(m.dependencies[0].ref.kind, RefKind.VERSION)
-        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.0.0")
-
-    def test_commitish_dep_not_suffixed(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '{ commitish = "b7a6a3c" }'}))
-
-        m = load_manifest()
-
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.COMMITISH)
-        self.assertEqual(m.dependencies[0].ref.value, "b7a6a3c")
-
-    def test_tag_dep_not_suffixed(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": '{ tag = "v1.0.0-nanvix-abc" }'}))
-
-        m = load_manifest()
-
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.TAG)
-        self.assertEqual(m.dependencies[0].ref.value, "v1.0.0-nanvix-abc")
-
-    def test_id_dep_not_suffixed(self) -> None:
-        path = paths.manifest_path()
-        path.write_text(make_toml(deps={"zlib": "{ id = 99999 }"}))
-
-        m = load_manifest()
-
-        self.assertEqual(m.dependencies[0].ref.kind, RefKind.ID)
-        self.assertEqual(m.dependencies[0].ref.value, 99999)
+        self.assertEqual(m.dependencies[0].ref.value, "4.5.6-nanvix-1.0.0-sdk.1")
 
     def test_full_ref_with_nanvix_rejected(self) -> None:
         path = paths.manifest_path()
@@ -389,8 +325,8 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
 
         m = load_manifest()
 
-        self.assertEqual(m.dependencies[0].ref.value, "1.2.3-nanvix-1.0.0")
-        self.assertEqual(m.dependencies[1].ref.value, "2.0.0-nanvix-1.0.0")
+        self.assertEqual(m.dependencies[0].ref.value, "1.2.3-nanvix-1.0.0-sdk.1")
+        self.assertEqual(m.dependencies[1].ref.value, "2.0.0-nanvix-1.0.0-sdk.1")
 
     def test_system_deps_version_suffixed(self) -> None:
         path = paths.manifest_path()
@@ -400,7 +336,10 @@ class TestLoadManifestAutoSuffix(unittest.TestCase):
 
         self.assertEqual(m.system_dependencies[0].name, "foobar")
         self.assertEqual(m.system_dependencies[0].ref.kind, RefKind.VERSION)
-        self.assertEqual(m.system_dependencies[0].ref.value, "1.2.3-nanvix-0.12.257")
+        self.assertEqual(
+            m.system_dependencies[0].ref.value,
+            "1.2.3-nanvix-0.12.257-sdk.1",
+        )
 
 
 class TestLoadManifestSystemDependencies(unittest.TestCase):
@@ -410,7 +349,7 @@ class TestLoadManifestSystemDependencies(unittest.TestCase):
         path = paths.manifest_path()
         path.write_text(
             make_toml(
-                sys_deps={"foobar": '"1.2.3"', "bazqux": '{ commitish = "deadbeef" }'},
+                sys_deps={"foobar": '"1.2.3"', "bazqux": '{ version = "2.0.0" }'},
             )
         )
 
@@ -420,16 +359,22 @@ class TestLoadManifestSystemDependencies(unittest.TestCase):
         self.assertEqual(m.system_dependencies[0].name, "foobar")
         self.assertEqual(m.system_dependencies[0].repo, "nanvix/foobar")
         self.assertEqual(m.system_dependencies[0].ref.kind, RefKind.VERSION)
-        self.assertEqual(m.system_dependencies[0].ref.value, "1.2.3-nanvix-0.12.257")
+        self.assertEqual(
+            m.system_dependencies[0].ref.value,
+            "1.2.3-nanvix-0.12.257-sdk.1",
+        )
         self.assertEqual(m.system_dependencies[1].name, "bazqux")
-        self.assertEqual(m.system_dependencies[1].ref.kind, RefKind.COMMITISH)
-        self.assertEqual(m.system_dependencies[1].ref.value, "deadbeef")
+        self.assertEqual(m.system_dependencies[1].ref.kind, RefKind.VERSION)
+        self.assertEqual(
+            m.system_dependencies[1].ref.value,
+            "2.0.0-nanvix-0.12.257-sdk.1",
+        )
 
     def test_both_dep_sections_parsed(self) -> None:
         path = paths.manifest_path()
         path.write_text(
             make_toml(
-                deps={"zlib": '{ commitish = "aaa" }'},
+                deps={"zlib": '"1.0.0"'},
                 sys_deps={"foobar": '"1.2.3"'},
             )
         )

--- a/tests/test_resolve_cmd.py
+++ b/tests/test_resolve_cmd.py
@@ -15,6 +15,7 @@ from nanvix_zutil.commands.resolve import main
 from nanvix_zutil.lockfile import Lockfile, LockfileMetadata, ResolvedPackage
 from nanvix_zutil.manifest import Manifest, SdkPin, Toolchain, ToolchainKind
 from nanvix_zutil.sdk import SdkImage, SdkProvenance
+from tests.testutils import make_sdk_provenance
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -28,11 +29,7 @@ _VERSION = "1.3.1"
 
 def _make_manifest() -> Manifest:
     """Return a minimal fake Manifest."""
-    return Manifest(
-        name=_NAME,
-        version=_VERSION,
-        sysroot_ref=Ref(kind=RefKind.TAG, value="0.12.266"),
-    )
+    return _make_sdk_manifest()
 
 
 def _make_lockfile() -> Lockfile:
@@ -41,6 +38,7 @@ def _make_lockfile() -> Lockfile:
         metadata=LockfileMetadata(
             manifest_hash="sha256:abc123",
             nanvix_zutil_version="0.3.0",
+            sdk=make_sdk_provenance("0.20.0"),
         ),
         packages=[
             ResolvedPackage(
@@ -62,6 +60,7 @@ def _make_lockfile_no_sysroot() -> Lockfile:
         metadata=LockfileMetadata(
             manifest_hash="sha256:abc123",
             nanvix_zutil_version="0.3.0",
+            sdk=make_sdk_provenance("0.20.0"),
         ),
         packages=[],
     )
@@ -151,16 +150,7 @@ class TestDefaultOutput(unittest.TestCase):
         self.assertIn(f"nanvix_version={_TAG.lstrip('v')}", output)
         self.assertIn(f"package_name={_NAME}", output)
         self.assertIn(f"package_version={_VERSION}", output)
-        self.assertEqual(
-            output.splitlines(),
-            [
-                f"nanvix_tag={_TAG}",
-                f"nanvix_sha={_SHA[:7]}",
-                f"nanvix_version={_TAG.lstrip('v')}",
-                f"package_name={_NAME}",
-                f"package_version={_VERSION}",
-            ],
-        )
+        self.assertIn("sdk_version=v0.20.0-sdk.1", output)
 
     @patch("nanvix_zutil.commands.resolve.resolve")
     @patch("nanvix_zutil.commands.resolve.load_manifest")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,815 +1,103 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-# pyright: reportPrivateUsage=false
+"""Focused tests for SDK-only resolver helpers and staleness."""
 
-"""Tests for nanvix_zutil.resolver."""
+from __future__ import annotations
 
 import unittest
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+
+# pyright: reportPrivateUsage=false
 
 from nanvix_zutil import paths
-from nanvix_zutil.buildroot import Dependency, Ref, RefKind
+from nanvix_zutil.buildroot import Ref, RefKind
 from nanvix_zutil.lockfile import (
     Lockfile,
     LockfileMetadata,
     ResolvedPackage,
+    compute_manifest_hash,
 )
-from nanvix_zutil.manifest import Manifest
-from nanvix_zutil.resolver import _unsuffix_deps, is_stale, resolve
+from nanvix_zutil.resolver import _collect_assets, _detect_cycles, is_stale
+from tests.testutils import MINIMAL_MANIFEST, make_sdk_provenance
 
 
-def _make_release(
-    tag: str = "v0.1.0",
-    commitish: str = "aaa111",
-    release_id: int = 100,
-    assets: list[dict[str, object]] | None = None,
-) -> dict[str, object]:
-    """Build a fake GitHub release dict."""
-    if assets is None:
-        assets = []
-    return {
-        "tag_name": tag,
-        "target_commitish": commitish,
-        "id": release_id,
-        "assets": assets,
-    }
+class TestResolverHelpers(unittest.TestCase):
+    """Asset filtering and cycle detection remain deterministic."""
 
-
-def _make_manifest(
-    deps: list[Dependency] | None = None,
-    sys_deps: list[Dependency] | None = None,
-    sysroot_ref: Ref | None = None,
-) -> Manifest:
-    """Build a Manifest with the given dependencies."""
-    return Manifest(
-        name="test",
-        version="0.1.0",
-        sysroot_ref=sysroot_ref or Ref(kind=RefKind.TAG, value="0.1.0"),
-        dependencies=deps or [],
-        system_dependencies=sys_deps or [],
-    )
-
-
-def _archive_asset(name: str) -> dict[str, object]:
-    """Build a fake archive asset entry."""
-    return {
-        "name": name,
-        "browser_download_url": f"https://example.com/{name}",
-    }
-
-
-def _lockfile_asset() -> dict[str, object]:
-    """Build a fake nanvix.lock asset entry."""
-    return {
-        "name": "nanvix.lock",
-        "browser_download_url": "https://example.com/nanvix.lock",
-    }
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestResolveSysrootOnly(unittest.TestCase):
-    """Resolver with no dependencies (sysroot only)."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\nnanvix-version = "0.1.0"\n'
-        )
-
-    def test_sysroot_only(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(
-            tag="v0.1.0",
-            commitish="aaa111",
-            release_id=100,
-            assets=[
-                _archive_asset(
-                    "nanvix-hyperlight-multi-process-release-128mb-aaa111.tar.bz2"
-                )
-            ],
-        )
-        mock_resolve.return_value = sysroot_release
-        mock_download.return_value = None
-
-        manifest = _make_manifest()
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
-
-        self.assertEqual(len(lockfile.packages), 1)
-        self.assertEqual(lockfile.packages[0].name, "nanvix")
-        self.assertEqual(lockfile.packages[0].kind, "sysroot")
-        self.assertEqual(len(lockfile.packages[0].assets), 1)
-        self.assertTrue(lockfile.metadata.manifest_hash.startswith("sha256:"))
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestResolveDirectDep(unittest.TestCase):
-    """Resolver with one direct dependency."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "0.1.0"\n'
-            "[dependencies]\n"
-            'zlib = { tag = "v1.0.0" }\n'
-        )
-
-    def test_one_direct_dep(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(tag="v0.1.0", release_id=100)
-        zlib_release = _make_release(
-            tag="v1.0.0",
-            commitish="bbb222",
-            release_id=200,
-            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
-        )
-        mock_resolve.side_effect = [sysroot_release, zlib_release]
-        mock_download.return_value = None
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                )
-            ]
-        )
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
-
-        self.assertEqual(len(lockfile.packages), 2)
-        names = [p.name for p in lockfile.packages]
-        self.assertIn("nanvix", names)
-        self.assertIn("zlib", names)
-
-        zlib_pkg = next(p for p in lockfile.packages if p.name == "zlib")
-        self.assertEqual(zlib_pkg.kind, "dependency")
-        self.assertFalse(zlib_pkg.transitive)
-        self.assertEqual(len(zlib_pkg.assets), 1)
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestResolveTransitive(unittest.TestCase):
-    """Resolver discovers transitive deps from a dep's lockfile asset."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "0.1.0"\n'
-            "[dependencies]\n"
-            'libfoo = { tag = "v1.0.0" }\n'
-        )
-
-    def test_transitive_discovery(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(tag="v0.1.0", release_id=100)
-        libfoo_release = _make_release(
-            tag="v1.0.0",
-            commitish="ccc333",
-            release_id=300,
-            assets=[
-                _archive_asset("libfoo-hyperlight-multi-process-128mb.tar.bz2"),
-                _lockfile_asset(),
-            ],
-        )
-        zlib_release = _make_release(
-            tag="v2.0.0",
-            commitish="ddd444",
-            release_id=400,
-            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
-        )
-
-        mock_resolve.side_effect = [sysroot_release, libfoo_release, zlib_release]
-
-        # libfoo's lockfile lists zlib as a dependency
-        inner_lockfile = Lockfile(
-            metadata=LockfileMetadata(
-                manifest_hash="sha256:inner",
-                nanvix_zutil_version="0.2.2",
-            ),
-            packages=[
-                ResolvedPackage(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    kind="dependency",
-                    ref=Ref(kind=RefKind.TAG, value="v2.0.0"),
-                    resolved_tag="v2.0.0",
-                    resolved_commitish="ddd444",
-                    release_id=400,
-                ),
-            ],
-        )
-        # First call (for libfoo) returns inner lockfile,
-        # second call (for zlib) returns None (leaf)
-        mock_download.side_effect = [inner_lockfile, None]
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="libfoo",
-                    repo="nanvix/libfoo",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                )
-            ]
-        )
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
-
-        self.assertEqual(len(lockfile.packages), 3)
-        names = [p.name for p in lockfile.packages]
-        self.assertIn("zlib", names)
-
-        zlib_pkg = next(p for p in lockfile.packages if p.name == "zlib")
-        self.assertTrue(zlib_pkg.transitive)
-        self.assertIn("libfoo", zlib_pkg.required_by)
-
-        libfoo_pkg = next(p for p in lockfile.packages if p.name == "libfoo")
-        self.assertIn("zlib", libfoo_pkg.dependencies)
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestResolveShallow(unittest.TestCase):
-    """shallow=True does not download lockfile assets."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "0.1.0"\n'
-            "[dependencies]\n"
-            'libfoo = { tag = "v1.0.0" }\n'
-        )
-
-    def test_shallow_skips_transitive(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(tag="v0.1.0", release_id=100)
-        libfoo_release = _make_release(tag="v1.0.0", commitish="ccc333", release_id=300)
-        mock_resolve.side_effect = [sysroot_release, libfoo_release]
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="libfoo",
-                    repo="nanvix/libfoo",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                )
-            ]
-        )
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache", shallow=True)
-
-        # download_lockfile_asset should NOT be called
-        mock_download.assert_not_called()
-        # Only sysroot + direct dep
-        self.assertEqual(len(lockfile.packages), 2)
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestCycleDetection(unittest.TestCase):
-    """Resolver detects and rejects dependency cycles."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "0.1.0"\n'
-            "[dependencies]\n"
-            'liba = { tag = "v1.0.0" }\n'
-        )
-
-    def test_cycle_detected(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(tag="v0.1.0", release_id=100)
-        liba_release = _make_release(tag="v1.0.0", commitish="aaa", release_id=200)
-        libb_release = _make_release(tag="v1.0.0", commitish="bbb", release_id=300)
-
-        mock_resolve.side_effect = [sysroot_release, liba_release, libb_release]
-
-        # liba depends on libb
-        liba_lockfile = Lockfile(
-            metadata=LockfileMetadata(
-                manifest_hash="sha256:a", nanvix_zutil_version="0.2.2"
-            ),
-            packages=[
-                ResolvedPackage(
-                    name="libb",
-                    repo="nanvix/libb",
-                    kind="dependency",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                    resolved_tag="v1.0.0",
-                    resolved_commitish="bbb",
-                    release_id=300,
-                ),
-            ],
-        )
-        # libb depends on liba → cycle
-        libb_lockfile = Lockfile(
-            metadata=LockfileMetadata(
-                manifest_hash="sha256:b", nanvix_zutil_version="0.2.2"
-            ),
-            packages=[
-                ResolvedPackage(
-                    name="liba",
-                    repo="nanvix/liba",
-                    kind="dependency",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                    resolved_tag="v1.0.0",
-                    resolved_commitish="aaa",
-                    release_id=200,
-                ),
-            ],
-        )
-        mock_download.side_effect = [liba_lockfile, libb_lockfile]
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="liba",
-                    repo="nanvix/liba",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                )
-            ]
-        )
-
-        with self.assertRaises(SystemExit) as ctx:
-            resolve(manifest, cache_dir=Path.cwd() / "cache")
-        self.assertEqual(ctx.exception.code, 2)
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestVersionConflict(unittest.TestCase):
-    """Resolver detects version conflicts."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "0.1.0"\n'
-            "[dependencies]\n"
-            'libfoo = { tag = "v1.0.0" }\n'
-            'zlib = { tag = "v1.0.0" }\n'
-        )
-
-    def test_conflict_exits_2(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(tag="v0.1.0", release_id=100)
-        zlib_release = _make_release(tag="v1.0.0", commitish="aaa", release_id=200)
-        libfoo_release = _make_release(tag="v1.0.0", commitish="bbb", release_id=300)
-
-        mock_resolve.side_effect = [
-            sysroot_release,
-            zlib_release,
-            libfoo_release,
-        ]
-
-        # libfoo's lockfile lists zlib at a DIFFERENT version
-        inner_lockfile = Lockfile(
-            metadata=LockfileMetadata(
-                manifest_hash="sha256:inner", nanvix_zutil_version="0.2.2"
-            ),
-            packages=[
-                ResolvedPackage(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    kind="dependency",
-                    ref=Ref(kind=RefKind.TAG, value="v2.0.0"),
-                    resolved_tag="v2.0.0",
-                    resolved_commitish="ccc",
-                    release_id=999,
-                ),
-            ],
-        )
-        mock_download.side_effect = [None, inner_lockfile]
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                ),
-                Dependency(
-                    name="libfoo",
-                    repo="nanvix/libfoo",
-                    ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-                ),
-            ]
-        )
-
-        with self.assertRaises(SystemExit) as ctx:
-            resolve(manifest, cache_dir=Path.cwd() / "cache")
-        self.assertEqual(ctx.exception.code, 2)
-
-
-class TestIsStale(unittest.TestCase):
-    """is_stale() returns correct results."""
-
-    def test_not_stale(self) -> None:
-        path = paths.manifest_path()
-        path.write_text('[package]\nname = "test"\n')
-
-        from nanvix_zutil.lockfile import compute_manifest_hash
-
-        h = compute_manifest_hash(path)
-        lockfile = Lockfile(
-            metadata=LockfileMetadata(manifest_hash=h, nanvix_zutil_version="0.2.2"),
-        )
-        self.assertFalse(is_stale(lockfile))
-
-    def test_stale(self) -> None:
-        path = paths.manifest_path()
-        path.write_text('[package]\nname = "test"\n')
-
-        lockfile = Lockfile(
-            metadata=LockfileMetadata(
-                manifest_hash="sha256:old", nanvix_zutil_version="0.2.2"
-            ),
-        )
-        self.assertTrue(is_stale(lockfile))
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-@patch("nanvix_zutil.resolver.github.resolve_release_with_fallback")
-class TestResolveLatestSysroot(unittest.TestCase):
-    """Resolver with 'latest' sysroot and a VERSION dep."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "latest"\n'
-            "[dependencies]\n"
-            'zlib = "1.3.1"\n'
-        )
-
-    def test_latest_sysroot_deferred_suffix(
-        self,
-        mock_fallback: MagicMock,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(
-            tag="v0.12.277", commitish="fa06b88", release_id=100
-        )
-        zlib_release = _make_release(
-            tag="v1.3.1-nanvix-0.12.277",
-            commitish="bbb222",
-            release_id=200,
-            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
-        )
-        # resolve_release is only called for sysroot — zlib is served
-        # from the probe cache, eliminating a duplicate API call.
-        mock_resolve.side_effect = [sysroot_release]
-        # Fallback probe: exact tag found, no fallback needed.
-        mock_fallback.return_value = (zlib_release, None)
-        mock_download.return_value = None
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
-                )
-            ],
-            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
-        )
-
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
-
-        self.assertEqual(len(lockfile.packages), 2)
-        # Verify sysroot resolved correctly
-        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
-        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.277")
-        # Verify dep was suffixed with resolved version
-        zlib_pkg = next(p for p in lockfile.packages if p.name == "zlib")
-        self.assertEqual(zlib_pkg.ref.value, "1.3.1-nanvix-0.12.277")
-        # zlib resolved via probe cache — resolve_release NOT called for it.
-        mock_resolve.assert_called_once_with(
-            "nanvix/nanvix", "latest", gh_token=None, semver=True
-        )
-        # Probe was called with the suffixed tag.
-        mock_fallback.assert_called_once_with(
-            "nanvix/zlib",
-            "1.3.1-nanvix-0.12.277",
-            "1.3.1",
-            gh_token=None,
-        )
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestAssetFiltering(unittest.TestCase):
-    """Resolver filters out non-archive assets and nanvix.lock."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\nnanvix-version = "0.1.0"\n'
-        )
-
-    def test_filters_non_tar_bz2(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        sysroot_release = _make_release(
-            tag="v0.1.0",
-            release_id=100,
-            assets=[
-                _archive_asset("nanvix-hyperlight-multi-process-release-128mb.tar.bz2"),
-                _archive_asset("nanvix-hyperlight-multi-process-release-128mb.tar.gz"),
-                _archive_asset("nanvix-hyperlight-multi-process-release-128mb.zip"),
-                _lockfile_asset(),
+    def test_collects_supported_archives_only(self) -> None:
+        release: dict[str, object] = {
+            "assets": [
                 {
-                    "name": "notes.txt",
-                    "browser_download_url": "https://example.com/notes.txt",
+                    "name": "dep.tar.bz2",
+                    "browser_download_url": "https://example.invalid/dep.tar.bz2",
+                    "id": 1,
                 },
-            ],
-        )
-        mock_resolve.return_value = sysroot_release
-        mock_download.return_value = None
+                {
+                    "name": "nanvix.lock",
+                    "browser_download_url": "https://example.invalid/nanvix.lock",
+                },
+            ]
+        }
+        assets = _collect_assets(release)
+        self.assertEqual([asset.name for asset in assets], ["dep.tar.bz2"])
+        self.assertEqual(assets[0].asset_id, 1)
 
-        manifest = _make_manifest()
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
-
-        sysroot_pkg = lockfile.packages[0]
-        # .tar.bz2, .tar.gz, and .zip are collected; .txt and nanvix.lock are not.
-        self.assertEqual(len(sysroot_pkg.assets), 3)
-        names = {a.name for a in sysroot_pkg.assets}
-        self.assertIn("nanvix-hyperlight-multi-process-release-128mb.tar.bz2", names)
-        self.assertIn("nanvix-hyperlight-multi-process-release-128mb.tar.gz", names)
-        self.assertIn("nanvix-hyperlight-multi-process-release-128mb.zip", names)
-
-
-class TestUnsuffixDeps(unittest.TestCase):
-    """Tests for _unsuffix_deps()."""
-
-    def test_strips_suffix(self) -> None:
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.VERSION, value="1.3.1-nanvix-0.12.337"),
-        )
-        result = _unsuffix_deps([dep])
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].ref.value, "1.3.1")
-
-    def test_preserves_non_version_refs(self) -> None:
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.3.1-nanvix-0.12.337"),
-        )
-        result = _unsuffix_deps([dep])
-        self.assertEqual(result[0].ref.value, "v1.3.1-nanvix-0.12.337")
-
-    def test_preserves_unsuffixed(self) -> None:
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
-        )
-        result = _unsuffix_deps([dep])
-        self.assertEqual(result[0].ref.value, "1.3.1")
+    def test_cycle_is_rejected(self) -> None:
+        packages = [
+            ResolvedPackage(
+                name="a",
+                repo="nanvix/a",
+                kind="dependency",
+                ref=Ref(RefKind.VERSION, "1-nanvix-0.1.0-sdk.1"),
+                resolved_tag="1-nanvix-0.1.0-sdk.1",
+                resolved_commitish="a" * 40,
+                release_id=1,
+                dependencies=["b"],
+            ),
+            ResolvedPackage(
+                name="b",
+                repo="nanvix/b",
+                kind="dependency",
+                ref=Ref(RefKind.VERSION, "1-nanvix-0.1.0-sdk.1"),
+                resolved_tag="1-nanvix-0.1.0-sdk.1",
+                resolved_commitish="b" * 40,
+                release_id=2,
+                dependencies=["a"],
+            ),
+        ]
+        with self.assertRaises(SystemExit) as context:
+            _detect_cycles(packages)
+        self.assertEqual(context.exception.code, 2)
 
 
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-@patch("nanvix_zutil.resolver.github.resolve_release_with_fallback")
-class TestResolveVersionFallback(unittest.TestCase):
-    """Tests for fallback version downgrade in the resolver."""
+class TestSdkLockStaleness(unittest.TestCase):
+    """Manifest and immutable SDK coordinates determine staleness."""
 
     def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "latest"\n'
-            "[dependencies]\n"
-            'zlib = "1.3.1"\n'
+        paths.manifest_path().write_text(MINIMAL_MANIFEST)
+        self.lock = Lockfile(
+            LockfileMetadata(
+                manifest_hash=compute_manifest_hash(paths.manifest_path()),
+                nanvix_zutil_version="0.15.3",
+                sdk=make_sdk_provenance(),
+            )
         )
 
-    def test_fallback_downgrades_sysroot(
-        self,
-        mock_fallback: MagicMock,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        """Sysroot is downgraded when dep 404s and fallback finds older version."""
-        latest_sysroot = _make_release(
-            tag="v0.12.337", commitish="aaa111", release_id=100
-        )
-        downgraded_sysroot = _make_release(
-            tag="v0.12.291", commitish="bbb222", release_id=101
-        )
-        zlib_release = _make_release(
-            tag="v1.3.1-nanvix-0.12.291",
-            commitish="ccc333",
-            release_id=200,
-            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
-        )
-        # resolve_release: (1) sysroot@latest, (2) sysroot@0.12.291, (3) zlib
-        mock_resolve.side_effect = [latest_sysroot, downgraded_sysroot, zlib_release]
-        # Fallback probe: zlib 404 → fallback to 0.12.291
-        mock_fallback.return_value = (zlib_release, "0.12.291")
-        mock_download.return_value = None
+    def test_matching_lock_is_current(self) -> None:
+        self.assertFalse(is_stale(self.lock))
 
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
-                )
-            ],
-            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
-        )
+    def test_manifest_change_is_stale(self) -> None:
+        paths.manifest_path().write_text(MINIMAL_MANIFEST + "\n")
+        self.assertTrue(is_stale(self.lock))
 
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
+    def test_sdk_revision_change_is_stale(self) -> None:
+        stale = make_sdk_provenance()
+        object.__setattr__(stale, "sdk_version", "v0.1.0-sdk.2")
+        self.lock.metadata.sdk = stale
+        self.assertTrue(is_stale(self.lock))
 
-        # Sysroot should be downgraded to 0.12.291
-        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
-        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.291")
-        # zlib should use the downgraded suffix
-        zlib_pkg = next(p for p in lockfile.packages if p.name == "zlib")
-        self.assertEqual(zlib_pkg.ref.value, "1.3.1-nanvix-0.12.291")
-
-    def test_fallback_uses_minimum_across_deps(
-        self,
-        mock_fallback: MagicMock,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        """When multiple deps fall back, sysroot uses the minimum version."""
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "latest"\n'
-            "[dependencies]\n"
-            'zlib = "1.3.1"\n'
-            'sqlite = "3.49.0"\n'
-        )
-        latest_sysroot = _make_release(
-            tag="v0.12.337", commitish="aaa111", release_id=100
-        )
-        downgraded_sysroot = _make_release(
-            tag="v0.12.291", commitish="bbb222", release_id=101
-        )
-        zlib_release = _make_release(
-            tag="v1.3.1-nanvix-0.12.291",
-            commitish="ccc333",
-            release_id=200,
-        )
-        sqlite_release = _make_release(
-            tag="v3.49.0-nanvix-0.12.291",
-            commitish="ddd444",
-            release_id=300,
-        )
-        # resolve_release: (1) sysroot@latest, (2) sysroot@0.12.291,
-        # (3) zlib, (4) sqlite
-        mock_resolve.side_effect = [
-            latest_sysroot,
-            downgraded_sysroot,
-            zlib_release,
-            sqlite_release,
-        ]
-        # Fallback probe: zlib → 0.12.291, sqlite → 0.12.320
-        mock_fallback.side_effect = [
-            (zlib_release, "0.12.291"),
-            (sqlite_release, "0.12.320"),
-        ]
-        mock_download.return_value = None
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
-                ),
-                Dependency(
-                    name="sqlite",
-                    repo="nanvix/sqlite",
-                    ref=Ref(kind=RefKind.VERSION, value="3.49.0"),
-                ),
-            ],
-            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
-        )
-
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
-
-        # Sysroot should use the minimum: 0.12.291
-        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
-        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.291")
-
-    def test_no_fallback_when_all_deps_available(
-        self,
-        mock_fallback: MagicMock,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        """No warning when all deps resolve on first try."""
-        sysroot_release = _make_release(
-            tag="v0.12.337", commitish="aaa111", release_id=100
-        )
-        zlib_release = _make_release(
-            tag="v1.3.1-nanvix-0.12.337",
-            commitish="ccc333",
-            release_id=200,
-            assets=[_archive_asset("zlib-hyperlight-multi-process-128mb.tar.bz2")],
-        )
-        # resolve_release only called for sysroot — zlib served from
-        # probe cache.
-        mock_resolve.side_effect = [sysroot_release]
-        # Fallback probe: exact tag found, no fallback.
-        mock_fallback.return_value = (zlib_release, None)
-        mock_download.return_value = None
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    ref=Ref(kind=RefKind.VERSION, value="1.3.1"),
-                )
-            ],
-            sysroot_ref=Ref(kind=RefKind.TAG, value="latest"),
-        )
-
-        lockfile = resolve(manifest, cache_dir=Path.cwd() / "cache")
-
-        sysroot_pkg = next(p for p in lockfile.packages if p.name == "nanvix")
-        self.assertEqual(sysroot_pkg.resolved_tag, "v0.12.337")
-
-
-@patch("nanvix_zutil.resolver.download_lockfile_asset")
-@patch("nanvix_zutil.resolver.github.resolve_release")
-class TestNoFallbackWhenPinned(unittest.TestCase):
-    """Pinned sysroot preserves hard-fail behavior."""
-
-    def setUp(self) -> None:
-        self._manifest_path = paths.manifest_path()
-        self._manifest_path.write_text(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "0.12.337"\n'
-            "[dependencies]\n"
-            'zlib = "1.3.1"\n'
-        )
-
-    def test_no_fallback_when_pinned(
-        self,
-        mock_resolve: MagicMock,
-        mock_download: MagicMock,
-    ) -> None:
-        """Pinned version hard-fails on 404 (no fallback)."""
-        sysroot_release = _make_release(
-            tag="v0.12.337", commitish="aaa111", release_id=100
-        )
-        mock_resolve.side_effect = [sysroot_release, SystemExit(3)]
-        mock_download.return_value = None
-
-        manifest = _make_manifest(
-            deps=[
-                Dependency(
-                    name="zlib",
-                    repo="nanvix/zlib",
-                    ref=Ref(
-                        kind=RefKind.VERSION,
-                        value="1.3.1-nanvix-0.12.337",
-                    ),
-                )
-            ],
-            sysroot_ref=Ref(kind=RefKind.TAG, value="0.12.337"),
-        )
-
-        with self.assertRaises(SystemExit) as ctx:
-            resolve(manifest, cache_dir=Path.cwd() / "cache")
-        self.assertEqual(ctx.exception.code, 3)
+    def test_shallow_mode_change_is_stale(self) -> None:
+        self.assertTrue(is_stale(self.lock, shallow=True))
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -8,6 +8,7 @@ import os
 import subprocess as sp
 import sys
 import unittest
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -32,13 +33,76 @@ from nanvix_zutil.lockfile import (
     ResolvedAsset,
     ResolvedPackage,
 )
+from nanvix_zutil.manifest import Manifest
 from nanvix_zutil.resolver import BlockedResolution
 from nanvix_zutil.script import ZScript
 from tests.testutils import (
-    MANIFEST_LATEST_WITH_DEPS,
     MANIFEST_WITH_DEPS,
+    make_toml,
+    make_sdk_provenance,
     write_manifest,
 )
+
+_default_resolve_stop: Callable[[], None]
+
+
+def _default_resolution(
+    manifest: Manifest,
+    *_args: object,
+    **_kwargs: object,
+) -> Lockfile:
+    """Return exact SDK releases for a script test manifest."""
+    runtime = str(manifest.sysroot_ref.value).removeprefix("v")
+    packages = [
+        ResolvedPackage(
+            name="nanvix",
+            repo="nanvix/nanvix",
+            kind="sysroot",
+            ref=manifest.sysroot_ref,
+            resolved_tag=f"v{runtime}",
+            resolved_commitish="a" * 40,
+            release_id=1,
+        )
+    ]
+    for index, dep in enumerate(manifest.dependencies, start=2):
+        packages.append(
+            ResolvedPackage(
+                name=dep.name,
+                repo=dep.repo,
+                kind="dependency",
+                ref=dep.ref,
+                resolved_tag=str(dep.ref.value),
+                resolved_commitish="b" * 40,
+                release_id=index,
+                assets=[
+                    ResolvedAsset(
+                        name=f"{dep.name}-microvm-standalone-256mb.tar.bz2",
+                        url=f"https://example.invalid/{dep.name}.tar.bz2",
+                    )
+                ],
+            )
+        )
+    return Lockfile(
+        LockfileMetadata(
+            manifest_hash="sha256:test",
+            nanvix_zutil_version="0.15.3",
+            sdk=make_sdk_provenance(runtime),
+        ),
+        packages,
+    )
+
+
+def setUpModule() -> None:
+    """Prevent routine script tests from accessing SDK release services."""
+    global _default_resolve_stop
+    patcher = patch("nanvix_zutil.script.resolve", side_effect=_default_resolution)
+    patcher.start()
+    _default_resolve_stop = patcher.stop
+
+
+def tearDownModule() -> None:
+    """Stop the module-wide SDK resolver patch."""
+    _default_resolve_stop()
 
 
 class TestZScriptInit(unittest.TestCase):
@@ -128,17 +192,11 @@ class TestZScriptAutoSetup(unittest.TestCase):
         fake_sysroot.path = Path("/fake/sysroot")
 
         fake_buildroot = MagicMock()
-        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.1.0"}
-
         with (
             patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
             patch(
                 "nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot
             ) as mock_create,
-            patch(
-                "nanvix_zutil.script.resolve_release_with_fallback",
-                return_value=(fake_release, "0.1.0"),
-            ),
         ):
             script = ZScript()
             script.setup()
@@ -175,58 +233,6 @@ class TestZScriptAutoSetup(unittest.TestCase):
 
         config_file = paths.nanvix_root() / "env.json"
         self.assertTrue(config_file.exists())
-
-
-class TestZScriptSetupLatestSysroot(unittest.TestCase):
-    """setup() with nanvix-version = "latest" suffixes deps correctly."""
-
-    def setUp(self) -> None:
-        write_manifest(MANIFEST_LATEST_WITH_DEPS)
-        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
-            os.environ.pop(key, None)
-
-    def test_setup_latest_sysroot_suffixes_deps(self) -> None:
-        """setup() suffixes VERSION deps with the resolved sysroot tag."""
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = Path("/fake/sysroot")
-        fake_sysroot.tag = "v0.12.277"
-
-        fake_buildroot = MagicMock()
-        fake_release: dict[str, object] = {"tag_name": "1.3.1-nanvix-0.12.277"}
-
-        with (
-            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
-            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
-            patch(
-                "nanvix_zutil.script.resolve_release_with_fallback",
-                return_value=(fake_release, "0.12.277"),
-            ),
-        ):
-            script = ZScript()
-            script.setup()
-
-        # install_dep should be called with the suffixed ref value.
-        fake_buildroot.install_dep.assert_called_once()
-        _, kwargs = fake_buildroot.install_dep.call_args
-        self.assertEqual(kwargs["dep"].ref.value, "1.3.1-nanvix-0.12.277")
-
-    def test_setup_latest_sysroot_empty_tag_fatal(self) -> None:
-        """setup() exits fatally when sysroot tag is empty (upgrade path)."""
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = Path("/fake/sysroot")
-        fake_sysroot.tag = ""
-
-        with (
-            patch(
-                "nanvix_zutil.script.Sysroot.download",
-                return_value=fake_sysroot,
-            ),
-            self.assertRaises(SystemExit) as ctx,
-        ):
-            script = ZScript()
-            script.setup()
-
-        self.assertEqual(ctx.exception.code, 3)
 
 
 class TestZScriptSyncConfigs(unittest.TestCase):
@@ -512,7 +518,11 @@ class TestSdkDockerSelection(unittest.TestCase):
             ],
         )
         lock = Lockfile(
-            LockfileMetadata("sha256:x", "0.15.0"),
+            LockfileMetadata(
+                "sha256:x",
+                "0.15.0",
+                sdk=make_sdk_provenance("0.20.0"),
+            ),
             packages=[package],
         )
         fake_buildroot = MagicMock()
@@ -526,18 +536,14 @@ class TestSdkDockerSelection(unittest.TestCase):
                 return_value=fake_buildroot,
             ),
             patch("nanvix_zutil.script.resolve", return_value=lock) as resolver,
-            patch("nanvix_zutil.script.resolve_release_with_fallback") as fallback,
         ):
             script = ZScript()
-            used_fallback = script.setup()
-        self.assertFalse(used_fallback)
+            script.setup()
         resolver.assert_called_once()
-        self.assertTrue(resolver.call_args.kwargs["strict"])
         self.assertEqual(
             resolver.call_args.kwargs["verify_sdk_image"],
             sys.platform != "win32",
         )
-        fallback.assert_not_called()
         fake_buildroot.install_dep.assert_called_once()
         release = fake_buildroot.install_dep.call_args.kwargs["_release"]
         self.assertEqual(
@@ -566,13 +572,11 @@ class TestSdkDockerSelection(unittest.TestCase):
             ),
             patch("nanvix_zutil.script.resolve", return_value=blocked),
             patch("nanvix_zutil.script.Buildroot.create") as create,
-            patch("nanvix_zutil.script.resolve_release_with_fallback") as fallback,
             self.assertRaises(SystemExit) as context,
         ):
             ZScript().setup()
         self.assertEqual(context.exception.code, EXIT_MISSING_DEP)
         create.assert_not_called()
-        fallback.assert_not_called()
 
 
 class TestHelpersRun(unittest.TestCase):
@@ -894,8 +898,6 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
             os.environ["NANVIX_DEPLOYMENT_MODE"] = mode
             script = ZScript()
             files = script.sysroot_required_files()
-            self.assertIn("lib/libposix.a", files, f"missing in {mode}")
-            self.assertIn("lib/user.ld", files, f"missing in {mode}")
             self.assertIn(nanvixd, files, f"missing in {mode}")
             self.assertIn("bin/kernel.elf", files, f"missing in {mode}")
             self.assertIn(mkramfs, files, f"missing in {mode}")
@@ -1064,192 +1066,6 @@ class TestZScriptCleanWindows(unittest.TestCase):
         script.clean()  # Should not raise.
 
 
-class TestZScriptSetupFallbackReporting(unittest.TestCase):
-    """setup() reports fallback state correctly."""
-
-    def setUp(self) -> None:
-        write_manifest(MANIFEST_WITH_DEPS)
-        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
-            os.environ.pop(key, None)
-
-    def test_setup_returns_false_when_no_fallback(self) -> None:
-        """setup() returns False when all deps resolve exactly."""
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = Path("/fake/sysroot")
-
-        fake_buildroot = MagicMock()
-        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.1.0"}
-
-        with (
-            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
-            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
-            patch(
-                "nanvix_zutil.script.resolve_release_with_fallback",
-                return_value=(fake_release, None),  # None = no fallback
-            ),
-        ):
-            script = ZScript()
-            result = script.setup()
-
-        self.assertFalse(result)
-
-    def test_setup_returns_true_when_fallback_used(self) -> None:
-        """setup() returns True when a dep falls back to a different version."""
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = Path("/fake/sysroot")
-
-        fake_buildroot = MagicMock()
-        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.0.9"}
-
-        with (
-            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
-            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
-            patch(
-                "nanvix_zutil.script.resolve_release_with_fallback",
-                return_value=(fake_release, "0.0.9"),  # non-None = fallback used
-            ),
-        ):
-            script = ZScript()
-            result = script.setup()
-
-        self.assertTrue(result)
-
-    def test_setup_no_deps_returns_false(self) -> None:
-        """setup() returns False when there are no dependencies."""
-        write_manifest()  # default manifest, no deps
-
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = Path("/fake/sysroot")
-
-        with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
-            script = ZScript()
-            result = script.setup()
-
-        self.assertFalse(result)
-
-    def test_setup_fallback_logs_warning(self) -> None:
-        """setup() logs at warning level when fallback is used."""
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = Path("/fake/sysroot")
-
-        fake_buildroot = MagicMock()
-        fake_release: dict[str, object] = {"tag_name": "1.0-nanvix-0.0.9"}
-
-        with (
-            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
-            patch("nanvix_zutil.script.Buildroot.create", return_value=fake_buildroot),
-            patch(
-                "nanvix_zutil.script.resolve_release_with_fallback",
-                return_value=(fake_release, "0.0.9"),
-            ),
-            patch("nanvix_zutil.script.log") as mock_log,
-        ):
-            script = ZScript()
-            script.setup()
-
-        # Verify warning was called (not info) for fallback message.
-        warning_calls = [
-            call
-            for call in mock_log.warning.call_args_list
-            if "fallback" in str(call).lower()
-        ]
-        self.assertTrue(warning_calls, "Expected a warning log for fallback")
-
-        # Verify info was NOT called for fallback (regression guard).
-        info_calls = [
-            call
-            for call in mock_log.info.call_args_list
-            if "fallback" in str(call).lower()
-        ]
-        self.assertFalse(info_calls, "Fallback should use warning, not info")
-
-
-class TestZScriptMainDegradedExit(unittest.TestCase):
-    """main() exits with EXIT_DEGRADED_SETUP when setup uses fallback."""
-
-    def setUp(self) -> None:
-        write_manifest(MANIFEST_WITH_DEPS)
-        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
-            os.environ.pop(key, None)
-
-        # script.py calls helpers.check_docker (imported into the script
-        # module namespace). Patch it to a no-op so these tests don't try to
-        # actually pull a Docker image.
-        p = patch("nanvix_zutil.script.check_docker", return_value=None)
-        p.start()
-        self.addCleanup(p.stop)
-
-    def test_exit_degraded_setup_value(self) -> None:
-        """EXIT_DEGRADED_SETUP has the expected value of 7."""
-        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
-
-        self.assertEqual(EXIT_DEGRADED_SETUP, 7)
-
-    def test_main_exits_7_on_fallback_setup(self) -> None:
-        """main() with setup subcommand exits 7 when fallback was used."""
-        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
-
-        def _setup_with_fallback(self_inner: ZScript) -> bool:
-            self_inner._used_fallback = True  # pyright: ignore[reportPrivateUsage]
-            return True
-
-        with (
-            patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
-            patch.object(ZScript, "setup", _setup_with_fallback),
-            self.assertRaises(SystemExit) as ctx,
-        ):
-            ZScript.main()
-
-        self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
-
-    def test_main_exits_7_on_return_only_fallback_setup(self) -> None:
-        """main() honors setup() returning True without touching private state."""
-        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
-
-        with (
-            patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
-            patch.object(ZScript, "setup", return_value=True),
-            self.assertRaises(SystemExit) as ctx,
-        ):
-            ZScript.main()
-
-        self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
-
-    def test_main_exits_0_on_clean_setup(self) -> None:
-        """main() with setup subcommand completes normally when no fallback."""
-        with (
-            patch("sys.argv", ["z.py", "setup", "--with-docker", "test/image:tag"]),
-            patch.object(ZScript, "setup", return_value=False),
-            patch("nanvix_zutil.script.log") as mock_log,
-        ):
-            # Should not raise SystemExit.
-            ZScript.main()
-
-        # Verify success log was emitted.
-        success_calls = [
-            call
-            for call in mock_log.success.call_args_list
-            if "complete" in str(call).lower()
-        ]
-        self.assertTrue(success_calls, "Expected a success log on clean setup")
-
-    def test_main_fatal_exits_with_degraded_code(self) -> None:
-        """main() exits with EXIT_DEGRADED_SETUP when setup() returns True."""
-        from nanvix_zutil.exitcodes import EXIT_DEGRADED_SETUP
-
-        with (
-            patch(
-                "sys.argv",
-                ["z.py", "setup", "--with-docker", "test/image:tag"],
-            ),
-            patch.object(ZScript, "setup", return_value=True),
-            self.assertRaises(SystemExit) as ctx,
-        ):
-            ZScript.main()
-
-        self.assertEqual(ctx.exception.code, EXIT_DEGRADED_SETUP)
-
-
 class TestZScriptSysrootDriftCheck(unittest.TestCase):
     """Preflight check fatals on env.json / nanvix.toml sysroot drift."""
 
@@ -1261,40 +1077,13 @@ class TestZScriptSysrootDriftCheck(unittest.TestCase):
         """Non-setup subcommand fatals when cached sysroot_tag != pinned version."""
         import json
 
-        write_manifest(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "0.14.0"\n'
-        )
+        write_manifest(make_toml(nanvix_version="0.14.0"))
         (paths.nanvix_root() / "env.json").write_text(
             json.dumps({"sysroot_tag": "v0.15.0"})
         )
 
         with (
             patch("sys.argv", ["z.py", "lock", "--check"]),
-            self.assertRaises(SystemExit) as ctx,
-        ):
-            ZScript.main()
-
-        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-
-    def test_main_exits_missing_dep_on_latest_sysroot_drift(self) -> None:
-        """Non-setup subcommand fatals when pinned latest resolves != cached sysroot_tag."""
-        import json
-
-        write_manifest(
-            '[package]\nname = "test"\nversion = "0.1.0"\n'
-            'nanvix-version = "latest"\n'
-        )
-        (paths.nanvix_root() / "env.json").write_text(
-            json.dumps({"sysroot_tag": "v0.14.0"})
-        )
-
-        with (
-            patch("sys.argv", ["z.py", "lock", "--check"]),
-            patch(
-                "nanvix_zutil.script.resolve_release",
-                return_value={"tag_name": "v0.15.0"},
-            ),
             self.assertRaises(SystemExit) as ctx,
         ):
             ZScript.main()
@@ -1340,30 +1129,6 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
             script.setup()
 
         fake_sysroot.overlay_local_nanvix.assert_not_called()
-
-    def test_setup_local_deps_skips_github(self) -> None:
-        """setup() skips GitHub download for deps found locally."""
-        write_manifest(MANIFEST_WITH_DEPS)
-
-        local_dir = Path.cwd() / "local-nanvix"
-        (local_dir / "deps" / "zlib" / "lib").mkdir(parents=True)
-        (local_dir / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"local-zlib")
-
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = Path("/fake/sysroot")
-        fake_sysroot.tag = "v0.1.0"
-
-        with (
-            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
-            patch("nanvix_zutil.script.resolve_release_with_fallback") as mock_resolve,
-        ):
-            script = ZScript()
-            script._with_nanvix_path = str(local_dir)
-            script.setup()
-
-        # The dependency was satisfied locally so GitHub resolve should not
-        # have been called.
-        mock_resolve.assert_not_called()
 
 
 class TestZScriptSetupLocalSysroot(unittest.TestCase):
@@ -2120,7 +1885,7 @@ class TestOfflineMode(unittest.TestCase):
                 "nanvix_zutil.script.Sysroot.from_local",
                 return_value=fake_sysroot,
             ),
-            patch("nanvix_zutil.script.resolve_release") as mock_resolve,
+            patch("nanvix_zutil.script.resolve") as mock_resolve,
         ):
             script.setup()
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -15,7 +15,6 @@ from nanvix_zutil.sdk import (
     SDK_LABEL_PREFIX,
     SdkValidationError,
     _release_asset,
-    consumer_release_tag,
     sdk_consumer_release_tag,
     validate_sdk_release,
     verify_sdk_metadata,
@@ -234,16 +233,6 @@ class TestSdkReleaseNames(unittest.TestCase):
         second = sdk_consumer_release_tag("1.3.1", "v0.20.0-sdk.2")
         self.assertEqual(first, "1.3.1-nanvix-0.20.0-sdk.1")
         self.assertNotEqual(first, second)
-
-    def test_legacy_coordinate_preserved(self) -> None:
-        self.assertEqual(
-            consumer_release_tag("1.3.1", "0.20.0"),
-            "1.3.1-nanvix-0.20.0",
-        )
-
-    def test_runtime_skew_rejected(self) -> None:
-        with self.assertRaises(SdkValidationError):
-            consumer_release_tag("1.3.1", "0.20.1", "v0.20.0-sdk.1")
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_manifest_lock.py
+++ b/tests/test_sdk_manifest_lock.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import unittest
+from dataclasses import replace
 
 from nanvix_zutil import paths
 from nanvix_zutil.lockfile import (
@@ -20,7 +21,7 @@ from tests.test_sdk import make_sdk_contract
 
 
 class TestSdkManifest(unittest.TestCase):
-    """Preferred, derived, legacy, and malformed SDK pin forms."""
+    """Canonical SDK pins are mandatory."""
 
     def test_immutable_sdk_pin_and_exact_dependency_tag(self) -> None:
         digest = f"sha256:{'a' * 64}"
@@ -53,7 +54,7 @@ class TestSdkManifest(unittest.TestCase):
             "1.3.1-nanvix-0.20.0-sdk.1",
         )
 
-    def test_early_spelling_remains_readable(self) -> None:
+    def test_transitional_spelling_is_rejected(self) -> None:
         digest = f"sha256:{'a' * 64}"
         paths.manifest_path().write_text(
             "[package]\n"
@@ -67,18 +68,20 @@ class TestSdkManifest(unittest.TestCase):
             'image = "ghcr.io/nanvix/nanvix-sdk-c-clang"\n'
             f'digest = "{digest}"\n'
         )
-        pin = load_manifest().toolchain.sdk
-        assert pin is not None
-        self.assertEqual(pin.image_ref, f"{pin.image}@{digest}")
+        with self.assertRaises(SystemExit) as context:
+            load_manifest()
+        self.assertEqual(context.exception.code, 2)
 
-    def test_missing_toolchain_is_legacy(self) -> None:
+    def test_missing_toolchain_is_rejected(self) -> None:
         paths.manifest_path().write_text(
             "[package]\n"
             'name = "test"\n'
             'version = "1.0.0"\n'
             'nanvix-version = "0.20.0"\n'
         )
-        self.assertEqual(load_manifest().toolchain.kind, ToolchainKind.LEGACY)
+        with self.assertRaises(SystemExit) as context:
+            load_manifest()
+        self.assertEqual(context.exception.code, 2)
 
     def test_sdk_runtime_skew_fails(self) -> None:
         paths.manifest_path().write_text(
@@ -87,10 +90,11 @@ class TestSdkManifest(unittest.TestCase):
             'version = "1.0.0"\n'
             'nanvix-version = "0.20.1"\n'
             "\n[toolchain]\n"
-            'type = "sdk"\n'
-            'version = "v0.20.0-sdk.1"\n'
+            'kind = "nanvix-sdk"\n'
+            'sdk-version = "v0.20.0-sdk.1"\n'
             'provider = "c-clang"\n'
-            f'image = "ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:{"a" * 64}"\n'
+            'sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"\n'
+            f'sdk-digest = "sha256:{"a" * 64}"\n'
         )
         with self.assertRaises(SystemExit) as context:
             load_manifest()
@@ -98,7 +102,7 @@ class TestSdkManifest(unittest.TestCase):
 
 
 class TestSdkLockfile(unittest.TestCase):
-    """SDK provenance is optional, round-trippable, and shallow-aware."""
+    """SDK provenance is required, round-trippable, and shallow-aware."""
 
     def test_provenance_round_trip(self) -> None:
         provenance = validate_sdk_release(make_sdk_contract()).provenance()
@@ -116,16 +120,31 @@ class TestSdkLockfile(unittest.TestCase):
         self.assertEqual(restored.metadata.sdk, provenance)
         self.assertTrue(restored.metadata.shallow)
 
-    def test_legacy_lock_remains_readable(self) -> None:
+    def test_lock_without_sdk_is_rejected(self) -> None:
         path = paths.nanvix_root() / "nanvix.lock"
         path.write_text(
             "[metadata]\n"
             'manifest-hash = "sha256:x"\n'
             'nanvix-zutil-version = "0.14.0"\n'
         )
-        restored = read_lockfile(path)
-        self.assertIsNone(restored.metadata.sdk)
-        self.assertFalse(restored.metadata.shallow)
+        with self.assertRaises(SystemExit) as context:
+            read_lockfile(path)
+        self.assertEqual(context.exception.code, 2)
+
+    def test_incomplete_sdk_lock_is_not_written(self) -> None:
+        provenance = validate_sdk_release(make_sdk_contract()).provenance()
+        lock = Lockfile(
+            LockfileMetadata(
+                manifest_hash="sha256:manifest",
+                nanvix_zutil_version="0.15.3",
+                sdk=replace(provenance, target={}),
+            )
+        )
+        path = paths.nanvix_root() / "nanvix.lock"
+        with self.assertRaises(SystemExit) as context:
+            write_lockfile(lock, path)
+        self.assertEqual(context.exception.code, 2)
+        self.assertFalse(path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_resolver.py
+++ b/tests/test_sdk_resolver.py
@@ -82,7 +82,6 @@ class TestStrictSdkResolver(unittest.TestCase):
         result = resolve(
             self.manifest,
             cache_dir=Path.cwd() / "cache",
-            strict=True,
         )
         self.assertIsInstance(result, BlockedResolution)
         assert isinstance(result, BlockedResolution)
@@ -115,7 +114,6 @@ class TestStrictSdkResolver(unittest.TestCase):
         result = resolve(
             self.manifest,
             cache_dir=Path.cwd() / "cache",
-            strict=True,
             shallow=True,
         )
         self.assertNotIsInstance(result, BlockedResolution)
@@ -151,7 +149,6 @@ class TestStrictSdkResolver(unittest.TestCase):
         result = resolve(
             self.manifest,
             cache_dir=Path.cwd() / "cache",
-            strict=True,
         )
         self.assertIsInstance(result, BlockedResolution)
         assert isinstance(result, BlockedResolution)
@@ -173,7 +170,6 @@ class TestStrictSdkResolver(unittest.TestCase):
                 resolve(
                     self.manifest,
                     cache_dir=Path.cwd() / "cache",
-                    strict=True,
                 )
         self.assertEqual(context.exception.code, 2)
 
@@ -196,7 +192,6 @@ class TestStrictSdkResolver(unittest.TestCase):
                 resolve(
                     self.manifest,
                     cache_dir=Path.cwd() / "cache",
-                    strict=True,
                 )
         self.assertEqual(context.exception.code, 2)
 
@@ -241,7 +236,6 @@ class TestStrictSdkResolver(unittest.TestCase):
                 resolve(
                     self.manifest,
                     cache_dir=Path.cwd() / "cache",
-                    strict=True,
                 )
         self.assertEqual(context.exception.code, 2)
 

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -16,7 +16,6 @@ import os
 import stat
 import subprocess
 import sys
-import tomllib
 import unittest
 import zipfile
 from pathlib import Path
@@ -84,8 +83,6 @@ def make_consumer(root: Path, *, newline: str = "\n") -> Path:
             f"jobs:{newline}"
             f"  ci:{newline}"
             f"    with:{newline}"
-            f"      docker-image: >-{newline}"
-            f"        {_OLD_IMAGE}{newline}"
             f"      caller-event-name: pull_request{newline}"
         ).encode()
     )
@@ -171,7 +168,6 @@ class TestUpdateNanvix(unittest.TestCase):
         self.assertEqual(
             result.changed_files,
             (
-                ".github/workflows/nanvix-ci.yml",
                 ".nanvix/nanvix.lock",
                 ".nanvix/nanvix.toml",
             ),
@@ -182,7 +178,6 @@ class TestUpdateNanvix(unittest.TestCase):
         self.assertNotIn("NANVIX_SDK_IMAGE", (root / ".nanvix/z.py").read_text())
         workflow = (root / ".github/workflows/nanvix-ci.yml").read_text()
         self.assertNotIn("docker-image:", workflow)
-        self.assertNotIn(_OLD_IMAGE, workflow)
         self.assertIn("caller-event-name: pull_request", workflow)
         self.assertEqual(
             read_lockfile(root / ".nanvix/nanvix.lock").metadata.sdk,
@@ -218,35 +213,26 @@ class TestUpdateNanvix(unittest.TestCase):
             self.assertIn(b"\r\n", content)
             self.assertNotIn(b"\n", content.replace(b"\r\n", b""))
 
-    def test_transitional_marker_is_optional_and_checked(self) -> None:
+    def test_unrelated_script_is_not_modified(self) -> None:
         root = Path.cwd()
         contract = make_consumer(root)
         marker = root / ".nanvix/z.py"
         marker.write_text(
             f'NANVIX_SDK_IMAGE = "{_OLD_IMAGE}"\n' "from nanvix_zutil import ZScript\n"
         )
+        original = marker.read_bytes()
         result, _code = update_nanvix._run(nanvix_args(contract.name))
-        self.assertIn(".nanvix/z.py", result.changed_files)
-        self.assertIn(self.contract.image.ref, marker.read_text())
+        self.assertNotIn(".nanvix/z.py", result.changed_files)
+        self.assertEqual(marker.read_bytes(), original)
 
-    def test_workflow_call_input_definition_is_preserved(self) -> None:
-        """Only caller values, not reusable-workflow input schemas, are removed."""
-        workflow = (
-            "on:\n"
-            "  workflow_call:\n"
-            "    inputs:\n"
-            "      docker-image:\n"
-            "        type: string\n"
-            "jobs:\n"
-            "  ci:\n"
-            "    with:\n"
-            f"      docker-image: {_OLD_IMAGE}\n"
-        )
-        candidate = update_nanvix._remove_docker_image_inputs(workflow)
-        self.assertIsNotNone(candidate)
-        assert candidate is not None
-        self.assertIn("      docker-image:\n        type: string\n", candidate)
-        self.assertNotIn(_OLD_IMAGE, candidate)
+    def test_workflow_is_outside_sdk_revision_update(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        workflow = root / ".github/workflows/nanvix-ci.yml"
+        original = workflow.read_bytes()
+        result, _code = update_nanvix._run(nanvix_args(contract.name))
+        self.assertNotIn(".github/workflows/nanvix-ci.yml", result.changed_files)
+        self.assertEqual(workflow.read_bytes(), original)
 
     def test_dependencies_are_retargeted_before_strict_resolution(self) -> None:
         root = Path.cwd()
@@ -261,13 +247,20 @@ class TestUpdateNanvix(unittest.TestCase):
             candidate.dependencies[0].ref.value,
             "1.3.1-nanvix-0.20.0-sdk.1",
         )
-        self.assertTrue(self.resolve.call_args.kwargs["strict"])
+        self.assertNotIn("strict", self.resolve.call_args.kwargs)
+        current_pin = update_nanvix.load_manifest(manifest_path).toolchain.sdk
         self.assertEqual(
             self.resolve.call_args.kwargs["manifest_content"],
-            update_nanvix._update_manifest(manifest_path.read_bytes(), self.contract),
+            update_nanvix._update_manifest(
+                manifest_path.read_bytes(),
+                self.contract,
+                current_pin,
+            ),
         )
 
-    def test_nested_transitional_toolchain_is_fully_canonicalized(self) -> None:
+    def test_nested_transitional_toolchain_is_rejected(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
         old = (
             "[package]\n"
             'name = "test"\n'
@@ -282,13 +275,10 @@ class TestUpdateNanvix(unittest.TestCase):
             "\n[dependencies]\n"
             'zlib = "1.3.1"\n'
         ).encode()
-        candidate = update_nanvix._update_manifest(old, self.contract)
-        data = tomllib.loads(candidate.decode())
-        self.assertNotIn("sdk", data["toolchain"])
-        self.assertEqual(
-            data["toolchain"]["kind"],
-            "nanvix-sdk",
-        )
+        (root / ".nanvix/nanvix.toml").write_bytes(old)
+        with self.assertRaises(SystemExit) as context:
+            update_nanvix._run(nanvix_args(contract.name))
+        self.assertEqual(context.exception.code, 2)
 
     def test_blocked_result_writes_nothing(self) -> None:
         root = Path.cwd()

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -4,10 +4,69 @@
 """Shared test helpers for nanvix_zutil tests."""
 
 from nanvix_zutil.paths import manifest_path
+from nanvix_zutil.sdk import SdkImage, SdkProvenance
+
+SDK_DIGEST = f"sha256:{'a' * 64}"
+
+
+def toolchain_toml(runtime: str = "0.1.0") -> str:
+    """Return a canonical immutable SDK toolchain table."""
+    sdk_runtime = runtime if runtime not in {"", "latest"} else "0.1.0"
+    return (
+        "\n[toolchain]\n"
+        'kind = "nanvix-sdk"\n'
+        'provider = "c-clang"\n'
+        f'sdk-version = "v{sdk_runtime}-sdk.1"\n'
+        'sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"\n'
+        f'sdk-digest = "{SDK_DIGEST}"\n'
+    )
+
+
+def make_sdk_provenance(runtime: str = "0.1.0") -> SdkProvenance:
+    """Return complete SDK provenance for lockfile tests."""
+    image_name = "ghcr.io/nanvix/nanvix-sdk-c-clang"
+    return SdkProvenance(
+        sdk_version=f"v{runtime}-sdk.1",
+        provider_id="c-clang",
+        provider="clang",
+        role="c",
+        image=SdkImage(
+            name=image_name,
+            digest=SDK_DIGEST,
+            ref=f"{image_name}@{SDK_DIGEST}",
+        ),
+        nanvix_tag=f"v{runtime}",
+        nanvix_version=runtime,
+        nanvix_commit="b" * 40,
+        sysroot_sha256="c" * 64,
+        compat={
+            "c_abi": "i686-nanvix-sysv-1",
+            "cxx_abi": "libc++",
+            "abi": "static-elf",
+            "min_nanvix_os": runtime,
+        },
+        target={"triple": "i686-unknown-nanvix", "alias": "i686-nanvix"},
+        toolchain={
+            "llvm_version": "22.1.8",
+            "llvm_commit": "d" * 40,
+            "port_branch": "nanvix/v22.1.8",
+        },
+        features={
+            "localization": True,
+            "filesystem": True,
+            "wide_chars": True,
+            "compiler_rt": "builtins-only",
+            "dynamic_loader": False,
+        },
+    )
+
 
 # Minimal valid manifest content.
 MINIMAL_MANIFEST = (
-    "[package]\n" 'name = "test"\n' 'version = "0.1.0"\n' 'nanvix-version = "0.1.0"\n'
+    "[package]\n"
+    'name = "test"\n'
+    'version = "0.1.0"\n'
+    'nanvix-version = "0.1.0"\n' + toolchain_toml()
 )
 
 # Manifest with one build-time dependency.
@@ -15,20 +74,16 @@ MANIFEST_WITH_DEPS = (
     "[package]\n"
     'name = "test"\n'
     'version = "0.1.0"\n'
-    'nanvix-version = "0.1.0"\n'
-    "\n"
+    'nanvix-version = "0.1.0"\n' + toolchain_toml() + "\n"
     "[dependencies]\n"
     'zlib = "1.0"\n'
 )
 
-# Manifest with "latest" sysroot and a VERSION dep.
 MANIFEST_LATEST_WITH_DEPS = (
     "[package]\n"
     'name = "test"\n'
     'version = "0.1.0"\n'
-    'nanvix-version = "latest"\n'
-    "\n"
-    "[dependencies]\n"
+    'nanvix-version = "latest"\n' + toolchain_toml() + "\n[dependencies]\n"
     'zlib = "1.3.1"\n'
 )
 
@@ -45,7 +100,7 @@ def make_toml(
 
     Dependency values are raw TOML fragments placed after ``=``.
     For string values, include quotes: ``deps={"zlib": '"1.0.0"'}``.
-    For inline tables: ``deps={"zlib": '{ commitish = "abc" }'}``.
+    For inline tables: ``deps={"zlib": '{ version = "1.0.0" }'}``.
     """
     lines = [
         "[package]",
@@ -53,6 +108,7 @@ def make_toml(
         f'version = "{version}"',
         f'nanvix-version = "{nanvix_version}"',
     ]
+    lines.extend(toolchain_toml(nanvix_version).strip().splitlines())
     if deps is not None:
         lines.append("[dependencies]")
         for dep_name, dep_value in deps.items():


### PR DESCRIPTION
## Summary
- require canonical nanvix-sdk manifests and complete immutable pins
- reject pre-SDK locks and non-version dependency forms
- remove dependency fallback, degraded setup, and legacy release-tag APIs
- retain only explicit local/offline development overrides and derived image pins
- remove docker-image from the shipped workflow template

This is intentionally breaking; every active consumer is already canonical.

## Validation
- 621 tests passed, 2 platform skips
- strict Pyright: 0 errors/warnings
- Black, shfmt, ShellCheck, yamllint
- two specialist review passes