### PR TITLE
[TST-1] helpers: add mkramfs()

### DIFF
--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -94,6 +94,7 @@ from nanvix_zutil.helpers import (
     InitRdArgs,
     ensure_tool_installed,
     make_initrd,
+    mkramfs,
     run,
     sync_configs,
 )
@@ -204,6 +205,7 @@ __all__ = [
     "sync_configs",
     "write_lockfile",
     "InitRdArgs",
+    "mkramfs",
     "parse_sdk_version",
     "validate_sdk_release",
     "verify_sdk_metadata",

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -8,6 +8,8 @@ import importlib.util
 import shutil
 import subprocess
 import sys
+import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,7 +18,7 @@ from nanvix_zutil import log
 from nanvix_zutil.config import CFG_SYSROOT
 from nanvix_zutil.docker import DockerConfig, is_windows
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
-from nanvix_zutil.paths import nanvix_root
+from nanvix_zutil.paths import nanvix_root, sysroot
 
 if TYPE_CHECKING:
     from nanvix_zutil.script import ZScript
@@ -277,6 +279,52 @@ def make_initrd(
     run(*cmd)
 
     return output
+
+
+def mkramfs(
+    output: Path,
+    *,
+    files: Mapping[str, Path] | None = None,
+    timeout: int = 60,
+) -> None:
+    """Build a ramfs image at *output* containing *files*.
+
+    Stages *files* (guest-path → host-path) into a private temporary
+    directory, ensures ``tmp/`` exists (Nanvix convention), then
+    invokes ``mkramfs`` from the sysroot to produce the image. The
+    staging directory is cleaned up before returning.
+
+    Args:
+        output: Destination path for the generated image.
+        files: Mapping of guest path (POSIX-style, relative to ramfs
+            root) to host path. Parent directories are created as
+            needed. ``None`` (default) stages nothing.
+        timeout: Seconds before ``mkramfs`` is killed.
+
+    Raises:
+        SystemExit: With :data:`EXIT_MISSING_DEP` if the ``mkramfs``
+            tool is missing from the sysroot.
+        FileNotFoundError: A host path in *files* does not exist.
+            Treated as programmer error; not mapped to ``SystemExit``.
+    """
+    bin_dir = sysroot() / "bin"
+    tool = bin_dir / ("mkramfs.exe" if is_windows() else "mkramfs.elf")
+    if not tool.is_file():
+        log.fatal(
+            f"mkramfs not found at {tool}; run setup first.",
+            code=EXIT_MISSING_DEP,
+            hint="Ensure the sysroot contains mkramfs by running ./z setup.",
+        )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="nanvix_ramfs_") as tmpdir:
+        staging = Path(tmpdir) / "ramfs"
+        (staging / "tmp").mkdir(parents=True)
+        for guest, host in (files or {}).items():
+            dest = staging / guest.lstrip("/")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(host, dest)
+        run(str(tool), "-o", str(output), str(staging), timeout=timeout)
 
 
 def run(

--- a/tests/test_helpers_mkramfs.py
+++ b/tests/test_helpers_mkramfs.py
@@ -1,0 +1,98 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Tests for :func:`nanvix_zutil.helpers.mkramfs`."""
+
+from __future__ import annotations
+
+import subprocess as sp
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from nanvix_zutil import helpers
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+
+
+def _make_sysroot(nanvix_root: Path) -> Path:
+    """Create ``.nanvix/sysroot/bin`` with plausible tool files (Linux ext)."""
+    bin_dir = nanvix_root / ".nanvix" / "sysroot" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("mkramfs.elf", "mkramfs.exe"):
+        (bin_dir / name).write_bytes(b"")
+    return bin_dir
+
+
+class TestMkramfsHelper(unittest.TestCase):
+    """helpers.mkramfs stages files and invokes the sysroot tool."""
+
+    def setUp(self) -> None:
+        import os
+        import tempfile
+
+        from nanvix_zutil.paths import nanvix_root
+
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+
+        self._orig_cwd = Path.cwd()
+        self.addCleanup(os.chdir, self._orig_cwd)
+
+        os.chdir(self._td.name)
+
+        nanvix_root.cache_clear()
+        self.addCleanup(nanvix_root.cache_clear)
+
+        self.tmp = Path(self._td.name)
+        self.bin_dir = _make_sysroot(self.tmp)
+
+    def test_stages_files_and_ensures_tmp(self) -> None:
+        host = self.tmp / "sample.ref"
+        host.write_bytes(b"hello")
+
+        seen: list[tuple[str, bool]] = []
+
+        def spy(*args: str, **_kw: object) -> sp.CompletedProcess[str]:
+            # mkramfs invoked as: <tool> -o <output> <staging>
+            staging = Path(args[3])
+            seen.append(("tmp/sample.ref", (staging / "tmp/sample.ref").is_file()))
+            seen.append(("data/nested/file", (staging / "data/nested/file").is_file()))
+            seen.append(("tmp/", (staging / "tmp").is_dir()))
+            return sp.CompletedProcess(list(args), 0)
+
+        with patch("nanvix_zutil.helpers.run", side_effect=spy):
+            helpers.mkramfs(
+                self.tmp / "out.img",
+                files={"tmp/sample.ref": host, "data/nested/file": host},
+            )
+        self.assertEqual(
+            seen,
+            [
+                ("tmp/sample.ref", True),
+                ("data/nested/file", True),
+                ("tmp/", True),
+            ],
+        )
+
+    def test_ensures_tmp_when_no_files(self) -> None:
+        seen: dict[str, bool] = {}
+
+        def spy(*args: str, **_kw: object) -> sp.CompletedProcess[str]:
+            staging = Path(args[3])
+            seen["tmp"] = (staging / "tmp").is_dir()
+            return sp.CompletedProcess(list(args), 0)
+
+        with patch("nanvix_zutil.helpers.run", side_effect=spy):
+            helpers.mkramfs(self.tmp / "out.img")
+        self.assertTrue(seen.get("tmp"))
+
+    def test_missing_tool_is_fatal(self) -> None:
+        (self.bin_dir / "mkramfs.elf").unlink()
+        with patch("nanvix_zutil.helpers.is_windows", return_value=False):
+            with self.assertRaises(SystemExit) as ctx:
+                helpers.mkramfs(self.tmp / "out.img")
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# helpers: add mkramfs()

Closes #236.

## What

New helper `nanvix_zutil.helpers.mkramfs()`:

```python
def mkramfs(
    output: Path,
    *,
    files: Mapping[str, Path] | None = None,
    timeout: int = 60,
) -> None
```

Sister to `make_initrd`. Owns three moving parts that today's downstream
`test()` methods hand-roll every time:

1. Sysroot lookup for the `mkramfs` tool (Linux `.elf` / Windows `.exe`).
2. A private temp staging dir with `tmp/` pre-created (Nanvix convention).
3. Placing caller-supplied host files at caller-chosen guest paths
   (parent dirs created as needed), then invoking the tool to produce a
   ramfs image at `output`.

Missing tool → `SystemExit(EXIT_MISSING_DEP)` with the same
`./z setup`-oriented hint the rest of the sysroot helpers use.

## Why

Ramfs staging is duplicated across every consumer that runs functional
tests (sqlite, libxml2, libxslt, lxml, libffi, quickjs, xz, zlib, bzip2,
plus internal examples). Each copy re-does tool-path resolution and the
`tmp/`-ensure dance. Extracting once here means `StandaloneTest`
(#204, stacked on this) and future direct callers get one canonical
implementation.

## Design

- **Path-derived sysroot** — reads `paths.sysroot() / "bin"` directly.
  No `ZScript` / `Sysroot` object needed; would be vestigial here since
  the sysroot destination is already a fixed path.
- **`files` is a Mapping[guest_path, host_path]** — leading `/` on guest
  paths is stripped so both `"tmp/x"` and `"/tmp/x"` work; parents are
  created as needed. Empty / `None` still ensures `tmp/` exists.
- **Staging in `tempfile.TemporaryDirectory`** — cleaned up before
  return, whether the tool succeeded or not.
- **Missing host file → `FileNotFoundError` propagates** (from
  `shutil.copy2`). Treated as programmer error and documented as such;
  intentionally *not* mapped to `SystemExit`.
