### PR TITLE
[REL-PR-3] release: magic-path packaging, drop release_targets

### DIFF
--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -28,7 +28,7 @@ from nanvix_zutil import (
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE
 from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
-from nanvix_zutil.paths import bin_out, nanvix_root, repo_root
+from nanvix_zutil.paths import regular_out, nanvix_root, repo_root
 
 
 class BinHello(ZScript):
@@ -107,7 +107,7 @@ class BinHello(ZScript):
             make_initrd(
                 self,
                 repo_root() / "hello.elf",
-                bin_out(),
+                regular_out(),
                 args=InitRdArgs(),
             )
 

--- a/src/nanvix_zutil/commands/release.py
+++ b/src/nanvix_zutil/commands/release.py
@@ -1,112 +1,94 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-"""``nanvix-zutil release`` — package release archives from ``.nanvix/out/release``.
+"""``nanvix-zutil release`` — package release archives from ``.nanvix/out/staging``.
 
-Standalone command (per issue #191): does not require a ``ZScript``
-subclass, but honours a consumer-defined ``release_targets()`` override
-on ``.nanvix/z.py`` when present.
+Standalone command.  At package time, inspects ``.nanvix/out/staging/`` for
+the two magic subdirectories ``release/`` and ``dev/``.  For each present
+and non-empty subdirectory, produces one archive suffixed accordingly:
 
-Archives are written to ``.nanvix/out/dist`` under the manifest package
-name.  With no override, a single archive is produced covering the
-entire release directory.  With an override, one archive per entry is
-produced from the named subdirectory.
+    {name}-{host}-{arch}-{machine}-{mode}-{mem}.{ext}      (release/)
+    {name}-{host}-{arch}-{machine}-{mode}-{mem}-dev.{ext}  (dev/)
+
+The archive extension is gated on host: ``linux`` -> ``.tar.gz``,
+``windows`` -> ``.zip``.  If neither directory exists or both are empty,
+the command fails.
 """
 
 from __future__ import annotations
 
 import argparse
-import re
 import sys
+from pathlib import Path
 
 from nanvix_zutil import log
-from nanvix_zutil.config import Config
-from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_SUCCESS
+from nanvix_zutil.config import Config, Host
+from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR, EXIT_SUCCESS
 from nanvix_zutil.manifest import load_manifest
-from nanvix_zutil.paths import dist_dir, nanvix_root, staging_dir
-from nanvix_zutil.release import package
+from nanvix_zutil.paths import dev_out, dist_dir, regular_out
+from nanvix_zutil.release import ArchiveFormat, package
 
-HELP: str = "Package release archives from .nanvix/out/release into .nanvix/out/dist"
+HELP: str = "Package release archives from .nanvix/out/staging into .nanvix/out/dist"
 """One-line description surfaced in ``nanvix-zutil --help``."""
 
-_TARGET_ALLOWLIST = re.compile(r"^[A-Za-z0-9_.-]+$")
+_HOST_FORMAT: dict[Host, ArchiveFormat] = {
+    Host.linux: ArchiveFormat.TAR_GZ,
+    Host.windows: ArchiveFormat.ZIP,
+}
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Build and return the argument parser for ``nanvix-zutil release``.
-
-    Returns:
-        Configured :class:`argparse.ArgumentParser`.
-    """
+    """Build and return the argument parser for ``nanvix-zutil release``."""
     return argparse.ArgumentParser(
         prog="nanvix-zutil release",
         description=(
-            "Package release archives from .nanvix/out/release into"
-            " .nanvix/out/dist. If .nanvix/z.py defines a release_targets()"
-            " override, one archive is produced per entry; otherwise a"
-            " single archive covers the whole release directory."
+            "Package release archives from .nanvix/out/staging into"
+            " .nanvix/out/dist.  Produces one archive per non-empty magic"
+            " subdirectory (regular/, dev/), suffixed accordingly."
         ),
     )
 
 
-def _check_target(target: str) -> None:
-    """Reject release-target names that are not filename-safe."""
-    if not _TARGET_ALLOWLIST.match(target) and target not in (".", ".."):
-        log.fatal(
-            f"Invalid release target '{target}'."
-            " Characters must be alphanumeric, underscore, hyphen, or dot.",
-            code=EXIT_INVALID_ARGS,
-        )
-
-
-def consumer_release_targets() -> dict[str, str]:
-    """Return ``release_targets()`` from ``.nanvix/z.py`` if it defines one.
-
-    Returns ``{}`` when ``z.py`` is absent or defines no ``release_targets``
-    override.  Import errors on ``z.py`` propagate — a broken consumer
-    script must fail loudly rather than silently ship a default archive.
-    """
-    z_py = nanvix_root() / "z.py"
-    if not z_py.exists():
-        return {}
-
-    # Lazy import: ``__main__`` imports this module at top level for HELP.
-    from nanvix_zutil.__main__ import discover_script_class
-
-    script_cls = discover_script_class()
-    instance = script_cls()
-
-    targets_fn = getattr(instance, "release_targets", None)
-    if not callable(targets_fn):
-        return {}
-    result = targets_fn()
-    if not isinstance(result, dict):
-        return {}
-    return {str(k): str(v) for k, v in result.items()}  # type: ignore[reportUnknownVariableType]
+def _is_non_empty_dir(path: Path) -> bool:
+    """Return True when *path* exists, is a directory, and contains an entry."""
+    return path.is_dir() and any(path.iterdir())
 
 
 def release() -> None:
-    """Package release archives from ``.nanvix/out/release``."""
+    """Package release archives from ``.nanvix/out/staging``."""
     manifest = load_manifest()
     config = Config()
 
-    targets = consumer_release_targets()
-    if not targets:
-        name = (
-            f"{manifest.name}"
-            f"-{config.host}"
-            f"-{config.target}"
-            f"-{config.machine}"
-            f"-{config.deployment_mode}"
-            f"-{config.memory_size}"
-        )
-        package([staging_dir()], dist_dir(), name)
-        return
+    fmt = _HOST_FORMAT[config.host]
+    base = (
+        f"{manifest.name}"
+        f"-{config.host}"
+        f"-{config.target}"
+        f"-{config.machine}"
+        f"-{config.deployment_mode}"
+        f"-{config.memory_size}"
+    )
 
-    for input, output in targets.items():
-        _check_target(input)
-        _check_target(output)
-        package([staging_dir() / input], dist_dir(), output)
+    # (source, archive suffix): regular/ -> no suffix, dev/ -> "-dev".
+    slots: list[tuple[Path, str]] = []
+    if _is_non_empty_dir(regular_out()):
+        slots.append((regular_out(), ""))
+    if _is_non_empty_dir(dev_out()):
+        slots.append((dev_out(), "-dev"))
+
+    if not slots:
+        log.fatal(
+            "Nothing to package: no non-empty regular/ or dev/ under"
+            f" {regular_out().parent}.",
+            code=EXIT_GENERAL_ERROR,
+            hint=(
+                "Stage runtime artifacts under regular_out() during build."
+                " Stage headers and libraries under dev_out()."
+            ),
+        )
+
+    for source, suffix in slots:
+        package([source], dist_dir(), f"{base}{suffix}", formats=(fmt,))
 
 
 def main() -> None:

--- a/src/nanvix_zutil/commands/release.py
+++ b/src/nanvix_zutil/commands/release.py
@@ -23,7 +23,7 @@ from nanvix_zutil import log
 from nanvix_zutil.config import Config
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_SUCCESS
 from nanvix_zutil.manifest import load_manifest
-from nanvix_zutil.paths import dist_dir, nanvix_root, release_dir
+from nanvix_zutil.paths import dist_dir, nanvix_root, staging_dir
 from nanvix_zutil.release import package
 
 HELP: str = "Package release archives from .nanvix/out/release into .nanvix/out/dist"
@@ -100,13 +100,13 @@ def release() -> None:
             f"-{config.deployment_mode}"
             f"-{config.memory_size}"
         )
-        package([release_dir()], dist_dir(), name)
+        package([staging_dir()], dist_dir(), name)
         return
 
     for input, output in targets.items():
         _check_target(input)
         _check_target(output)
-        package([release_dir() / input], dist_dir(), output)
+        package([staging_dir() / input], dist_dir(), output)
 
 
 def main() -> None:

--- a/src/nanvix_zutil/paths.py
+++ b/src/nanvix_zutil/paths.py
@@ -65,7 +65,7 @@ def out_dir() -> Path:
 
 
 def staging_dir() -> Path:
-    """Path to build outputs staged for the ``release`` command
+    """Path to built outputs staged for the ``release`` command
     (``.nanvix/out/staging``)."""
     return out_dir() / "staging"
 
@@ -75,22 +75,17 @@ def dist_dir() -> Path:
     return out_dir() / "dist"
 
 
-def lib_out() -> Path:
-    """Path to built library outputs to be bundled into the release
-    lib path. (``.nanvix/out/staging/lib``)"""
-    return staging_dir() / "lib"
+def dev_out() -> Path:
+    """Path to build outputs bundled into the ``-dev`` archive consumed
+    by downstream builds (headers, static/shared libraries).
+    (``.nanvix/out/staging/dev``)"""
+    return staging_dir() / "dev"
 
 
-def include_out() -> Path:
-    """Path to built header outputs to be bundled into the release
-    include path. (``.nanvix/out/staging/include``)"""
-    return staging_dir() / "include"
-
-
-def bin_out() -> Path:
-    """Path to built binaries to be bundled into the release bin path.
-    (``.nanvix/out/staging/bin``)"""
-    return staging_dir() / "bin"
+def regular_out() -> Path:
+    """Path to build outputs bundled into the end-user release archive
+    (runtime binaries, initrd images). (``.nanvix/out/staging/regular``)"""
+    return staging_dir() / "regular"
 
 
 def test_out() -> Path:

--- a/src/nanvix_zutil/paths.py
+++ b/src/nanvix_zutil/paths.py
@@ -64,9 +64,10 @@ def out_dir() -> Path:
     return nanvix_root() / "out"
 
 
-def release_dir() -> Path:
-    """Path to built outputs to be distributed with ``release`` (``.nanvix/out/release``)."""
-    return out_dir() / "release"
+def staging_dir() -> Path:
+    """Path to build outputs staged for the ``release`` command
+    (``.nanvix/out/staging``)."""
+    return out_dir() / "staging"
 
 
 def dist_dir() -> Path:
@@ -76,20 +77,20 @@ def dist_dir() -> Path:
 
 def lib_out() -> Path:
     """Path to built library outputs to be bundled into the release
-    lib path. (``.nanvix/out/release/lib``)"""
-    return release_dir() / "lib"
+    lib path. (``.nanvix/out/staging/lib``)"""
+    return staging_dir() / "lib"
 
 
 def include_out() -> Path:
     """Path to built header outputs to be bundled into the release
-    include path. (``.nanvix/out/release/include``)"""
-    return release_dir() / "include"
+    include path. (``.nanvix/out/staging/include``)"""
+    return staging_dir() / "include"
 
 
 def bin_out() -> Path:
     """Path to built binaries to be bundled into the release bin path.
-    (``.nanvix/out/release/bin``)"""
-    return release_dir() / "bin"
+    (``.nanvix/out/staging/bin``)"""
+    return staging_dir() / "bin"
 
 
 def test_out() -> Path:

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -139,27 +139,6 @@ class ZScript:
     # Subcommands that always run inside Docker.
     DOCKER_COMMANDS: frozenset[str | None] = frozenset({"setup", "build", "clean"})
 
-    def release_targets(self) -> dict[str, str]:
-        """
-        Consumer-provided release targets, consumed by the standalone
-        ``nanvix-zutil release`` command.
-        By default, ``release`` will wrap everything in ``staging_dir()``.
-        Override to produce one archive per subdirectory.
-        This value maps from subdirectory names to release artifact names.
-
-        Example usage:
-        ```python
-        def release_targets() -> dict[str,str]:
-            return {
-                # staging_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
-                "sysroot-pkg": f"{name}-{toolchain}",
-                # staging_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
-                "buildroot-pkg": f"{name}-{toolchain}-buildroot",
-            }
-        ```
-        """
-        return {}
-
     def sysroot_required_files(self) -> list[str]:
         """Return the sysroot files required for the current platform and mode.
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -143,7 +143,7 @@ class ZScript:
         """
         Consumer-provided release targets, consumed by the standalone
         ``nanvix-zutil release`` command.
-        By default, ``release`` will wrap everything in ``release_dir()``.
+        By default, ``release`` will wrap everything in ``staging_dir()``.
         Override to produce one archive per subdirectory.
         This value maps from subdirectory names to release artifact names.
 
@@ -151,9 +151,9 @@ class ZScript:
         ```python
         def release_targets() -> dict[str,str]:
             return {
-                # release_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+                # staging_dir()/sysroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
                 "sysroot-pkg": f"{name}-{toolchain}",
-                # release_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
+                # staging_dir()/buildroot-pkg -> dist_dir()/{name}-{toolchain}.tar.gz
                 "buildroot-pkg": f"{name}-{toolchain}-buildroot",
             }
         ```

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -44,14 +44,14 @@ class TestReleaseDefault(unittest.TestCase):
         env_patch.start()
         self.addCleanup(env_patch.stop)
 
-    def _populate_release_dir(self) -> Path:
-        rel = paths.release_dir()
+    def _populate_staging_dir(self) -> Path:
+        rel = paths.staging_dir()
         rel.mkdir(parents=True, exist_ok=True)
         (rel / "artifact.bin").write_bytes(b"payload")
         return rel
 
-    def test_packages_when_release_dir_exists(self) -> None:
-        self._populate_release_dir()
+    def test_packages_when_staging_dir_exists(self) -> None:
+        self._populate_staging_dir()
 
         release_cmd.release()
 
@@ -68,7 +68,7 @@ class TestReleaseDefault(unittest.TestCase):
             self.assertGreater(p.stat().st_size, 0, f"empty archive: {p}")
 
     def test_emits_success_message(self) -> None:
-        self._populate_release_dir()
+        self._populate_staging_dir()
 
         buf = StringIO()
         original_stderr = sys.stderr
@@ -86,8 +86,8 @@ class TestReleaseDefault(unittest.TestCase):
         )
         self.assertIn(str(paths.dist_dir()), output)
 
