### PR TITLE
[SYS-2] cli: drop LOCAL sysroot code paths

### DIFF
--- a/docs/with-nanvix.md
+++ b/docs/with-nanvix.md
@@ -16,26 +16,20 @@ etc.) without publishing a release.
 
 ## Offline Mode
 
-The `--offline` flag skips the dependency resolver entirely and requires
-all artifacts to be available locally via `--with-nanvix`.  In offline mode:
+The `--offline` flag skips the dependency resolver entirely and reuses
+the sysroot already extracted at `.nanvix/sysroot`.  Run `./z setup`
+online at least once (or copy the directory in) before using it.  In
+offline mode:
 
 - `--with-nanvix PATH` is **required** — a fatal error is raised if it
   is not provided.
+- `.nanvix/sysroot` is created if missing and populated from `PATH/bin/`
+  and `PATH/lib/`.  Verification then decides whether the result is
+  sufficient.
 - **All** dependencies (not just `nanvix/`-owned) are resolved from
   `PATH/deps/<name>/`.
-- Missing individual local dependencies produce a warning rather than a fatal
-  error so local development can provide them by other means.
-- A local sysroot must be declared in `nanvix.toml` via a `LOCAL` sysroot ref.
-
-## Local Sysroot
-
-Declare the sysroot as a filesystem path in `nanvix.toml` to bypass the
-GitHub download entirely:
-
-```toml
-[package]
-nanvix = { local = "/path/to/sysroot" }
-```
+- Missing individual local dependencies produce a warning rather than a
+  fatal error so local development can provide them by other means.
 
 ## Prerequisites
 

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -176,8 +176,8 @@ def build_parser(
                 "--offline",
                 action="store_true",
                 default=False,
-                help="Skip the dependency resolver entirely and require"
-                " all artifacts to be available locally via --with-nanvix.",
+                help="Skip all network calls. Reuses .nanvix/sysroot as-is;"
+                " combine with --with-nanvix to overlay locally-built artifacts.",
             )
             sub.add_argument(
                 "--with-nanvix",

--- a/src/nanvix_zutil/manifest.py
+++ b/src/nanvix_zutil/manifest.py
@@ -513,16 +513,15 @@ def load_manifest(path: Path | None = None) -> Manifest:
     )
 
     # Auto-suffix VERSION refs with the exact SDK revision.
