### PR TITLE
[TST-3] testing: add StandaloneTest for booting nanvix ELFs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Enable KVM
+        run: |
+          test -e /dev/kvm || { echo "::error::/dev/kvm not found"; exit 1; }
+          test -w /dev/kvm || sudo chmod 666 /dev/kvm
+          ls -l /dev/kvm
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/examples/bin-hello/.nanvix/_test.py
+++ b/examples/bin-hello/.nanvix/_test.py
@@ -3,16 +3,16 @@
 # and to prevent collisions with stdlib
 
 import sys
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 from nanvix_zutil import (
-    CFG_SYSROOT,
-    EXIT_BUILD_FAILURE,
+    StandaloneTest,
+    StandaloneTestFailure,
     ZScript,
     log,
 )
+from nanvix_zutil.config import DeploymentMode
 from nanvix_zutil.exitcodes import EXIT_TEST_FAILURE
-from nanvix_zutil.helpers import run
 from nanvix_zutil.paths import repo_root
 
 
@@ -23,11 +23,16 @@ class Test:
     def test(self) -> None:
         """Run the test suite (smoke + integration + functional).
 
-        The functional test phase runs under ``nanvixd.elf`` inside a
-        Docker container on Linux, or natively under ``nanvixd.exe`` on
-        Windows.  On Linux, functional tests are skipped when Docker is
-        not configured (the ``test`` subcommand does not enable Docker
-        automatically).
+        Functional tests run the built ELF under ``nanvixd`` in
+        standalone mode via :class:`StandaloneTest`. That is the
+        shared plumbing all downstream consumers use — a case object
+        per invocation, ``.run()`` to boot, aggregate failures
+        yourself. The same code path runs on Linux and Windows;
+        ``nanvixd``'s host extension (``.elf`` vs ``.exe``) is picked
+        internally.
+
+        Non-standalone modes are not exercised here; they need
+        ``linuxd`` and a different topology (see design docs).
         """
         binary = repo_root() / "hello.elf"
 
@@ -51,76 +56,19 @@ class Test:
             log.fatal(f"{binary} is not a valid ELF binary.", code=EXIT_TEST_FAILURE)
         log.success(f"OK: {binary.name} is a valid ELF binary")
 
-        # Functional: run under nanvixd on the appropriate platform.
-        #
-        # On Linux the functional test requires Docker (nanvixd.elf
-        # cannot run directly on the CI host).  The ``test`` subcommand
-        # does not enable Docker, so functional tests are skipped unless
-        # Docker was explicitly configured.
-        #
-        # On Windows, nanvixd.exe is a native host binary and runs
-        # without Docker.
-        if sys.platform == "win32":
-            self._test_functional_windows(binary)
-        elif self.script.docker:
-            self._test_functional_docker(binary)
-        else:
-            log.info("=== skipping functional tests (Docker not configured) ===")
-
-    def _sysroot(self) -> PurePosixPath | Path:
-        """Return the sysroot path, translated for Docker if active."""
-        sysroot_str = self.script.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
+        log.info("=== bin-hello functional tests ===")
+        cases = [StandaloneTest(elf_path=binary)]
+        failures: list[StandaloneTestFailure] = []
+        for case in cases:
+            try:
+                case.run()
+            except StandaloneTestFailure as e:
+                failures.append(e)
+        if failures:
+            for f in failures:
+                log.warning(f"  {f}")
             log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_BUILD_FAILURE,
-            )
-        host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.script.docker.translate_path(host) if self.script.docker else host
-
-    def _test_functional_docker(self, binary: Path) -> None:
-        """Run functional tests inside a Docker container (Linux)."""
-        log.info("=== bin-hello functional tests (Docker) ===")
-        sysroot = self._sysroot()
-        workspace_binary = (
-            self.script.docker.translate_path(binary) if self.script.docker else binary
-        )
-        run(
-            "timeout",
-            "--foreground",
-            "60",
-            f"{sysroot}/bin/nanvixd.elf",
-            "-bin-dir",
-            f"{sysroot}/bin",
-            "--",
-            str(workspace_binary),
-            docker=self.script.docker,
-        )
-        log.success("PASS: bin-hello functional tests")
-
-    def _test_functional_windows(self, binary: Path) -> None:
-        """Run functional tests natively on Windows using nanvixd.exe."""
-        log.info("=== bin-hello functional tests (Windows) ===")
-        sysroot_str = self.script.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
-            log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
+                f"{len(failures)} functional test(s) failed.",
                 code=EXIT_TEST_FAILURE,
             )
