### PR TITLE
[SYS-1] cli: drop --sysroot-path setup flag

### DIFF
--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -25,13 +25,17 @@ all artifacts to be available locally via `--with-nanvix`.  In offline mode:
   `PATH/deps/<name>/`.
 - Missing individual local dependencies produce a warning rather than a fatal
   error so local development can provide them by other means.
-- A local sysroot must be provided via `--sysroot-path`.
+- A local sysroot must be declared in `nanvix.toml` via a `LOCAL` sysroot ref.
 
-## Sysroot Path Override
+## Local Sysroot
 
-The `--sysroot-path PATH` flag provides an explicit local sysroot
-directory, bypassing the GitHub download entirely.  This takes
-precedence over version-based resolution.
+Declare the sysroot as a filesystem path in `nanvix.toml` to bypass the
+GitHub download entirely:
+
+```toml
+[package]
+nanvix = { local = "/path/to/sysroot" }
+```
 
 ## Prerequisites
 
@@ -88,8 +92,7 @@ PYTHONPATH=~/nanvix/usr/lib/zutils/src \
     --offline \
     --with-docker ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35 \
     --allow-local-docker-override \
-    --with-nanvix ~/nanvix/build \
-    --sysroot-path ~/nanvix/build/sysroot
+    --with-nanvix ~/nanvix/build
 
 # Then build
 PYTHONPATH=~/nanvix/usr/lib/zutils/src \

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -189,16 +189,6 @@ def build_parser(
                 " Relative paths and ~ are accepted; the path is"
                 " canonicalised to an absolute directory.",
             )
