### PR TITLE
[templates] F: Remove stale workflow input

### DIFF
--- a/templates/nanvix-ci.yml
+++ b/templates/nanvix-ci.yml
@@ -27,6 +27,5 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v{{WORKFLOW_VERSION}}
     with:
       caller-event-name: ${{ github.event_name }}
-      nanvix-version-source: sdk
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/tests/test_update_commands.py
+++ b/tests/test_update_commands.py
@@ -420,6 +420,13 @@ class TestUpdateZutils(unittest.TestCase):
             (root / "src/nanvix_zutil/configs/.gitignore").read_bytes(),
         )
 
+    def test_shipped_workflow_has_no_removed_inputs(self) -> None:
+        """New consumers must use only the canonical workflows v3 API."""
+        root = Path(__file__).resolve().parent.parent
+        workflow = (root / "templates/nanvix-ci.yml").read_text()
+        self.assertNotIn("docker-image:", workflow)
+        self.assertNotIn("nanvix-version-source:", workflow)
+
     def test_update_and_noop_exact_allowlist(self) -> None:
         root = Path.cwd()
         make_consumer(root)


### PR DESCRIPTION
Remove the undefined nanvix-version-source input from the new-consumer template and add regression coverage for both removed workflow inputs.