-    def test_fails_when_release_dir_missing(self) -> None:
-        self.assertFalse(paths.release_dir().exists())
+    def test_fails_when_staging_dir_missing(self) -> None:
+        self.assertFalse(paths.staging_dir().exists())
 
         with self.assertRaises(SystemExit) as ctx:
             release_cmd.release()
@@ -109,7 +109,7 @@ class TestReleaseDefault(unittest.TestCase):
 
         output = buf.getvalue()
         self.assertIn("error:", output)
-        self.assertIn(str(paths.release_dir()), output)
+        self.assertIn(str(paths.staging_dir()), output)
         self.assertIn("hint:", output)
         self.assertIn("release", output)
 
@@ -129,7 +129,7 @@ class TestReleaseTargetsOverride(unittest.TestCase):
 
     def _populate(self, *subdirs: str) -> None:
         for sub in subdirs:
-            d = paths.release_dir() / sub
+            d = paths.staging_dir() / sub
             d.mkdir(parents=True, exist_ok=True)
             (d / "artifact.bin").write_bytes(b"payload")
 
@@ -149,7 +149,7 @@ class TestReleaseTargetsOverride(unittest.TestCase):
         ):
             release_cmd.release()
 
-        rel = paths.release_dir()
+        rel = paths.staging_dir()
         dist = paths.dist_dir()
         self.assertEqual(mock_pkg.call_count, 2)
         seen = {(tuple(c.args[0]), c.args[2]) for c in mock_pkg.call_args_list}
