### PR TITLE
[REL-PR-2] release: standardised archive name

### DIFF
--- a/src/nanvix_zutil/commands/release.py
+++ b/src/nanvix_zutil/commands/release.py
@@ -94,6 +94,8 @@ def release() -> None:
     if not targets:
         name = (
             f"{manifest.name}"
+            f"-{config.host}"
+            f"-{config.target}"
             f"-{config.machine}"
             f"-{config.deployment_mode}"
             f"-{config.memory_size}"

--- a/src/nanvix_zutil/release.py
+++ b/src/nanvix_zutil/release.py
@@ -13,7 +13,7 @@ consumers may also invoke :func:`package` directly for custom staging::
     archives = package(
         sources=[Path("build/output")],
         dest=Path("dist"),
-        name="mylib-microvm-standalone-256mb",
+        name="mylib-linux-x86-microvm-standalone-256mb",
     )
 """
 

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -18,6 +18,16 @@ from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
 from nanvix_zutil.script import ZScript
 from tests.testutils import write_manifest
 
+# Pin every config-level knob so archive names are deterministic
+# regardless of the developer's ambient environment.
+_PINNED_ENV = {
+    "NANVIX_HOST": "linux",
+    "NANVIX_TARGET": "x86",
+    "NANVIX_MACHINE": "microvm",
+    "NANVIX_DEPLOYMENT_MODE": "standalone",
+    "NANVIX_MEMORY_SIZE": "256mb",
+}
+
 
 class TestReleaseDefault(unittest.TestCase):
     """Default packaging path — no ``.nanvix/z.py`` override.
@@ -30,6 +40,9 @@ class TestReleaseDefault(unittest.TestCase):
 
     def setUp(self) -> None:
         write_manifest()  # manifest name = "test"
+        env_patch = patch.dict("os.environ", _PINNED_ENV, clear=False)
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
 
     def _populate_release_dir(self) -> Path:
         rel = paths.release_dir()
@@ -47,8 +60,8 @@ class TestReleaseDefault(unittest.TestCase):
         self.assertEqual(
             produced,
             {
-                "test-microvm-standalone-256mb.tar.gz",
-                "test-microvm-standalone-256mb.zip",
+                "test-linux-x86-microvm-standalone-256mb.tar.gz",
+                "test-linux-x86-microvm-standalone-256mb.zip",
             },
         )
         for p in dist.iterdir():
@@ -68,7 +81,8 @@ class TestReleaseDefault(unittest.TestCase):
         output = buf.getvalue()
         self.assertIn("success:", output)
         self.assertIn(
-            "Packaged 2 archive(s) for 'test-microvm-standalone-256mb'", output
+            "Packaged 2 archive(s) for 'test-linux-x86-microvm-standalone-256mb'",
+            output,
         )
         self.assertIn(str(paths.dist_dir()), output)
 
@@ -109,6 +123,9 @@ class TestReleaseTargetsOverride(unittest.TestCase):
 
     def setUp(self) -> None:
         write_manifest()
+        env_patch = patch.dict("os.environ", _PINNED_ENV, clear=False)
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
 
     def _populate(self, *subdirs: str) -> None:
         for sub in subdirs:
@@ -157,7 +174,7 @@ class TestReleaseTargetsOverride(unittest.TestCase):
         mock_pkg.assert_called_once()
         args, _ = mock_pkg.call_args
         self.assertEqual(args[0], [rel])
-        self.assertEqual(args[2], "test-microvm-standalone-256mb")
+        self.assertEqual(args[2], "test-linux-x86-microvm-standalone-256mb")
 
 
 class TestConsumerReleaseTargets(unittest.TestCase):


### PR DESCRIPTION
# release: standardised archive name

Closes #302. Child of #287. Step 2 of 5. **Stacks on #306 (#301).**

## What

The default archive base name produced by `nanvix-zutil release` becomes:

```
{package}-{host}-{arch}-{machine}-{mode}-{memory_size}
```

e.g. `cpython-linux-x86-microvm-standalone-256mb.tar.gz`. The `.ext` is
still appended by `package()`.

The `release_targets()` consumer override remains supported unchanged and
will be removed at step 4 once magic-path packaging replaces it.

## Why

#287 defines one archive schema across the ecosystem so filenames alone
identify host, arch, machine, deployment mode, and memory size for
release automation and human readers.

## Not in this PR

- Extension gating by host (step 4).
- `bin` / `lib` split (step 4).
- Sysroot download naming (`sysroot.py`) — separate system.
- Dep-download naming (`buildroot.py`, `lockfile.py`) — separate system.
- Downstream migration of consumer repos and `nanvix/workflows`.

## Notes for reviewers

- Test hermeticity: `tests/test_release_cmd.py` now pins all five
  flag-managed config keys via `patch.dict(os.environ, ...)` so ambient
  `NANVIX_*` in the developer environment doesn't skew expected archive
  names.
- Depends on `Host`/`Target` StrEnums from #306.
