### PR TITLE
buildroot: expect standardised -lib dependency archives

### DIFF
--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -21,8 +21,10 @@ from pathlib import Path
 from nanvix_zutil import github, log
 from nanvix_zutil.config import (
     DEFAULT_DEPLOYMENT_MODE,
+    DEFAULT_HOST,
     DEFAULT_MACHINE,
     DEFAULT_MEMORY_SIZE,
+    DEFAULT_TARGET,
 )
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 from nanvix_zutil.paths import buildroot as _buildroot_dir
@@ -103,8 +105,10 @@ class Dependency:
             (e.g. ``"nanvix/zlib"``).
         ref: Version reference — one of tag, commitish, ID, or version.
         artifact_pattern: ``str.format``-style template for the asset file
-            name.  Interpolated keys: ``{name}``, ``{machine}``,
-            ``{mode}``, ``{mem}``.
+            name.  Interpolated keys: ``{name}``, ``{host}``, ``{arch}``,
+            ``{machine}``, ``{mode}``, ``{mem}``.  Default targets the
+            standardised ``-dev`` archive produced by
+            ``nanvix-zutil release`` (see #287).
         install_libs: List of ``.a`` file names to copy into
             ``<buildroot>/lib/``.  ``None`` copies all ``.a`` files found.
         install_headers: List of header file names to copy into
@@ -114,7 +118,7 @@ class Dependency:
     name: str
     repo: str
     ref: Ref
-    artifact_pattern: str = "{name}-{machine}-{mode}-{mem}"
+    artifact_pattern: str = "{name}-{host}-{arch}-{machine}-{mode}-{mem}-dev"
     install_libs: list[str] | None = None
     install_headers: list[str] | None = None
 
@@ -234,11 +238,13 @@ class Buildroot:
     def install_dep(
         self,
         dep: Dependency,
+        *,
+        host: str = DEFAULT_HOST,
+        target: str = DEFAULT_TARGET,
         machine: str = DEFAULT_MACHINE,
         deployment_mode: str = DEFAULT_DEPLOYMENT_MODE,
         memory_size: str = DEFAULT_MEMORY_SIZE,
         gh_token: str | None = None,
-        *,
         _release: dict[str, object] | None = None,
     ) -> None:
         """Download a dependency release and install its libraries and headers.
@@ -247,8 +253,14 @@ class Buildroot:
         extracted.  Selected ``.a`` and ``.h`` files are copied into
         ``<buildroot>/lib/`` and ``<buildroot>/include/`` respectively.
 
+        Dependencies are assumed to publish a standardised ``-dev`` archive
+        (see #287).  A missing archive is fatal — no fallback to the legacy
+        naming.
+
         Args:
             dep: The :class:`Dependency` descriptor.
+            host: Development host operating system.
+            target: Target CPU architecture.
             machine: Target machine identifier.
             deployment_mode: Deployment mode string.
             memory_size: Memory size string.
@@ -260,6 +272,8 @@ class Buildroot:
         """
         asset_name = dep.artifact_pattern.format(
             name=dep.name,
+            host=host,
+            arch=target,
             machine=machine,
             mode=deployment_mode,
             mem=memory_size,

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -427,6 +427,8 @@ class ZScript:
 
                     self.buildroot.install_dep(
                         dep=dep,
+                        host=self.config.host,
+                        target=self.config.target,
                         machine=self.config.machine,
                         deployment_mode=self.config.deployment_mode,
                         memory_size=self.config.memory_size,

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -72,7 +72,7 @@ class TestDependency(unittest.TestCase):
         dep = Dependency(
             name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
         )
-        expected = "{name}-{machine}-{mode}-{mem}"
+        expected = "{name}-{host}-{arch}-{machine}-{mode}-{mem}-dev"
         self.assertEqual(dep.artifact_pattern, expected)
 
     def test_default_install_libs_none(self) -> None:
@@ -273,12 +273,78 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(
                 dep,
+                host="linux",
+                target="x86",
                 machine="microvm",
                 deployment_mode="single-process",
                 memory_size="256mb",
             )
 
-        self.assertEqual(captured[0], "zlib-microvm-single-process-256mb")
+        self.assertEqual(captured[0], "zlib-linux-x86-microvm-single-process-256mb-dev")
+
+    def test_install_dep_custom_pattern_receives_host_and_arch(self) -> None:
+        """Custom ``artifact_pattern`` still receives the new host/arch keys."""
+        br = self._setup_buildroot()
+        archive = _make_tar_bz2({"sysroot/lib/libz.a": b""})
+        archive_path = Path.cwd() / "zlib.tar.bz2"
+        archive_path.write_bytes(archive)
+
+        dep = Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+            artifact_pattern="{name}-{host}-{arch}",
+        )
+
+        captured: list[str] = []
+
+        def fake_download(
+            repo: str,
+            version_specifier: str | int,
+            asset_name: str,
+            dest: Path,
+            gh_token: str | None = None,
+            *,
+            match_prefix: bool = False,
+            semver: bool = False,
+            _release: dict[str, object] | None = None,
+            allow_missing: bool = False,
+        ) -> Path:
+            captured.append(asset_name)
+            return archive_path
+
+        with patch(
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
+        ):
+            br.install_dep(dep, host="windows", target="arm")
+
+        self.assertEqual(captured[0], "zlib-windows-arm")
+
+    def test_install_dep_fatal_when_asset_missing(self) -> None:
+        """A missing ``-dev`` asset must fail hard — no fallback."""
+        br = self._setup_buildroot()
+        dep = Dependency(
+            name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
+        )
+
+        captured_kwargs: dict[str, object] = {}
+
+        def fake_download(*_args: object, **kwargs: object) -> Path:
+            captured_kwargs.update(kwargs)
+            from nanvix_zutil import log
+
+            log.fatal("Asset 'zlib-...-dev' not found in release nanvix/zlib@v1.0.0")
+
+        with patch(
+            "nanvix_zutil.buildroot.github.download_release_asset",
+            side_effect=fake_download,
+        ):
+            with self.assertRaises(SystemExit):
+                br.install_dep(dep)
+
+        # Lock the contract: install_dep must never pass allow_missing=True.
+        self.assertNotEqual(captured_kwargs.get("allow_missing"), True)
 
     def test_install_dep_preserves_header_subdirectory(self) -> None:
         """Headers in subdirectories are extracted with directory structure preserved."""


### PR DESCRIPTION
# buildroot: expect standardised -dev dependency archives

Closes #310. Child of #287. **Stacks on #309 (#304).**

## What

Consumer-side follow-on to the producer switch in #304. Updates
dependency resolution to match the new archive schema:

- `Dependency.artifact_pattern` default becomes
  `{name}-{host}-{arch}-{machine}-{mode}-{mem}-dev`.
- `Buildroot.install_dep()` gains keyword-only `host` and `target`
  parameters (defaults from `Config`), wired through from the ZScript
  driver.
- A missing `-dev` asset is fatal — `github.download_release_asset`
  already `log.fatal`s on a not-found asset; a test locks that contract
  at the `install_dep` boundary **and** asserts `allow_missing` is never
  `True` in the download call, so future refactors can't silently soften
  it.

## Why

#304 flipped producers to
`{name}-{host}-{arch}-{machine}-{mode}-{mem}.{ext}` (end-user) and
`{name}-{host}-{arch}-{machine}-{mode}-{mem}-dev.{ext}` (downstream
build-time). Without this PR, the default `artifact_pattern` misses
every new publication and every downstream manifest would need an
override.

Dependencies in the nanvix ecosystem are always libraries/headers
consumed at build time, so the default pattern hard-codes the `-dev`
suffix. A binary dependency does not make sense here.

## No silent fallbacks

`install_dep` requires an asset whose name starts with `{...}-dev`.
`github.download_release_asset(match_prefix=True)` picks only among
**extensions** of that exact prefix (`.tar.gz`, `.zip`, ...); an
end-user (no-suffix) archive can never accidentally match. If no `-dev`
asset exists, we `log.fatal` — no legacy-name fallback, no guesswork.

## Not in this PR

- Sysroot download naming (`sysroot.py` `_SYSROOT_ASSET_PREFIX`) — waits
  for the nanvix repo to migrate.
- `commands/info.py` asset prefix — same trigger.
- Downstream manifest updates — #305.

## Notes for reviewers

- Tail params on `install_dep()` are keyword-only to prevent future
  positional binding to the wrong slot. Note: this is a positional-arg
  API break for any caller of `install_dep(dep, machine, ...)`; the only
  known downstream caller (`cpython/active/.nanvix/z.py`) already uses
  kwargs, so nothing observable breaks today.
- New test `test_install_dep_custom_pattern_receives_host_and_arch`
  verifies user-supplied patterns still receive the new interpolation
  keys.
- Cross-host consumption asymmetry (a Windows consumer pulling a dep
  whose CI only publishes `-linux-` archives will fail hard) is the
  intended semantics of #287; downstream dual-publishing is a #305
  concern.