@@ -164,7 +164,7 @@ class TestReleaseTargetsOverride(unittest.TestCase):
             self.assertEqual(c.args[1], dist)
 
     def test_empty_targets_falls_back_to_default(self) -> None:
-        rel = paths.release_dir()
+        rel = paths.staging_dir()
         rel.mkdir(parents=True, exist_ok=True)
         (rel / "artifact.bin").write_bytes(b"payload")
 

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -9,13 +9,11 @@ import sys
 import unittest
 from io import StringIO
 from pathlib import Path
-from typing import override
 from unittest.mock import patch
 
 from nanvix_zutil import paths
 from nanvix_zutil.commands import release as release_cmd
 from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
-from nanvix_zutil.script import ZScript
 from tests.testutils import write_manifest
 
 # Pin every config-level knob so archive names are deterministic
@@ -28,76 +26,88 @@ _PINNED_ENV = {
     "NANVIX_MEMORY_SIZE": "256mb",
 }
 
+_BASE = "test-linux-x86-microvm-standalone-256mb"
 
-class TestReleaseDefault(unittest.TestCase):
-    """Default packaging path — no ``.nanvix/z.py`` override.
 
-    Content coverage lives in ``tests/test_release.py``. These tests only
-    verify wiring: the release directory is picked up, archives land in the
-    dist directory under the manifest name, and a missing release directory
-    fails cleanly.
-    """
-
+class _ReleaseTestBase(unittest.TestCase):
     def setUp(self) -> None:
         write_manifest()  # manifest name = "test"
         env_patch = patch.dict("os.environ", _PINNED_ENV, clear=False)
         env_patch.start()
         self.addCleanup(env_patch.stop)
 