-    if sysroot_ref.kind != RefKind.LOCAL:
-        version_suffix = toolchain.sdk.version.removeprefix("v")
-        for dep in [*dependencies, *system_dependencies]:
-            if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
-                if "-nanvix-" in dep.ref.value:
-                    continue
-                dep.ref = Ref(
-                    kind=dep.ref.kind,
-                    value=f"{dep.ref.value}-nanvix-{version_suffix}",
-                )
+    version_suffix = toolchain.sdk.version.removeprefix("v")
+    for dep in [*dependencies, *system_dependencies]:
+        if dep.ref.kind == RefKind.VERSION and isinstance(dep.ref.value, str):
+            if "-nanvix-" in dep.ref.value:
+                continue
+            dep.ref = Ref(
+                kind=dep.ref.kind,
+                value=f"{dep.ref.value}-nanvix-{version_suffix}",
+            )
 
     return Manifest(
         name=pkg_name,

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -277,13 +277,8 @@ class ZScript:
             ``False``. Degraded legacy setup no longer exists.
         """
         # Resolve sysroot. In offline mode, reuse whatever is already at
-        # .nanvix/sysroot; --with-nanvix may then populate it.
+        # .nanvix/sysroot; --with-nanvix may then overlay artifacts.
         if self._offline:
-            if not self._with_nanvix_path:
-                log.fatal(
-                    "Offline mode requires --with-nanvix to provide local artifacts.",
-                    code=EXIT_MISSING_DEP,
-                )
             local_dir = _sysroot_dir()
             if local_dir.exists() and not local_dir.is_dir():
                 log.fatal(
@@ -392,19 +387,23 @@ class ZScript:
                 # When --with-nanvix is active, try local artifacts first.
                 # In offline mode, try for ALL deps (not just nanvix-owned).
                 # In online mode, only try for nanvix-owned deps.
-                if nanvix_local and self._offline:
+                if nanvix_local:
                     should_try_local = self._offline or dep.repo.startswith("nanvix/")
                     if should_try_local and self.buildroot.install_local_nanvix(
                         dep, Path(nanvix_local)
                     ):
                         continue
 
-                # In offline mode, warn if local artifacts were not found.
-                # nanvix_local is guaranteed set here (fatal above).
+                # In offline mode, skip network install and warn.
                 if self._offline:
+                    hint = (
+                        f"{nanvix_local}/deps/{dep.name}/"
+                        if nanvix_local
+                        else "pass --with-nanvix PATH"
+                    )
                     log.warning(
                         f"Offline mode: no local artifacts found for '{dep.name}'."
-                        f" Expected at: {nanvix_local}/deps/{dep.name}/",
+                        f" Expected at: {hint}",
                     )
                     continue
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -276,18 +276,25 @@ class ZScript:
         Returns:
             ``False``. Degraded legacy setup no longer exists.
         """
-        # Resolve sysroot: manifest LOCAL ref takes precedence over download.
-        if self.manifest.sysroot_ref.kind == RefKind.LOCAL:
-            self.sysroot = Sysroot.from_local(
-                Path(str(self.manifest.sysroot_ref.value)),
-                config=self.config,
-            )
-        elif self._offline:
-            log.fatal(
-                "Offline mode requires a local sysroot."
-                " Declare a LOCAL sysroot ref in nanvix.toml.",
-                code=EXIT_MISSING_DEP,
-            )
+        # Resolve sysroot. In offline mode, reuse whatever is already at
+        # .nanvix/sysroot; --with-nanvix may then populate it.
+        if self._offline:
+            if not self._with_nanvix_path:
+                log.fatal(
+                    "Offline mode requires --with-nanvix to provide local artifacts.",
+                    code=EXIT_MISSING_DEP,
+                )
+            local_dir = _sysroot_dir()
+            if local_dir.exists() and not local_dir.is_dir():
+                log.fatal(
+                    f"Sysroot path '{local_dir}' exists but is not a directory.",
+                    code=EXIT_MISSING_DEP,
+                    hint="Remove or rename this path and re-run `./z setup`.",
+                )
+            local_dir.mkdir(parents=True, exist_ok=True)
+            cached_tag = self.config.get("sysroot_tag", "")
+            self.sysroot = Sysroot(local_dir.resolve(), tag=cached_tag)
+            log.info(f"Offline: using sysroot at {local_dir}")
         else:
             self.sysroot = Sysroot.download(
                 machine=self.config.machine,
@@ -316,11 +323,6 @@ class ZScript:
         # (nanvixd.elf, mkramfs.elf, uservm.elf, libposix.a, etc.) on top
         # of the downloaded sysroot before verification.
         nanvix_local = self._with_nanvix_path
-        if self._offline and not nanvix_local:
-            log.fatal(
-                "Offline mode requires --with-nanvix to" " provide local artifacts.",
-                code=EXIT_MISSING_DEP,
-            )
         if nanvix_local:
             self.sysroot.overlay_local_nanvix(Path(nanvix_local))
 
@@ -680,12 +682,7 @@ class ZScript:
         # See https://github.com/nanvix/zutils/issues/263.
         if subcommand is not None and subcommand != "setup":
             pinned = instance.manifest.sysroot_ref
-            if pinned.kind == RefKind.LOCAL:
-                log.warning(
-                    f"Using local sysroot at {pinned.value!r};"
-                    " skipping version drift check."
-                )
-            elif pinned.kind == RefKind.TAG and isinstance(pinned.value, str):
+            if pinned.kind == RefKind.TAG and isinstance(pinned.value, str):
                 cached = instance.config.get("sysroot_tag")
                 if isinstance(cached, str) and cached:
                     expected = pinned.value

--- a/src/nanvix_zutil/sysroot.py
+++ b/src/nanvix_zutil/sysroot.py
@@ -62,34 +62,6 @@ class Sysroot:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def from_local(local_path: Path, config: Config | None = None) -> "Sysroot":
-        """Use an existing local directory as the sysroot (no download).
-
-        Args:
-            local_path: Absolute or relative path to the sysroot directory.
-            config: Optional :class:`Config` instance; if provided the
-                resolved sysroot path is persisted.
-
-        Returns:
-            A :class:`Sysroot` pointing at *local_path*.
-
-        Raises:
-            SystemExit: If *local_path* does not exist or is not a directory.
-        """
-        resolved = Path(local_path).resolve()
-        if not resolved.is_dir():
-            log.fatal(
-                f"Local sysroot path is not a directory: {local_path}",
-                code=EXIT_MISSING_DEP,
-                hint="Declare a LOCAL sysroot ref in nanvix.toml.",
-            )
-        log.info(f"Using local sysroot at {resolved}")
-        if config is not None:
-            config.set("sysroot_tag", "")
-            config.save()
-        return Sysroot(resolved, tag="")
-
-    @staticmethod
     def download(
         machine: str,
         deployment_mode: str,

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1117,40 +1117,6 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         fake_sysroot.overlay_local_nanvix.assert_not_called()
 
 
-class TestZScriptSetupLocalSysroot(unittest.TestCase):
-    """setup() with RefKind.LOCAL sysroot uses from_local, no GitHub."""
-
-    def setUp(self) -> None:
-        for key in ("NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE", "NANVIX_MEMORY_SIZE"):
-            os.environ.pop(key, None)
-
-    def test_local_sysroot_skips_github(self) -> None:
-        """When sysroot ref is LOCAL, Sysroot.from_local is used."""
-        repo_root = paths.repo_root()
-        # Create a local sysroot directory.
-        local_sysroot = repo_root / "my-sysroot"
-        local_sysroot.mkdir()
-
-        write_manifest()
-
-        script = ZScript()
-        # Simulate a manifest with a LOCAL sysroot ref.
-        from nanvix_zutil.buildroot import Ref
-
-        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(local_sysroot))
-
-        with (
-            patch("nanvix_zutil.script.Sysroot.download") as mock_download,
-            patch(
-                "nanvix_zutil.script.Sysroot.from_local",
-                return_value=MagicMock(path=local_sysroot, tag=""),
-            ) as mock_from_local,
-        ):
-            script.setup()
-            mock_download.assert_not_called()
-            mock_from_local.assert_called_once()
-
-
 class TestHelpersMakeInitrd(unittest.TestCase):
     """helpers.make_initrd() builds the correct mkimage command."""
 
@@ -1678,38 +1644,42 @@ class TestOfflineMode(unittest.TestCase):
         script = ZScript()
         self.assertIsNone(script._with_nanvix_path)
 
-    def test_cli_sysroot_path_attr_removed(self) -> None:
-        """_cli_sysroot_path attribute no longer exists."""
-        script = ZScript()
-        self.assertFalse(hasattr(script, "_cli_sysroot_path"))
-
-    def test_offline_with_local_sysroot_ref_uses_from_local(self) -> None:
-        """In offline mode with a LOCAL sysroot ref, Sysroot.from_local is used."""
-        sysroot_dir = paths.repo_root() / "my-sysroot"
+    def test_offline_uses_cached_sysroot(self) -> None:
+        """Offline mode reuses the on-disk sysroot without calling GitHub."""
+        sysroot_dir = paths.sysroot()
         sysroot_dir.mkdir()
 
         script = ZScript()
         script._offline = True
-        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
         script._with_nanvix_path = str(paths.repo_root())
-
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = sysroot_dir
-        fake_sysroot.tag = ""
 
         with (
             patch("nanvix_zutil.script.Sysroot.download") as mock_download,
-            patch(
-                "nanvix_zutil.script.Sysroot.from_local",
-                return_value=fake_sysroot,
-            ) as mock_from_local,
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve") as mock_resolve,
         ):
             script.setup()
-            mock_download.assert_not_called()
-            mock_from_local.assert_called_once()
 
-    def test_offline_without_sysroot_exits(self) -> None:
-        """Offline mode without a LOCAL sysroot ref exits fatally."""
+        mock_download.assert_not_called()
+        mock_resolve.assert_not_called()
+        assert script.sysroot is not None
+        self.assertEqual(script.sysroot.path, sysroot_dir.resolve())
+
+    def test_offline_creates_sysroot_dir_if_missing(self) -> None:
+        """Offline mode creates .nanvix/sysroot if it does not yet exist."""
+        script = ZScript()
+        script._offline = True
+        script._with_nanvix_path = str(paths.repo_root())
+
+        with patch("nanvix_zutil.script.Sysroot.verify"):
+            script.setup()
+
+        self.assertTrue(paths.sysroot().is_dir())
+
+    def test_offline_without_with_nanvix_exits(self) -> None:
+        """Offline mode with sysroot but no --with-nanvix exits fatally."""
+        paths.sysroot().mkdir()
+
         script = ZScript()
         script._offline = True
 
@@ -1718,79 +1688,33 @@ class TestOfflineMode(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
 
-    def test_offline_without_with_nanvix_exits(self) -> None:
-        """Offline mode with sysroot but no --with-nanvix exits fatally."""
-        repo_root = paths.repo_root()
-        sysroot_dir = repo_root / "my-sysroot"
-        sysroot_dir.mkdir()
-
-        script = ZScript()
-        script._offline = True
-        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
-
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = sysroot_dir
-        fake_sysroot.tag = ""
-
-        with (
-            patch(
-                "nanvix_zutil.script.Sysroot.from_local",
-                return_value=fake_sysroot,
-            ),
-            self.assertRaises(SystemExit) as ctx,
-        ):
-            script.setup()
-
-        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
-
     def test_offline_missing_dep_warns_not_fatal(self) -> None:
         """Offline mode warns (not fatal) when a dep has no local artifacts."""
-        repo_root = paths.repo_root()
-        sysroot_dir = repo_root / "my-sysroot"
-        sysroot_dir.mkdir()
-        # Create --with-nanvix dir without deps
-        build_dir = repo_root / "build"
+        paths.sysroot().mkdir()
+        build_dir = paths.repo_root() / "build"
         build_dir.mkdir()
 
         script = ZScript()
         script._offline = True
-        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
         script._with_nanvix_path = str(build_dir)
 
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = sysroot_dir
-        fake_sysroot.tag = ""
-
-        with patch(
-            "nanvix_zutil.script.Sysroot.from_local",
-            return_value=fake_sysroot,
-        ):
-            # Should NOT raise SystemExit — just warn
+        # Should NOT raise SystemExit — just warn
+        with patch("nanvix_zutil.script.Sysroot.verify"):
             script.setup()
 
     def test_offline_with_local_dep_installs(self) -> None:
         """Offline mode installs dep from local path when artifacts exist."""
-        repo_root = paths.repo_root()
-        sysroot_dir = repo_root / "my-sysroot"
-        sysroot_dir.mkdir()
-        build_dir = repo_root / "build"
+        paths.sysroot().mkdir()
+        build_dir = paths.repo_root() / "build"
         (build_dir / "deps" / "zlib" / "lib").mkdir(parents=True)
         (build_dir / "deps" / "zlib" / "lib" / "libz.a").write_bytes(b"fake")
 
         script = ZScript()
         script._offline = True
-        script.manifest.sysroot_ref = Ref(kind=RefKind.LOCAL, value=str(sysroot_dir))
         script._with_nanvix_path = str(build_dir)
 
-        fake_sysroot = MagicMock()
-        fake_sysroot.path = sysroot_dir
-        fake_sysroot.tag = ""
-
         with (
-            patch(
-                "nanvix_zutil.script.Sysroot.from_local",
-                return_value=fake_sysroot,
-            ),
+            patch("nanvix_zutil.script.Sysroot.verify"),
             patch("nanvix_zutil.script.resolve") as mock_resolve,
         ):
             script.setup()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1676,17 +1676,17 @@ class TestOfflineMode(unittest.TestCase):
 
         self.assertTrue(paths.sysroot().is_dir())
 
-    def test_offline_without_with_nanvix_exits(self) -> None:
-        """Offline mode with sysroot but no --with-nanvix exits fatally."""
+    def test_offline_without_with_nanvix_ok(self) -> None:
+        """Offline mode with sysroot but no --with-nanvix reuses sysroot."""
         paths.sysroot().mkdir()
 
         script = ZScript()
         script._offline = True
 
-        with self.assertRaises(SystemExit) as ctx:
+        with patch("nanvix_zutil.script.Sysroot.verify"):
             script.setup()
 
-        self.assertEqual(ctx.exception.code, EXIT_MISSING_DEP)
+        self.assertTrue(paths.sysroot().is_dir())
 
     def test_offline_missing_dep_warns_not_fatal(self) -> None:
         """Offline mode warns (not fatal) when a dep has no local artifacts."""

--- a/tests/test_sysroot.py
+++ b/tests/test_sysroot.py
@@ -504,50 +504,6 @@ class TestSysrootOverlayLocal(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 3)
 
 
-class TestSysrootFromLocal(unittest.TestCase):
-    """Sysroot.from_local() uses a directory as-is, no download."""
-
-    def setUp(self) -> None:
-        self._tmpdir = tempfile.TemporaryDirectory()
-
-    def tearDown(self) -> None:
-        self._tmpdir.cleanup()
-
-    def test_returns_sysroot_pointing_at_path(self) -> None:
-        sysroot_dir = Path(self._tmpdir.name) / "my-sysroot"
-        sysroot_dir.mkdir()
-
-        sysroot = Sysroot.from_local(sysroot_dir)
-
-        self.assertEqual(sysroot.path, sysroot_dir.resolve())
-        self.assertEqual(sysroot.tag, "")
-
-    def test_does_not_call_github(self) -> None:
-        sysroot_dir = Path(self._tmpdir.name) / "my-sysroot"
-        sysroot_dir.mkdir()
-
-        with patch("nanvix_zutil.github.resolve_release") as mock_resolve:
-            with patch("nanvix_zutil.github.download_release_asset") as mock_dl:
-                Sysroot.from_local(sysroot_dir)
-                mock_resolve.assert_not_called()
-                mock_dl.assert_not_called()
-
-    def test_exits_if_path_not_directory(self) -> None:
-        bad_path = Path(self._tmpdir.name) / "nonexistent"
-
-        with self.assertRaises(SystemExit) as ctx:
-            Sysroot.from_local(bad_path)
-        self.assertEqual(ctx.exception.code, 3)
-
-    def test_exits_if_path_is_file(self) -> None:
-        file_path = Path(self._tmpdir.name) / "a-file"
-        file_path.write_text("not a dir")
-
-        with self.assertRaises(SystemExit) as ctx:
-            Sysroot.from_local(file_path)
-        self.assertEqual(ctx.exception.code, 3)
-
-
 class TestSysrootDownloadZip(unittest.TestCase):
     """Sysroot.download() extracts .zip archives correctly."""
 


### PR DESCRIPTION
The manifest parser never emitted a `LOCAL` sysroot ref in production, so the `LOCAL` branches in `setup()` and the version-drift check were dead. `Sysroot.from_local()` was likewise only reachable from those branches. `RefKind.LOCAL` enum value is kept for future dependency-level local refs.

**Behavior change:** `--offline` no longer requires a `LOCAL` manifest ref. It now creates `.nanvix/sysroot` if missing, then lets `--with-nanvix` populate it; sysroot verification decides sufficiency. `--with-nanvix` is required for offline mode (checked before any directory mutation).

Depends on #322.