### PR TITLE
[setup] F: Preserve consumer hook contract

### DIFF
--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -283,7 +283,7 @@ class ZScript:
     # Lifecycle hooks — auto-implemented
     # ------------------------------------------------------------------
 
-    def setup(self) -> None:
+    def setup(self) -> bool:
         """Prepare the build environment.
 
         The base implementation automatically downloads the Nanvix sysroot
@@ -293,9 +293,13 @@ class ZScript:
         Subclasses may override this to perform additional setup steps.
         Call ``super().setup()`` to retain the automatic download behaviour::
 
-            def setup(self) -> None:
+            def setup(self) -> bool:
                 super().setup()
                 # extra verification or configuration here
+                return False
+
+        Returns:
+            ``False``. Degraded legacy setup no longer exists.
         """
         # Resolve sysroot: --sysroot-path takes precedence.
         sysroot_path = self._cli_sysroot_path
@@ -459,6 +463,7 @@ class ZScript:
 
         self.config.save()
         sync_configs()
+        return False
 
     def install_artifacts(self, output: str) -> None:
         """Export build artifacts to a target directory.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,9 +30,10 @@ class _MockConsumer(ZScript):
         super().__init__()
         self.called: list[str] = []
 
-    def setup(self) -> None:
+    def setup(self) -> bool:
         """Record setup hook invocation."""
         self.called.append("setup")
+        return False
 
     def build(self) -> None:
         """Record build hook invocation."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -218,9 +218,10 @@ class TestZScriptAutoSetup(unittest.TestCase):
 
         with patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot):
             script = ZScript()
-            script.setup()
+            result = script.setup()
 
         self.assertIsNone(script.buildroot)
+        self.assertFalse(result)
 
     def test_setup_saves_config(self) -> None:
         """setup() persists the sysroot path to env.json."""


### PR DESCRIPTION
Restore the canonical consumer setup hook return contract without restoring degraded or legacy behavior. Config synchronization now runs before the unconditional false result. Full validation: 621 passed, 2 skipped; strict typing and all linters pass.