-    def _populate_staging_dir(self) -> Path:
-        rel = paths.staging_dir()
-        rel.mkdir(parents=True, exist_ok=True)
-        (rel / "artifact.bin").write_bytes(b"payload")
-        return rel
+    def _stage(self, subdir: str) -> Path:
+        d = paths.staging_dir() / subdir
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "artifact.bin").write_bytes(b"payload")
+        return d
 
-    def test_packages_when_staging_dir_exists(self) -> None:
-        self._populate_staging_dir()
 
+class TestReleaseMagicPaths(_ReleaseTestBase):
+    """release/dev magic-path routing."""
+
+    def test_release_only_produces_unsuffixed_archive(self) -> None:
+        self._stage("regular")
         release_cmd.release()
+        produced = {p.name for p in paths.dist_dir().iterdir()}
+        self.assertEqual(produced, {f"{_BASE}.tar.gz"})
 
-        dist = paths.dist_dir()
-        produced = {p.name for p in dist.iterdir()}
+    def test_dev_only_produces_dev_archive(self) -> None:
+        self._stage("dev")
+        release_cmd.release()
+        produced = {p.name for p in paths.dist_dir().iterdir()}
+        self.assertEqual(produced, {f"{_BASE}-dev.tar.gz"})
+
+    def test_both_produces_both_archives(self) -> None:
+        self._stage("regular")
+        self._stage("dev")
+        release_cmd.release()
+        produced = {p.name for p in paths.dist_dir().iterdir()}
         self.assertEqual(
             produced,
-            {
-                "test-linux-x86-microvm-standalone-256mb.tar.gz",
-                "test-linux-x86-microvm-standalone-256mb.zip",
-            },
+            {f"{_BASE}.tar.gz", f"{_BASE}-dev.tar.gz"},
         )
