### PR TITLE
[update] F: Ignore generator-only lock drift

### DIFF
--- a/src/nanvix_zutil/commands/update_nanvix.py
+++ b/src/nanvix_zutil/commands/update_nanvix.py
@@ -24,7 +24,7 @@ from nanvix_zutil.exitcodes import (
     EXIT_MISSING_DEP,
     EXIT_SUCCESS,
 )
-from nanvix_zutil.lockfile import serialize_lockfile
+from nanvix_zutil.lockfile import read_lockfile, serialize_lockfile
 from nanvix_zutil.manifest import (
     Manifest,
     SdkPin,
@@ -352,6 +352,18 @@ def _run_locked(
             return result, EXIT_MISSING_DEP
         lock_relative = relative.with_name("nanvix.lock")
         lock_bytes = serialize_lockfile(lock)
+        existing_lock_path = root / lock_relative
+        if manifest_bytes == path.read_bytes() and existing_lock_path.is_file():
+            existing_lock = read_lockfile(existing_lock_path)
+            existing_metadata = replace(
+                existing_lock.metadata,
+                nanvix_zutil_version=lock.metadata.nanvix_zutil_version,
+            )
+            if (
+                existing_metadata == lock.metadata
+                and existing_lock.packages == lock.packages
+            ):
+                lock_bytes = existing_lock_path.read_bytes()
         candidates[relative] = manifest_bytes
         candidates[lock_relative] = lock_bytes
 

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -201,6 +201,26 @@ class TestUpdateNanvix(unittest.TestCase):
         self.assertEqual((root / ".nanvix/nanvix.toml").read_bytes(), original)
         self.assertFalse((root / ".nanvix/nanvix.lock").exists())
 
+    def test_generator_version_only_does_not_trigger_update(self) -> None:
+        root = Path.cwd()
+        contract = make_consumer(root)
+        update_nanvix._run(nanvix_args(contract.name))
+        lock_path = root / ".nanvix/nanvix.lock"
+        lock_path.write_text(
+            lock_path.read_text().replace(
+                'nanvix-zutil-version = "0.15.0"',
+                'nanvix-zutil-version = "0.14.0"',
+            )
+        )
+
+        result, code = update_nanvix._run(nanvix_args(contract.name))
+
+        self.assertEqual((result.status, code), ("up-to-date", 0))
+        self.assertIn(
+            'nanvix-zutil-version = "0.14.0"',
+            lock_path.read_text(),
+        )
+
     def test_crlf_manifest_and_workflow_are_preserved(self) -> None:
         root = Path.cwd()
         contract = make_consumer(root, newline="\r\n")


### PR DESCRIPTION
Prevent zutils-only upgrades from opening stale Nanvix SDK PRs when the manifest, SDK provenance, dependency graph, and assets are unchanged. Validation: 622 passed, 2 skipped; strict typing and all linters pass.