### PR TITLE
helpers: sanitize Docker temporary paths

### DIFF
--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -28,7 +28,8 @@ from nanvix_zutil.paths import nanvix_root, sysroot
 # ``USER``/``USERNAME`` are not forwarded; the container image sets its own.
 # The caller must not override them.  ``LD_LIBRARY_PATH`` and ``PYTHONPATH``
 # similarly refer to host filesystem locations that do not exist inside the
-# container.
+# container.  ``TEMP``/``TMP``/``TMPDIR`` are honored by Clang but may contain
+# Windows paths that cannot hold compiler intermediates inside Linux.
 _CONTAINER_ENV_BLOCKLIST: frozenset[str] = frozenset(
     {
         "PATH",
@@ -43,6 +44,9 @@ _CONTAINER_ENV_BLOCKLIST: frozenset[str] = frozenset(
         "DYLD_LIBRARY_PATH",
         "PYTHONPATH",
         "PYTHONHOME",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
     }
 )
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -795,6 +795,9 @@ class TestHelpersRun(unittest.TestCase):
             "DYLD_LIBRARY_PATH": "/host/dyld",
             "PYTHONPATH": "/host/py",
             "PYTHONHOME": "/host/pyhome",
+            "TEMP": "C:\\host\\temp",
+            "TMP": "C:\\host\\tmp",
+            "TMPDIR": "/host/tmpdir",
             # Blocklisted (mixed case).
             "Path": "C:\\mixed",
             "home": "/home/lower",
@@ -832,6 +835,9 @@ class TestHelpersRun(unittest.TestCase):
             "DYLD_LIBRARY_PATH": "/host/dyld",
             "PYTHONPATH": "/host/py",
             "PYTHONHOME": "/host/pyhome",
+            "TEMP": "C:\\host\\temp",
+            "TMP": "C:\\host\\tmp",
+            "TMPDIR": "/host/tmpdir",
             "Path": "C:\\mixed",
             "home": "/home/lower",
         }


### PR DESCRIPTION
Prevent host TEMP, TMP, and TMPDIR values from leaking into Linux Docker commands, where Windows paths can break Clang temporary-file creation. Ported from the distro Windows/WSL feature branch onto v0.19.0. The focused regression passes; Black and Pyright are clean; the full local suite reached 626 passes with only three terminal-host DuplicateHandle failures before test code.