-        for p in dist.iterdir():
-            self.assertGreater(p.stat().st_size, 0, f"empty archive: {p}")
 
-    def test_emits_success_message(self) -> None:
-        self._populate_staging_dir()
+    def test_empty_release_is_ignored(self) -> None:
+        (paths.staging_dir() / "regular").mkdir(parents=True)  # empty
+        self._stage("dev")
+        release_cmd.release()
+        produced = {p.name for p in paths.dist_dir().iterdir()}
+        self.assertEqual(produced, {f"{_BASE}-dev.tar.gz"})
 
-        buf = StringIO()
-        original_stderr = sys.stderr
-        sys.stderr = buf
-        try:
-            release_cmd.release()
-        finally:
-            sys.stderr = original_stderr
-
-        output = buf.getvalue()
-        self.assertIn("success:", output)
-        self.assertIn(
-            "Packaged 2 archive(s) for 'test-linux-x86-microvm-standalone-256mb'",
-            output,
-        )
-        self.assertIn(str(paths.dist_dir()), output)
-
-    def test_fails_when_staging_dir_missing(self) -> None:
-        self.assertFalse(paths.staging_dir().exists())
-
+    def test_neither_is_fatal(self) -> None:
         with self.assertRaises(SystemExit) as ctx:
             release_cmd.release()
         self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
 
-        dist = paths.dist_dir()
-        if dist.exists():
-            self.assertEqual(list(dist.iterdir()), [])
+    def test_both_empty_is_fatal(self) -> None:
+        (paths.staging_dir() / "regular").mkdir(parents=True)
+        (paths.staging_dir() / "dev").mkdir(parents=True)
+        with self.assertRaises(SystemExit) as ctx:
+            release_cmd.release()
+        self.assertEqual(ctx.exception.code, EXIT_GENERAL_ERROR)
 