-            sub.add_argument(
-                "--sysroot-path",
-                type=str,
-                metavar="PATH",
-                dest="sysroot_path",
-                help="Explicit path to a local sysroot directory,"
-                " bypassing sysroot download/version resolution."
-                " The manifest's nanvix-version is still used for"
-                " dependency tag suffixing.",
-            )
         if name == "install":
             sub.add_argument(
                 "--output",

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -177,7 +177,6 @@ class ZScript:
         self.docker: DockerConfig | None = None
         self._offline: bool = False
         self._with_nanvix_path: str | None = None
-        self._cli_sysroot_path: str | None = None
 
     # ------------------------------------------------------------------
     # Hook classification helpers
@@ -277,15 +276,8 @@ class ZScript:
         Returns:
             ``False``. Degraded legacy setup no longer exists.
         """
-        # Resolve sysroot: --sysroot-path takes precedence.
-        sysroot_path = self._cli_sysroot_path
-
-        if sysroot_path:
-            self.sysroot = Sysroot.from_local(
-                Path(sysroot_path),
-                config=self.config,
-            )
-        elif self.manifest.sysroot_ref.kind == RefKind.LOCAL:
+        # Resolve sysroot: manifest LOCAL ref takes precedence over download.
+        if self.manifest.sysroot_ref.kind == RefKind.LOCAL:
             self.sysroot = Sysroot.from_local(
                 Path(str(self.manifest.sysroot_ref.value)),
                 config=self.config,
@@ -293,7 +285,7 @@ class ZScript:
         elif self._offline:
             log.fatal(
                 "Offline mode requires a local sysroot."
-                " Set --sysroot-path to a directory.",
+                " Declare a LOCAL sysroot ref in nanvix.toml.",
                 code=EXIT_MISSING_DEP,
             )
         else:
@@ -616,14 +608,12 @@ class ZScript:
         args = parser.parse_args(framework_argv)
 
         # ------------------------------------------------------------------
-        # Handle --offline, --with-nanvix, --sysroot-path from CLI.
+        # Handle --offline, --with-nanvix from CLI.
         # ------------------------------------------------------------------
         if getattr(args, "offline", False):
             instance._offline = True
         if getattr(args, "with_nanvix", None):
             instance._with_nanvix_path = args.with_nanvix
-        if getattr(args, "sysroot_path", None):
-            instance._cli_sysroot_path = args.sysroot_path
 
         # ------------------------------------------------------------------
         # Docker: resolve image from CLI or persisted config, then check availability.

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -81,7 +81,7 @@ class Sysroot:
             log.fatal(
                 f"Local sysroot path is not a directory: {local_path}",
                 code=EXIT_MISSING_DEP,
-                hint="Pass --sysroot-path with a valid sysroot directory.",
+                hint="Declare a LOCAL sysroot ref in nanvix.toml.",
             )
         log.info(f"Using local sysroot at {resolved}")
         if config is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,29 +248,6 @@ class TestWithNanvixFlag(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
-class TestSysrootPathFlag(unittest.TestCase):
-    """Tests for the --sysroot-path flag on the setup subcommand."""
-
-    def test_sysroot_path_parsed(self) -> None:
-        parser = build_parser()
-        args = parser.parse_args(
-            ["setup", "--with-docker", "img:t", "--sysroot-path", "/my/sysroot"]
-        )
-        self.assertEqual(args.sysroot_path, "/my/sysroot")
-
-    def test_sysroot_path_default_none(self) -> None:
-        parser = build_parser()
-        args = parser.parse_args(["setup", "--with-docker", "img:t"])
-        self.assertIsNone(args.sysroot_path)
-
-    def test_sysroot_path_rejected_on_test(self) -> None:
-        """--sysroot-path is only accepted on setup."""
-        parser = build_parser()
-        with self.assertRaises(SystemExit) as ctx:
-            parser.parse_args(["test", "--sysroot-path", "/p"])
-        self.assertEqual(ctx.exception.code, 2)
-
-
 class TestInstallArtifactsSubcommand(unittest.TestCase):
     """Tests for the install subcommand."""
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1150,28 +1150,6 @@ class TestZScriptSetupLocalSysroot(unittest.TestCase):
             mock_download.assert_not_called()
             mock_from_local.assert_called_once()
 
-    def test_local_sysroot_via_cli_sysroot_path(self) -> None:
-        """When --sysroot-path is provided, Sysroot.from_local is used."""
-        repo_root = paths.repo_root()
-        local_sysroot = repo_root / "my-sysroot"
-        local_sysroot.mkdir()
-
-        write_manifest()
-
-        script = ZScript()
-        script._cli_sysroot_path = str(local_sysroot)
-
-        with (
-            patch("nanvix_zutil.script.Sysroot.download") as mock_download,
-            patch(
-                "nanvix_zutil.script.Sysroot.from_local",
-                return_value=MagicMock(path=local_sysroot, tag=""),
-            ) as mock_from_local,
-        ):
-            script.setup()
-            mock_download.assert_not_called()
-            mock_from_local.assert_called_once()
-
 
 class TestHelpersMakeInitrd(unittest.TestCase):
     """helpers.make_initrd() builds the correct mkimage command."""
@@ -1700,19 +1678,19 @@ class TestOfflineMode(unittest.TestCase):
         script = ZScript()
         self.assertIsNone(script._with_nanvix_path)
 
-    def test_cli_sysroot_path_initially_none(self) -> None:
-        """_cli_sysroot_path starts as None."""
+    def test_cli_sysroot_path_attr_removed(self) -> None:
+        """_cli_sysroot_path attribute no longer exists."""
         script = ZScript()
-        self.assertIsNone(script._cli_sysroot_path)
+        self.assertFalse(hasattr(script, "_cli_sysroot_path"))
 
-    def test_offline_with_sysroot_path_uses_from_local(self) -> None:
-        """In offline mode with --sysroot-path, Sysroot.from_local is used."""
+    def test_offline_with_local_sysroot_ref_uses_from_local(self) -> None:
+        """In offline mode with a LOCAL sysroot ref, Sysroot.from_local is used."""
         sysroot_dir = paths.repo_root() / "my-sysroot"
         sysroot_dir.mkdir()
 
         script = ZScript()
         script._offline = True
-        script._cli_sysroot_path = str(sysroot_dir)
+        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
         script._with_nanvix_path = str(paths.repo_root())
 
         fake_sysroot = MagicMock()
@@ -1731,7 +1709,7 @@ class TestOfflineMode(unittest.TestCase):
             mock_from_local.assert_called_once()
 
     def test_offline_without_sysroot_exits(self) -> None:
-        """Offline mode without a local sysroot path exits fatally."""
+        """Offline mode without a LOCAL sysroot ref exits fatally."""
         script = ZScript()
         script._offline = True
 
@@ -1748,7 +1726,7 @@ class TestOfflineMode(unittest.TestCase):
 
         script = ZScript()
         script._offline = True
-        script._cli_sysroot_path = str(sysroot_dir)
+        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
 
         fake_sysroot = MagicMock()
         fake_sysroot.path = sysroot_dir
@@ -1776,7 +1754,7 @@ class TestOfflineMode(unittest.TestCase):
 
         script = ZScript()
         script._offline = True
-        script._cli_sysroot_path = str(sysroot_dir)
+        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
         script._with_nanvix_path = str(build_dir)
 
         fake_sysroot = MagicMock()
@@ -1801,7 +1779,7 @@ class TestOfflineMode(unittest.TestCase):
 
         script = ZScript()
         script._offline = True
-        script._cli_sysroot_path = str(sysroot_dir)
+        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
         script._with_nanvix_path = str(build_dir)
 
         fake_sysroot = MagicMock()


### PR DESCRIPTION
`--sysroot-path PATH` was a redundant CLI surface for overriding the sysroot location. This flag is removed; the on-disk `.nanvix/sysroot` is the authoritative location.

Preparation for #300 and for the stacked follow-up `chore/drop-local-sysroot-refs`, which removes the second override surface.

**Behavior change:** `--sysroot-path` no longer accepted on `setup`.