-        sysroot = Path(sysroot_str)  # type: ignore[arg-type]
-        nanvixd = sysroot / "bin" / "nanvixd.exe"
-        if not nanvixd.exists():
-            log.fatal(
-                f"{nanvixd} not found — run 'nanvix-zutil setup' to download it.",
-                code=EXIT_TEST_FAILURE,
-            )
-        run(
-            str(nanvixd),
-            "-bin-dir",
-            str(sysroot / "bin"),
-            "--",
-            str(binary),
-            cwd=repo_root(),
-            timeout=60,
-        )
         log.success("PASS: bin-hello functional tests")

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -131,6 +131,7 @@ from nanvix_zutil.sdk import (
 )
 from nanvix_zutil.script import ZScript
 from nanvix_zutil.sysroot import Sysroot
+from nanvix_zutil.testing import StandaloneTest, StandaloneTestFailure
 
 __all__ = [
     "ArchiveFormat",
@@ -205,6 +206,8 @@ __all__ = [
     "sync_configs",
     "write_lockfile",
     "InitRdArgs",
+    "StandaloneTest",
+    "StandaloneTestFailure",
     "mkramfs",
     "parse_sdk_version",
     "validate_sdk_release",

--- a/src/nanvix_zutil/paths.py
+++ b/src/nanvix_zutil/paths.py
@@ -103,8 +103,15 @@ def buildroot() -> Path:
 
 
 def sysroot() -> Path:
-    """Path to the sysroot (``.nanvix/sysroot``).
+    """Path to the sysroot.
 
-    Used to store items needed at runtime.
+    Prefers the configured ``NANVIX_SYSROOT`` from ``env.json`` so
+    downstreams that stage a shared sysroot outside ``.nanvix/sysroot``
+    (e.g. Windows CI reusing another consumer's) resolve correctly.
+    Falls back to ``.nanvix/sysroot`` when unset.
     """
-    return nanvix_root() / "sysroot"
+    # Deferred import: ``config`` imports ``paths.nanvix_root``.
+    from nanvix_zutil.config import CFG_SYSROOT, Config
+
+    configured = Config().get(CFG_SYSROOT)
+    return Path(configured) if configured else nanvix_root() / "sysroot"

--- a/src/nanvix_zutil/testing.py
+++ b/src/nanvix_zutil/testing.py
@@ -1,0 +1,226 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Standalone-mode test-case abstraction for booting ELFs under ``nanvixd``.
+
+Consumers that ship Nanvix ELF test binaries duplicate the same
+boilerplate: locate ``nanvixd``/``mkramfs`` in the sysroot, build an
+initrd, stage a ramfs, run ``mkramfs`` then ``nanvixd``, and translate
+failures into a summary. This module hoists that plumbing behind
+:class:`StandaloneTest` so each consumer's ``test()`` reduces to
+building a list of cases and iterating.
+
+Scope is deliberately narrow: **standalone deployment mode only**, one
+ELF per case. Multi-/single-process modes require ``linuxd`` and are a
+different plumbing story; upstream-driven test drivers (``make check``
+& friends) stay outside this API. Strategy (allowlists, skiplists,
+parametrised invocations, stdin fixtures) stays with the consumer.
+
+Test failures raise :class:`StandaloneTestFailure`, a structured
+exception carrying the case, exit code, and reason. Environment
+failures (missing tools/ELF, broken sysroot) continue to surface as
+``SystemExit`` — those are per-run problems, not per-test.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from nanvix_zutil import log
+from nanvix_zutil.docker import is_windows
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+from nanvix_zutil.helpers import InitRdArgs, make_initrd, mkramfs
+from nanvix_zutil.paths import sysroot, test_out
+
+
+@dataclass
+class StandaloneTestFailure(Exception):
+    """Raised by :meth:`StandaloneTest.run` when the run fails.
+
+    Attributes:
+        case: The failing test case (for callers who want to introspect
+            more than the label).
+        returncode: Child exit code. ``None`` when the run timed out
+            or the ELF could not be executed.
+        reason: Short human-readable description
+            (``"exited 5"`` / ``"timed out after 120s"`` /
+            ``"failed to execute: ..."``).
+    """
+
+    case: StandaloneTest
+    returncode: int | None
+    reason: str
+
+    def __post_init__(self) -> None:
+        # Keep Exception.args populated so pytest/log tooling that
+        # reads .args still surfaces the failure detail.
+        super().__init__(self.reason)
+
+    def __str__(self) -> str:
+        return f"{self.case.name}: {self.reason}"
+
+
+@dataclass
+class StandaloneTest:
+    """One ELF-under-``nanvixd`` invocation in standalone mode.
+
+    The ELF is read from :attr:`elf_path` as-is — no copy, no lookup
+    in ``repo_root``. Point at wherever the build system drops it
+    (typically ``repo_root() / "foo.elf"``).
+
+    Attributes:
+        elf_path: Location of the test ELF on disk.
+        app_args: Argv appended to the app inside the initrd.
+        nanvixd_args: Extra arguments spliced into the ``nanvixd``
+            command line, immediately before the ``--`` separator
+            (i.e. after ``-bin-dir``/``-ramfs`` and before the initrd
+            path). Use this for per-platform toggles like
+            ``-memory-size``.
+        ramfs_files: Guest-path → host-path map staged into the ramfs
+            before ``mkramfs`` runs. Guest paths are POSIX-style and
+            relative to the ramfs root; parent directories are
+            created as needed. A ``tmp/`` directory is always present.
+        stdin: Bytes piped into ``nanvixd``'s standard input.
+        timeout: Seconds before ``nanvixd`` is killed.
+        label: Human-readable name for logs. Defaults to
+            ``elf_path.stem``.
+    """
+
+    elf_path: Path
+    app_args: Sequence[str] = ()
+    nanvixd_args: Sequence[str] = ()
+    ramfs_files: Mapping[str, Path] = field(default_factory=lambda: {})
+    stdin: bytes | None = None
+    timeout: int = 120
+    label: str | None = None
+
+    @property
+    def name(self) -> str:
+        return self.label or self.elf_path.stem
+
+    @property
+    def _fs_name(self) -> str:
+        """``name`` sanitized for use in filesystem paths.
+
+        Labels may contain ``/``, ``\\``, or other separators that
+        would silently create subdirectories (or fail outright on
+        Windows). Collapse anything outside ``[A-Za-z0-9._-]`` to ``_``.
+        """
+        return re.sub(r"[^A-Za-z0-9._-]+", "_", self.name) or "test"
+
+    def run(self, script: object | None = None) -> None:
+        """Boot the ELF under ``nanvixd``.
+
+        Args:
+            script: Accepted for API compatibility with callers that
+                pass their :class:`ZScript`. Currently unused; the
+                sysroot is resolved via :func:`nanvix_zutil.paths.sysroot`
+                (which honors ``env.json``).
+
+        Raises:
+            StandaloneTestFailure: The child exited non-zero or timed
+                out. Contains ``returncode`` and ``reason``.
+            SystemExit: Environment failure (missing sysroot, ELF,
+                ``nanvixd``, ``mkramfs``, or ``mkimage``). Not a test
+                failure; propagate as-is.
+        """
+        name = self.name
+        fs_name = self._fs_name
+        sysroot_bin = sysroot() / "bin"
+        nanvixd = sysroot_bin / ("nanvixd.exe" if is_windows() else "nanvixd.elf")
+        if not nanvixd.is_file():
+            log.fatal(
+                f"{nanvixd.name} not found at {nanvixd}.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `./z setup` first.",
+            )
+
+        if not self.elf_path.is_file():
+            log.fatal(
+                f"Test ELF not found: {self.elf_path}",
+                code=EXIT_MISSING_DEP,
+                hint="Build the test binaries before running tests.",
+            )
+
+        log.info(f"RUN  {name}")
+        # Precompute so cleanup runs even if make_initrd raises (mkimage may
+        # have written a partial image before failing).
+        initrd = test_out() / f"{self._fs_name}.img"
+        try:
+            make_initrd(
+                self.elf_path,
+                test_out(),
+                args=InitRdArgs(app_args=list(self.app_args) or None),
+            )
+            with tempfile.TemporaryDirectory(prefix=f"nanvix_{fs_name}_") as tmpdir:
+                ramfs_img = Path(tmpdir) / f"rootfs_{fs_name}.img"
+                mkramfs(ramfs_img, files=self.ramfs_files)
+                self._invoke_nanvixd(nanvixd, sysroot_bin, ramfs_img, initrd)
+        finally:
+            if initrd.exists():
+                initrd.unlink()
+
+        log.success(f"OK   {name}")
+
+    def _invoke_nanvixd(
+        self,
+        nanvixd: Path,
+        sysroot_bin: Path,
+        ramfs_img: Path,
+        initrd: Path,
+    ) -> None:
+        """Run ``nanvixd`` and translate exit codes into typed failures.
+
+        Bypasses :func:`nanvix_zutil.helpers.run` because that wrapper
+        funnels non-zero exits through ``log.fatal`` and discards the
+        child's returncode. We need the returncode intact so
+        :class:`StandaloneTestFailure` can carry it.
+        """
+        cmd = [
+            str(nanvixd),
+            "-bin-dir",
+            str(sysroot_bin),
+            "-ramfs",
+            str(ramfs_img),
+            *self.nanvixd_args,
+            "--",
+            str(initrd),
+        ]
+        log.info(f"$ {' '.join(cmd)}")
+        try:
+            result = subprocess.run(
+                cmd,
+                input=self.stdin,
+                text=(self.stdin is None),
+                timeout=self.timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            log.warning(f"FAIL {self.name} (timed out after {self.timeout}s)")
+            raise StandaloneTestFailure(
+                case=self,
+                returncode=None,
+                reason=f"timed out after {self.timeout}s",
+            ) from exc
+        except OSError as exc:
+            # Non-executable ELF, permission-denied, etc. The nanvixd
+            # tool exists (checked up front) so this is about the
+            # subprocess failing to start with the given argv.
+            log.warning(f"FAIL {self.name} (failed to execute: {exc})")
+            raise StandaloneTestFailure(
+                case=self,
+                returncode=None,
+                reason=f"failed to execute: {exc}",
+            ) from exc
+        if result.returncode != 0:
+            log.warning(f"FAIL {self.name} (exited {result.returncode})")
+            raise StandaloneTestFailure(
+                case=self,
+                returncode=result.returncode,
+                reason=f"exited {result.returncode}",
+            )

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,245 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# pyright: reportPrivateUsage=false
+"""Tests for :mod:`nanvix_zutil.testing`."""
+
+from __future__ import annotations
+
+import subprocess as sp
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
+from nanvix_zutil.paths import test_out as _test_out
+from nanvix_zutil.testing import StandaloneTest, StandaloneTestFailure
+
+
+def _make_sysroot(nanvix_root: Path) -> Path:
+    """Create ``.nanvix/sysroot/bin`` with plausible tool files (Linux ext)."""
+    bin_dir = nanvix_root / ".nanvix" / "sysroot" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("nanvixd.elf", "mkramfs.elf", "mkimage.elf"):
+        (bin_dir / name).write_bytes(b"")
+    return bin_dir
+
+
+def _make_elf(tmp_path: Path, name: str = "example.elf") -> Path:
+    elf = tmp_path / name
+    elf.write_bytes(b"")
+    return elf
+
+
+def _fake_make_initrd(*_args: object, **_kwargs: object) -> Path:
+    """Stand-in for make_initrd; drops a dummy file in test_out()."""
+    out = _test_out() / "example.img"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(b"")
+    return out
+
+
+def _fake_mkramfs(*_args: object, **_kwargs: object) -> None:
+    """Stand-in for mkramfs; the helper's own tests cover its plumbing."""
+    return None
+
+
+def _proc(rc: int) -> sp.CompletedProcess[bytes]:
+    return sp.CompletedProcess([], rc)
+
+
+def _ok_proc(*_a: object, **_kw: object) -> sp.CompletedProcess[bytes]:
+    return _proc(0)
+
+
+def _fail_proc(*_a: object, **_kw: object) -> sp.CompletedProcess[bytes]:
+    return _proc(5)
+
+
+class TestStandaloneTest(unittest.TestCase):
+    """Exercise StandaloneTest.run() with mocked subprocess plumbing."""
+
+    def setUp(self) -> None:
+        self.tmp = Path.cwd()
+        self.bin_dir = _make_sysroot(self.tmp)
+        self.elf = _make_elf(self.tmp)
+
+    def _patch_runtime(
+        self,
+        *,
+        subprocess_side_effect: object = None,
+        make_initrd: object = _fake_make_initrd,
+        mkramfs: object = _fake_mkramfs,
+    ) -> tuple[MagicMock, MagicMock, MagicMock]:
+        """Patch subprocess.run + make_initrd + mkramfs inside testing."""
+        sp_mock = MagicMock(side_effect=subprocess_side_effect or _ok_proc)
+        initrd_mock = MagicMock(side_effect=make_initrd)
+        mkramfs_mock = MagicMock(side_effect=mkramfs)
+        self.addCleanup(patch.stopall)
+        patch("nanvix_zutil.testing.subprocess.run", sp_mock).start()
+        patch("nanvix_zutil.testing.make_initrd", initrd_mock).start()
+        patch("nanvix_zutil.testing.mkramfs", mkramfs_mock).start()
+        patch("nanvix_zutil.testing.is_windows", return_value=False).start()
+        return sp_mock, initrd_mock, mkramfs_mock
+
+    # ---------- happy path ----------
+
+    def test_success_returns_none(self) -> None:
+        sp_mock, _, mkramfs_mock = self._patch_runtime()
+        StandaloneTest(elf_path=self.elf).run()  # no raise = pass
+        self.assertEqual(mkramfs_mock.call_count, 1)
+        self.assertEqual(sp_mock.call_count, 1)
+        cmd = sp_mock.call_args.args[0]
+        self.assertIn("nanvixd.elf", cmd[0])
+        self.assertIn("-bin-dir", cmd)
+        self.assertIn("-ramfs", cmd)
+
+    def test_windows_selects_exe_extension(self) -> None:
+        for f in self.bin_dir.iterdir():
+            f.unlink()
+        for name in ("nanvixd.exe", "mkramfs.exe", "mkimage.exe"):
+            (self.bin_dir / name).write_bytes(b"")
+
+        sp_mock = MagicMock(return_value=_proc(0))
+        self.addCleanup(patch.stopall)
+        patch("nanvix_zutil.testing.subprocess.run", sp_mock).start()
+        patch(
+            "nanvix_zutil.testing.make_initrd", MagicMock(side_effect=_fake_make_initrd)
+        ).start()
+        patch(
+            "nanvix_zutil.testing.mkramfs", MagicMock(side_effect=_fake_mkramfs)
+        ).start()
+        patch("nanvix_zutil.testing.is_windows", return_value=True).start()
+
+        StandaloneTest(elf_path=self.elf).run()
+        self.assertIn("nanvixd.exe", sp_mock.call_args.args[0][0])
+
+    # ---------- failure translation ----------
+
+    def test_nonzero_exit_raises_typed_failure(self) -> None:
+        self._patch_runtime(subprocess_side_effect=_fail_proc)
+        case = StandaloneTest(elf_path=self.elf, label="mytest")
+        with self.assertRaises(StandaloneTestFailure) as ctx:
+            case.run()
+        self.assertIs(ctx.exception.case, case)
+        self.assertEqual(ctx.exception.returncode, 5)
+        self.assertEqual(ctx.exception.reason, "exited 5")
+        self.assertEqual(str(ctx.exception), "mytest: exited 5")
+
+    def test_timeout_raises_typed_failure(self) -> None:
+        def _timeout(*_a: object, **_kw: object) -> sp.CompletedProcess[bytes]:
+            raise sp.TimeoutExpired(cmd="nanvixd", timeout=120)
+
+        self._patch_runtime(subprocess_side_effect=_timeout)
+        case = StandaloneTest(elf_path=self.elf, timeout=120)
+        with self.assertRaises(StandaloneTestFailure) as ctx:
+            case.run()
+        self.assertIsNone(ctx.exception.returncode)
+        self.assertEqual(ctx.exception.reason, "timed out after 120s")
+        # Finally must still run on timeout.
+        self.assertFalse((_test_out() / "example.img").exists())
+
+    def test_oserror_raises_typed_failure(self) -> None:
+        # e.g. permission-denied, non-executable ELF at exec time.
+        def _oserror(*_a: object, **_kw: object) -> sp.CompletedProcess[bytes]:
+            raise PermissionError(13, "Permission denied")
+
+        self._patch_runtime(subprocess_side_effect=_oserror)
+        case = StandaloneTest(elf_path=self.elf)
+        with self.assertRaises(StandaloneTestFailure) as ctx:
+            case.run()
+        self.assertIsNone(ctx.exception.returncode)
+        self.assertIn("failed to execute", ctx.exception.reason)
+
+    # ---------- fatal preconditions (env, not test failures) ----------
+
+    def test_missing_nanvixd_is_fatal(self) -> None:
+        (self.bin_dir / "nanvixd.elf").unlink()
+        self._patch_runtime()
+        with self.assertRaises(SystemExit) as ctx:
+            StandaloneTest(elf_path=self.elf).run()
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+
+    def test_missing_elf_is_fatal(self) -> None:
+        self._patch_runtime()
+        with self.assertRaises(SystemExit) as ctx:
+            StandaloneTest(elf_path=self.tmp / "nope.elf").run()
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+
+    def test_make_initrd_fatal_is_not_swallowed(self) -> None:
+        def _boom(*_a: object, **_kw: object) -> Path:
+            raise SystemExit(EXIT_MISSING_DEP)
+
+        self._patch_runtime(make_initrd=_boom)
+        with self.assertRaises(SystemExit) as ctx:
+            StandaloneTest(elf_path=self.elf).run()
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+
+    def test_mkramfs_fatal_is_not_swallowed(self) -> None:
+        def _boom(*_a: object, **_kw: object) -> None:
+            raise SystemExit(EXIT_MISSING_DEP)
+
+        self._patch_runtime(mkramfs=_boom)
+        with self.assertRaises(SystemExit) as ctx:
+            StandaloneTest(elf_path=self.elf).run()
+        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+        # Finally must still run on fatal.
+        self.assertFalse((_test_out() / "example.img").exists())
+
+    # ---------- payload plumbing ----------
+
+    def test_stdin_forwarded_to_nanvixd(self) -> None:
+        sp_mock, _, _ = self._patch_runtime()
+        payload = b"SELECT 1;\n"
+        StandaloneTest(elf_path=self.elf, stdin=payload).run()
+        kwargs = sp_mock.call_args.kwargs
+        self.assertEqual(kwargs.get("input"), payload)
+        self.assertIs(kwargs.get("text"), False)
+
+    def test_no_stdin_uses_text_mode(self) -> None:
+        sp_mock, _, _ = self._patch_runtime()
+        StandaloneTest(elf_path=self.elf).run()
+        kwargs = sp_mock.call_args.kwargs
+        self.assertIsNone(kwargs.get("input"))
+        self.assertIs(kwargs.get("text"), True)
+
+    def test_ramfs_files_forwarded_to_mkramfs(self) -> None:
+        host = self.tmp / "sample.ref"
+        host.write_bytes(b"hello")
+        _, _, mkramfs_mock = self._patch_runtime()
+        files = {"tmp/sample.ref": host, "data/nested/file": host}
+        StandaloneTest(elf_path=self.elf, ramfs_files=files).run()
+        self.assertEqual(mkramfs_mock.call_args.kwargs.get("files"), files)
+
+    def test_app_args_forwarded_to_initrd(self) -> None:
+        _, initrd_mock, _ = self._patch_runtime()
+        StandaloneTest(elf_path=self.elf, app_args=("-k", "-f", "/tmp/x")).run()
+        self.assertEqual(
+            initrd_mock.call_args.kwargs["args"].app_args, ["-k", "-f", "/tmp/x"]
+        )
+
+    def test_timeout_forwarded_to_nanvixd(self) -> None:
+        sp_mock, _, _ = self._patch_runtime()
+        StandaloneTest(elf_path=self.elf, timeout=180).run()
+        self.assertEqual(sp_mock.call_args.kwargs.get("timeout"), 180)
+
+    def test_label_overrides_default_name(self) -> None:
+        case = StandaloneTest(elf_path=self.elf, label="compress-sample1")
+        self.assertEqual(case.name, "compress-sample1")
+
+    # ---------- cleanup ----------
+
+    def test_initrd_removed_after_success(self) -> None:
+        self._patch_runtime()
+        StandaloneTest(elf_path=self.elf).run()
+        self.assertFalse((_test_out() / "example.img").exists())
+
+    def test_initrd_removed_after_test_failure(self) -> None:
+        self._patch_runtime(subprocess_side_effect=_fail_proc)
+        with self.assertRaises(StandaloneTestFailure):
+            StandaloneTest(elf_path=self.elf).run()
+        self.assertFalse((_test_out() / "example.img").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# testing: add StandaloneTest for booting nanvix ELFs

> Takes over from #319, accidentally closed.

Closes #204. **Stacks on #236.**

## What

New module `nanvix_zutil.testing` with two public names:

- `StandaloneTest` — dataclass describing one ELF-under-nanvixd run
  (`elf_path`, optional `label`, `app_args`, `ramfs_files`, `stdin`,
  `timeout`). `run(script)` builds an initrd (via `make_initrd`), stages
  the ramfs (via `mkramfs` from #236), invokes `nanvixd`, and cleans up.
- `StandaloneTestFailure` — dataclass exception carrying `case`,
  `returncode: int | None`, `reason: str`. Raised on per-case failures
  so callers can aggregate and report:

  ```python
  failures: list[StandaloneTestFailure] = []
  for case in cases:
      try:
          case.run(self.script)
      except StandaloneTestFailure as e:
          failures.append(e)
  if failures:
      log.fatal(f"{len(failures)} test(s) failed.", code=EXIT_TEST_FAILURE)
  ```

Also collapses the `examples/bin-hello/.nanvix/_test.py` platform-triage
shape (windows/docker/skip) into one `StandaloneTest`-based path, gated
on `DeploymentMode.standalone`. This gives downstream authors a
canonical example to copy.

## Why

Ten downstreams currently duplicate ~60 lines each of sysroot lookup,
initrd bundling, ramfs staging, and `nanvixd` invocation across their
`test()` methods (sqlite, libxml2, libxslt, lxml, libffi, quickjs, xz,
zlib, bzip2). Every copy re-invents the same plumbing while diverging
subtly on failure reporting and cleanup.

`StandaloneTest` owns the plumbing; consumers keep the *strategy* —
which cases to build, which fixtures to stage, how to aggregate
failures. Downstream `test()` bodies collapse to a case list plus a
try/except loop.

## Design

**Scope: standalone only.** The class name is deliberate: it targets
`DeploymentMode.standalone`. There is no attempt to abstract over
multi-/single-process modes here — those callers keep their bespoke
paths. This matches the deprecation direction for the non-standalone
modes.

**Failure translation.** Three axes, all mapped to
`StandaloneTestFailure`:

- Non-zero child exit → `returncode=N, reason="exited N"`.
- `subprocess.TimeoutExpired` → `returncode=None, reason="timed out
  after {timeout}s"`.
- `OSError` from `subprocess.run` (permission-denied, non-executable
  ELF, etc.) → `returncode=None, reason="failed to execute: ..."`.

Environment failures (missing `nanvixd`/`mkramfs`/ELF, `make_initrd`
internal fatal, `mkramfs` internal fatal) continue to propagate as
`SystemExit(EXIT_MISSING_DEP)`. They are *not* per-test failures.

**`StandaloneTestFailure` is a dataclass Exception with
`__post_init__` populating `Exception.args`.** Ensures pytest and log
tooling that reads `.args` still surfaces the failure detail; `__str__`
gives the pretty `label: reason` form for direct logging.

**Cleanup runs on every path.** The initrd image is removed in a
`finally` block whether the case passed, failed, timed out, or was
aborted by a fatal.

## Example migration

`examples/bin-hello/.nanvix/_test.py` shrinks from ~130 lines of
`is_windows()` / `is_docker_running()` triage to a single
standalone-mode-gated `StandaloneTest` invocation with aggregation.

This is a **deliberate semantic shift** from the old direct-load
(`nanvixd -- binary`) shape to standalone-bundled (initrd + ramfs +
`nanvixd -bin-dir ...`). The standalone-bundled shape is what
production consumers run, so the example now demonstrates the API
downstream authors will actually copy.