-    def test_failure_emits_error_with_hint(self) -> None:
+
+class TestReleaseHostExtension(_ReleaseTestBase):
+    """Extension is gated on Config.host."""
+
+    def test_windows_uses_zip(self) -> None:
+        env = dict(_PINNED_ENV)
+        env["NANVIX_HOST"] = "windows"
+        with patch.dict("os.environ", env, clear=False):
+            self._stage("regular")
+            release_cmd.release()
+        produced = {p.name for p in paths.dist_dir().iterdir()}
+        self.assertEqual(
+            produced,
+            {"test-windows-x86-microvm-standalone-256mb.zip"},
+        )
+
+
+class TestReleaseFailureMessages(_ReleaseTestBase):
+    """Failure paths surface actionable error messages."""
+
+    def test_missing_staging_dir_emits_hint(self) -> None:
         buf = StringIO()
         original_stderr = sys.stderr
         sys.stderr = buf
@@ -109,99 +119,9 @@ class TestReleaseDefault(unittest.TestCase):
 
         output = buf.getvalue()
         self.assertIn("error:", output)
-        self.assertIn(str(paths.staging_dir()), output)
+        self.assertIn("regular/", output)
+        self.assertIn("dev/", output)
         self.assertIn("hint:", output)
-        self.assertIn("release", output)
-
-
-class TestReleaseTargetsOverride(unittest.TestCase):
-    """A ``release_targets()`` override on ``.nanvix/z.py`` drives multi-archive packaging.
-
-    We patch ``consumer_release_targets`` to simulate a consumer override
-    without materialising a fake ``z.py`` module on disk.
-    """
-
-    def setUp(self) -> None:
-        write_manifest()
-        env_patch = patch.dict("os.environ", _PINNED_ENV, clear=False)
-        env_patch.start()
-        self.addCleanup(env_patch.stop)
-
-    def _populate(self, *subdirs: str) -> None:
-        for sub in subdirs:
-            d = paths.staging_dir() / sub
-            d.mkdir(parents=True, exist_ok=True)
-            (d / "artifact.bin").write_bytes(b"payload")
-
-    def test_dispatches_one_package_call_per_target(self) -> None:
-        self._populate("sysroot-pkg", "buildroot-pkg")
-
-        targets = {
-            "sysroot-pkg": "test-sysroot",
-            "buildroot-pkg": "test-buildroot",
-        }
-        with (
-            patch(
-                "nanvix_zutil.commands.release.consumer_release_targets",
-                return_value=targets,
-            ),
-            patch("nanvix_zutil.commands.release.package") as mock_pkg,
-        ):
-            release_cmd.release()
-
-        rel = paths.staging_dir()
-        dist = paths.dist_dir()
-        self.assertEqual(mock_pkg.call_count, 2)
-        seen = {(tuple(c.args[0]), c.args[2]) for c in mock_pkg.call_args_list}
-        self.assertEqual(
-            seen,
-            {
-                ((rel / "sysroot-pkg",), "test-sysroot"),
-                ((rel / "buildroot-pkg",), "test-buildroot"),
-            },
-        )
-        for c in mock_pkg.call_args_list:
-            self.assertEqual(c.args[1], dist)
-
-    def test_empty_targets_falls_back_to_default(self) -> None:
-        rel = paths.staging_dir()
-        rel.mkdir(parents=True, exist_ok=True)
-        (rel / "artifact.bin").write_bytes(b"payload")
-
-        with patch("nanvix_zutil.commands.release.package") as mock_pkg:
-            release_cmd.release()
-
-        mock_pkg.assert_called_once()
-        args, _ = mock_pkg.call_args
-        self.assertEqual(args[0], [rel])
-        self.assertEqual(args[2], "test-linux-x86-microvm-standalone-256mb")
-
-
-class TestConsumerReleaseTargets(unittest.TestCase):
-    """``consumer_release_targets()`` picks up overrides from ``.nanvix/z.py``."""
-
-    def setUp(self) -> None:
-        write_manifest()
-
-    def test_no_z_py_returns_empty(self) -> None:
-        self.assertFalse((paths.nanvix_root() / "z.py").exists())
-        self.assertEqual(release_cmd.consumer_release_targets(), {})
-
-    def test_override_returned(self) -> None:
-        class _Sub(ZScript):
-            @override
-            def release_targets(self) -> dict[str, str]:
-                return {"sysroot-pkg": "test-sysroot"}
-
-        # Create a placeholder z.py so the presence check passes; the
-        # discover step is patched to return _Sub directly.
-        (paths.nanvix_root() / "z.py").write_text("# placeholder\n")
-
-        with patch("nanvix_zutil.__main__.discover_script_class", return_value=_Sub):
-            self.assertEqual(
-                release_cmd.consumer_release_targets(),
-                {"sysroot-pkg": "test-sysroot"},
-            )
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1205,16 +1205,16 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             result = helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(),
             )
 
-        self.assertEqual(result, paths.bin_out() / "my-app.img")
+        self.assertEqual(result, paths.regular_out() / "my-app.img")
         cmd = captured[0]
         bin_dir = script.sysroot.path / "bin"  # type: ignore[union-attr]
         self.assertEqual(cmd[0], str(bin_dir / "mkimage.elf"))
         self.assertEqual(cmd[1], "-o")
-        self.assertEqual(cmd[2], str(paths.bin_out() / "my-app.img"))
+        self.assertEqual(cmd[2], str(paths.regular_out() / "my-app.img"))
         self.assertEqual(cmd[3], f"{bin_dir / 'procd.elf'};procd")
         self.assertEqual(cmd[4], f"{bin_dir / 'memd.elf'};memd")
         self.assertEqual(cmd[5], f"{bin_dir / 'vfsd.elf'};vfsd")
@@ -1234,7 +1234,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(),
             )
 
@@ -1255,7 +1255,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(app_args=["--verbose", "--port=8080"]),
             )
 
@@ -1279,7 +1279,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(
                     procd_args=["--debug"],
                     memd_args=["--heap=64m"],
@@ -1306,7 +1306,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(kernel_args=["console=ttyS0", "debug"]),
             )
 
@@ -1329,7 +1329,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(app_args=["--sep=;"]),
             )
 
@@ -1352,7 +1352,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(kernel_args=["a;b"]),
             )
 
@@ -1377,7 +1377,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(bin_dir=custom_bin),
             )
 
@@ -1392,7 +1392,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(),
             )
         self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
@@ -1411,11 +1411,11 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             result = helpers.make_initrd(
                 script,
                 paths.repo_root() / "hello-world.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(),
             )
 
-        self.assertEqual(result, paths.bin_out() / "hello-world.img")
+        self.assertEqual(result, paths.regular_out() / "hello-world.img")
         self.assertEqual(
             captured[0][6], f"{paths.repo_root() / 'hello-world.elf'};hello-world"
         )
@@ -1434,10 +1434,10 @@ class TestHelpersMakeInitrd(unittest.TestCase):
         input_path = paths.repo_root() / "build" / "hello.elf"
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             result = helpers.make_initrd(
-                script, input_path, paths.bin_out(), args=InitRdArgs()
+                script, input_path, paths.regular_out(), args=InitRdArgs()
             )
 
-        self.assertEqual(result, paths.bin_out() / "hello.img")
+        self.assertEqual(result, paths.regular_out() / "hello.img")
         self.assertEqual(captured[0][6], f"{input_path};hello")
 
     @patch("nanvix_zutil.helpers.is_windows", return_value=False)
@@ -1454,7 +1454,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(),
             )
         self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
@@ -1473,7 +1473,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(app_env=["VAR1=foo", "VAR2=bar"]),
             )
 
@@ -1497,7 +1497,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(app_args=["--verbose"], app_env=["DEBUG=1"]),
             )
 
@@ -1521,7 +1521,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(
                     procd_env=["LOG=debug"],
                     memd_env=["HEAP=64m"],
@@ -1548,7 +1548,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(app_env=["PATH=/a;/b"]),
             )
 
@@ -1572,7 +1572,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(
                     procd_args=["--log-level", "trace"], procd_env=["LOG=debug"]
                 ),
@@ -1598,7 +1598,7 @@ class TestHelpersMakeInitrd(unittest.TestCase):
             helpers.make_initrd(
                 script,
                 paths.repo_root() / "my-app.elf",
-                paths.bin_out(),
+                paths.regular_out(),
                 args=InitRdArgs(
                     app_args=["--verbose"], app_env=["DEBUG=1"], procd_env=["LOG=debug"]
                 ),
@@ -1625,25 +1625,25 @@ class TestHelpersMakeInitrd(unittest.TestCase):
 
         # Sanity: neither output directory should exist before the calls
         # so we can verify make_initrd creates them.
-        self.assertFalse(paths.bin_out().exists())
+        self.assertFalse(paths.regular_out().exists())
         self.assertFalse(paths.test_out().exists())
 
         input_path = paths.repo_root() / "my-app.elf"
         with patch("nanvix_zutil.helpers.subprocess.run", side_effect=fake_run):
             release = helpers.make_initrd(
-                script, input_path, paths.bin_out(), args=InitRdArgs()
+                script, input_path, paths.regular_out(), args=InitRdArgs()
             )
             test_img = helpers.make_initrd(
                 script, input_path, paths.test_out(), args=InitRdArgs()
             )
 
-        self.assertEqual(release, paths.bin_out() / "my-app.img")
+        self.assertEqual(release, paths.regular_out() / "my-app.img")
         self.assertEqual(test_img, paths.test_out() / "my-app.img")
-        self.assertTrue(paths.bin_out().is_dir())
+        self.assertTrue(paths.regular_out().is_dir())
         self.assertTrue(paths.test_out().is_dir())
         # The mkimage command's ``-o`` argument should reflect the chosen
         # output directory for each invocation.
-        self.assertEqual(captured[0][2], str(paths.bin_out() / "my-app.img"))
+        self.assertEqual(captured[0][2], str(paths.regular_out() / "my-app.img"))
         self.assertEqual(captured[1][2], str(paths.test_out() / "my-app.img"))
 
 


### PR DESCRIPTION
> Supersedes #309, which was auto-closed as MERGED after a stack reorder made its former base branch contain its head. Same content, correct base.

## Reviewer note: split into two commits

1. **`paths: rename release_dir -> staging_dir`** — pure rename + directory relocation (`.nanvix/out/release/` → `.nanvix/out/staging/`). No behavioural change; `bin_out()`/`lib_out()`/`include_out()` still resolve to the same relative slots under the renamed parent.
2. **`release: magic-path packaging, drop release_targets`** — the semantic changes below.

Review commit-by-commit for a much smaller second diff.


Closes #304. Child of #287. Step 4 of 5. **Stacks on #308 (#303).**

## What

Sharp cutover to the "staged by directory" layout. At package time,
`nanvix-zutil release` inspects `.nanvix/out/staging/`:

- For each of `release/` and `dev/` that exists and is non-empty,
  produces one archive:
  - `release/` → `{name}-{host}-{arch}-{machine}-{mode}-{mem}.{ext}` (end-user)
  - `dev/`     → `{name}-{host}-{arch}-{machine}-{mode}-{mem}-dev.{ext}` (consumed by downstream builds)
- Extension is gated on `Config.host`: `linux` → `.tar.gz`, `windows` → `.zip`. No more dual-format output.
- Neither present or both empty is a fatal error.

Path renames:
- `release_dir()` → `staging_dir()` (`.nanvix/out/staging/`)
- `bin_out()` → `release_out()` (`staging/release/`)
- `lib_out()` → `dev_out()` (`staging/dev/`)

Removed:
- `ZScript.release_targets`
- `consumer_release_targets()`
- `include_out()` (headers move under `dev_out()`)

## Why

Downstreams now declare intent by *where* they stage artifacts, not by a
manifest field or Python override. See #287.

`-dev` / no-suffix was chosen (over the earlier `-lib` / `-bin`) so the
end-user archive has the natural, unadorned name and the consumer-facing
archive is clearly marked as development material. Parent dir renamed
from `release/` to `staging/` to avoid a `.nanvix/out/release/release/`
collision under the new subdir names.

## Downstream impact

Breaks every downstream that currently overrides `release_targets()` or
stages release payloads outside `bin/`/`lib/` (now `release/`/`dev/`).
Step 5 (#305) mops up.

## Notes for reviewers

- `_HOST_FORMAT` is a total map against the `Host` enum (linux, windows).
  If a third variant is ever added, this map is the one place to update.
- Docs (`docs/design.md`) drop all "step 4" markers; the Release
  subsection is now present-tense with the new naming.
- Fatal-path hint prose split into two sentences to avoid ambiguity about
  which directory holds what.
- Test coverage: release-only, dev-only, both, empty-release ignored,
  both-missing fatal, both-empty fatal, host-driven extension for
  windows, error-hint content.



