### PR TITLE
[zutils] F: Add --with-deps for local overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Additional references:
 | ---------- | ------------- |
 | [Manifest Reference](docs/manifest.md) | `nanvix.toml` format and options |
 | [Local Development (`--with-nanvix`)](docs/with-nanvix.md) | Using local Nanvix builds |
+| [Local Deps (`--with-deps`)](docs/with-deps.md) | One-shot local dep overrides |
 | [Contributing](CONTRIBUTING.md) | Contribution guidelines and release process |
 
 SDK manifests pin a verified GitHub Release contract and immutable OCI digest.

--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -53,7 +53,6 @@ Paths are expanded (`~`) and canonicalised at parse time.
   released `.a` embeds calls against the pre-override version of
   the transitive; mixing at link time drifts ABI silently.  Either
   add the parent to `--with-deps` too, or drop the leaf override.
-  See nanvix/zutils#332 for the broader diamond-dep story.
 
 ## Precedence
 
@@ -72,6 +71,3 @@ entries.
 copies a sibling consumer's staged dev tree instead, honouring
 `install_libs` / `install_headers` filtering from the manifest.
 Both flags are one-shot.
-
-Live-edit dev loops (edit sibling → immediately visible without
-re-running `./z setup`) are tracked in nanvix/zutils#332.

--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -44,10 +44,16 @@ Paths are expanded (`~`) and canonicalised at parse time.
 
 ## Errors
 
-- Name not in the manifest's `[dependencies]`: warned and ignored.
-  Without a manifest entry we cannot know which files are wanted.
+- Name not in the resolved dep tree (neither a manifest direct dep
+  nor an SDK-resolved transitive): warned and ignored.
 - Staged dev tree not present under `<path>/../out/staging/dev/`:
   fatal, with a hint to build the sibling first.
+- Released package transitively depends on an overridden dep, and
+  the released package is not itself overridden: fatal.  The
+  released `.a` embeds calls against the pre-override version of
+  the transitive; mixing at link time drifts ABI silently.  Either
+  add the parent to `--with-deps` too, or drop the leaf override.
+  See nanvix/zutils#332 for the broader diamond-dep story.
 
 ## Precedence
 

--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -1,0 +1,66 @@
+# Using `--with-deps` for Local Dep Overrides
+
+`./z setup --with-deps 'name=path,name=path'` overrides one or more
+dependencies with **manifest paths** to sibling consumers.  The
+override applies to this `setup` run only: each entry's pre-built
+dev archive is installed into the sysroot in place of the released
+one from GitHub.
+
+Pass `--with-deps` again on the next `setup` to reapply.  Every
+`./z setup` is an explicit, one-shot override — nothing is persisted
+to `.nanvix/env.json`.
+
+## Path Semantics
+
+Each `path` points at a sibling consumer's manifest file (typically
+`.nanvix/nanvix.toml`).  Setup looks for the dev archive relative to
+that manifest:
+
+```
+<path>/../out/dist/<name>-<host>-<target>-<machine>-<mode>-<mem>-dev.<ext>
+```
+
+Extensions are probed in the same order as the online download path:
+`.tar.bz2`, then `.tar.gz`, then `.zip` (first match wins).
+
+If the archive is missing, setup fails with a hint to run `./z build`
+against that manifest first.  There is no auto-build.
+
+## Example
+
+Build zlib once, then point sqlite at its manifest:
+
+```bash
+(cd ~/repos/nanvix/zlib/default && ./z build)
+
+cd ~/repos/nanvix/sqlite/default
+./z setup --with-deps 'zlib=~/repos/nanvix/zlib/default/.nanvix/nanvix.toml'
+./z build
+```
+
+Paths are expanded (`~`) and canonicalised at parse time.
+
+## Errors
+
+- Name not in the manifest's `[dependencies]`: warned and ignored.
+  Without a manifest entry we cannot compute the expected archive name.
+- Archive not present under `<path>/../out/dist/`: fatal, with
+  a hint to build the sibling first.
+
+## Precedence
+
+Locally-overridden deps are authoritative.  In online mode, absence
+from the SDK lock is *not* fatal for overridden names — the local
+archive wins.  Transitive deps of an overridden dep are resolved from
+the SDK lock when the overridden dep is present there; otherwise
+transitive discovery is skipped and the user is responsible for
+overriding any transitives they need with additional `--with-deps`
+entries.
+
+## Relationship to `--with-nanvix`
+
+`--with-nanvix PATH` overlays a Nanvix-native build's `bin/` and
+`lib/` directly on top of the sysroot.  `--with-deps` routes through
+the same archive-extraction path used for released deps, honouring
+`install_libs` / `install_headers` filtering from the manifest.
+Both flags are one-shot.

--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -1,30 +1,32 @@
 # Using `--with-deps` for Local Dep Overrides
 
 `./z setup --with-deps 'name=path,name=path'` overrides one or more
-dependencies with **manifest paths** to sibling consumers.  The
-override applies to this `setup` run only: each entry's pre-built
-dev archive is installed into the sysroot in place of the released
-one from GitHub.
+dependencies with **manifest paths** to sibling consumers.  Each
+entry's staged dev tree is copied into the sysroot in place of the
+released archive from GitHub.
 
-Pass `--with-deps` again on the next `setup` to reapply.  Every
-`./z setup` is an explicit, one-shot override — nothing is persisted
-to `.nanvix/env.json`.
+The override applies to this `setup` run only — nothing is persisted
+to `.nanvix/env.json`.  Pass `--with-deps` again on the next `setup`
+to reapply, and re-run it after every sibling rebuild.
 
 ## Path Semantics
 
 Each `path` points at a sibling consumer's manifest file (typically
-`.nanvix/nanvix.toml`).  Setup looks for the dev archive relative to
-that manifest:
+`.nanvix/nanvix.toml`).  Setup reads the sibling's staged dev tree:
 
 ```
-<path>/../out/dist/<name>-<host>-<target>-<machine>-<mode>-<mem>-dev.<ext>
+<path>/../out/staging/dev/lib/*.a
+<path>/../out/staging/dev/include/**/*.h
 ```
 
-Extensions are probed in the same order as the online download path:
-`.tar.bz2`, then `.tar.gz`, then `.zip` (first match wins).
+This is the same tree the sibling's `release` step packs into the
+dev archive; contents are byte-identical.  Routing (`.a` → `lib/`,
+`.h` → `include/`) and `install_libs` / `install_headers` filters
+from the current manifest are applied exactly as they are during
+archive extraction.
 
-If the archive is missing, setup fails with a hint to run `./z build`
-against that manifest first.  There is no auto-build.
+If the staging tree is missing, setup fails with a hint to run
+`./z build` against that manifest first.  There is no auto-build.
 
 ## Example
 
@@ -43,15 +45,15 @@ Paths are expanded (`~`) and canonicalised at parse time.
 ## Errors
 
 - Name not in the manifest's `[dependencies]`: warned and ignored.
-  Without a manifest entry we cannot compute the expected archive name.
-- Archive not present under `<path>/../out/dist/`: fatal, with
-  a hint to build the sibling first.
+  Without a manifest entry we cannot know which files are wanted.
+- Staged dev tree not present under `<path>/../out/staging/dev/`:
+  fatal, with a hint to build the sibling first.
 
 ## Precedence
 
 Locally-overridden deps are authoritative.  In online mode, absence
 from the SDK lock is *not* fatal for overridden names — the local
-archive wins.  Transitive deps of an overridden dep are resolved from
+tree wins.  Transitive deps of an overridden dep are resolved from
 the SDK lock when the overridden dep is present there; otherwise
 transitive discovery is skipped and the user is responsible for
 overriding any transitives they need with additional `--with-deps`
@@ -60,7 +62,10 @@ entries.
 ## Relationship to `--with-nanvix`
 
 `--with-nanvix PATH` overlays a Nanvix-native build's `bin/` and
-`lib/` directly on top of the sysroot.  `--with-deps` routes through
-the same archive-extraction path used for released deps, honouring
+`lib/` on top of the sysroot by direct file copy.  `--with-deps`
+copies a sibling consumer's staged dev tree instead, honouring
 `install_libs` / `install_headers` filtering from the manifest.
 Both flags are one-shot.
+
+Live-edit dev loops (edit sibling → immediately visible without
+re-running `./z setup`) are tracked in nanvix/zutils#332.

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -35,6 +35,27 @@ from nanvix_zutil.release import DEV_ARCHIVE_SUFFIX
 # ---------------------------------------------------------------------------
 
 
+def _copy_local_dep_tree(dep: "Dependency", source_dir: Path) -> int:
+    """Copy ``.a``/``.h`` files from *source_dir* into the sysroot.
+
+    Files are routed via :func:`_member_target` (same rules as archive
+    extraction).  Returns the number of files copied.
+    """
+    copied = 0
+    for src in source_dir.rglob("*"):
+        if not src.is_file():
+            continue
+        target = _member_target(src.relative_to(source_dir), dep)
+        if target is None:
+            continue
+        anchor, rel = target
+        dest = sysroot() / anchor / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        copied += 1
+    return copied
+
+
 def _member_target(member_path: Path, dep: Dependency) -> tuple[str, str] | None:
     """Return ``(anchor_subdir, path_below_anchor)`` for a dep member, or ``None``.
 
@@ -370,8 +391,9 @@ class Buildroot:
         """Install a dependency from a local Nanvix build directory.
 
         Looks for ``<local_path>/deps/<dep.name>/`` containing ``lib/``
-        and/or ``include/`` subdirectories.  If found, copies the
-        matching artifacts into the buildroot.
+        and/or ``include/`` subdirectories.  If found, copies matching
+        artifacts into the sysroot using the same routing and filter
+        rules as archive extraction.
 
         Args:
             dep: The :class:`Dependency` descriptor.
@@ -381,42 +403,13 @@ class Buildroot:
             ``True`` if local artifacts were found and installed,
             ``False`` otherwise (caller should fall back to GitHub).
         """
-        import shutil
-
         dep_dir = local_path / "deps" / dep.name
         if not dep_dir.is_dir():
             return False
-
-        installed = False
-        lib_dir = dep_dir / "lib"
-        if lib_dir.is_dir():
-            dst_lib = sysroot() / "lib"
-            dst_lib.mkdir(parents=True, exist_ok=True)
-            for src_file in lib_dir.iterdir():
-                if src_file.is_file() and src_file.suffix == ".a":
-                    if dep.install_libs is None or src_file.name in dep.install_libs:
-                        shutil.copy2(src_file, dst_lib / src_file.name)
-                        installed = True
-
-        include_dir = dep_dir / "include"
-        if include_dir.is_dir():
-            dst_inc = sysroot() / "include"
-            dst_inc.mkdir(parents=True, exist_ok=True)
-            for src_file in include_dir.rglob("*"):
-                if src_file.is_file() and src_file.suffix == ".h":
-                    if (
-                        dep.install_headers is None
-                        or src_file.name in dep.install_headers
-                    ):
-                        rel = src_file.relative_to(include_dir)
-                        dst_file = dst_inc / rel
-                        dst_file.parent.mkdir(parents=True, exist_ok=True)
-                        shutil.copy2(src_file, dst_file)
-                        installed = True
-
-        if installed:
+        copied = _copy_local_dep_tree(dep, dep_dir)
+        if copied:
             log.info(f"Installed {dep.name} from local path: {dep_dir}")
-        return installed
+        return copied > 0
 
     def install_local_archive(
         self,
@@ -442,19 +435,7 @@ class Buildroot:
                 hint=f"Run `./z build` for {manifest_path} first.",
             )
 
-        copied = 0
-        for src in dev_dir.rglob("*"):
-            if not src.is_file():
-                continue
-            target = _member_target(src.relative_to(dev_dir), dep)
-            if target is None:
-                continue
-            anchor, rel = target
-            dest = sysroot() / anchor / rel
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src, dest)
-            copied += 1
-
+        copied = _copy_local_dep_tree(dep, dev_dir)
         log.success(f"Copied {copied} file(s) for {dep.name} from {dev_dir}")
 
     # ------------------------------------------------------------------

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -35,6 +35,27 @@ from nanvix_zutil.release import DEV_ARCHIVE_SUFFIX
 # ---------------------------------------------------------------------------
 
 
+def _member_target(member_path: Path, dep: Dependency) -> tuple[str, str] | None:
+    """Return ``(anchor_subdir, path_below_anchor)`` for a dep member, or ``None``.
+
+    Centralises the ``.a``/``.h`` routing and ``install_libs`` /
+    ``install_headers`` filtering shared by the archive-extraction
+    paths and the local-copy path.
+    """
+    if member_path.suffix == ".a":
+        if dep.install_libs is not None and member_path.name not in dep.install_libs:
+            return None
+        return "lib", _relative_to_segment(member_path, "lib")
+    if member_path.suffix == ".h":
+        if (
+            dep.install_headers is not None
+            and member_path.name not in dep.install_headers
+        ):
+            return None
+        return "include", _relative_to_segment(member_path, "include")
+    return None
+
+
 def _relative_to_segment(member_path: Path, segment: str) -> str:
     """Return the path portion after *segment* in *member_path*.
 
@@ -313,24 +334,14 @@ class Buildroot:
         """Extract libraries and headers from a tarball."""
         with tarfile.open(asset_path, "r:*") as tf:
             for member in tf.getmembers():
-                member_path = Path(member.name)
-                if member.isfile():
-                    if member_path.suffix == ".a":
-                        if dep.install_libs is None or member_path.name in (
-                            dep.install_libs
-                        ):
-                            member.name = _relative_to_segment(member_path, "lib")
-                            tf.extract(member, path=sysroot() / "lib", filter="data")
-                    elif member_path.suffix == ".h":
-                        if dep.install_headers is None or member_path.name in (
-                            dep.install_headers
-                        ):
-                            member.name = _relative_to_segment(member_path, "include")
-                            tf.extract(
-                                member,
-                                path=sysroot() / "include",
-                                filter="data",
-                            )
+                if not member.isfile():
+                    continue
+                target = _member_target(Path(member.name), dep)
+                if target is None:
+                    continue
+                anchor, rel = target
+                member.name = rel
+                tf.extract(member, path=sysroot() / anchor, filter="data")
 
     def _extract_dep_zip(self, asset_path: Path, dep: Dependency) -> None:
         """Extract libraries and headers from a zip archive."""
@@ -342,24 +353,14 @@ class Buildroot:
                 # Reject absolute paths and directory traversal.
                 if member_path.is_absolute() or ".." in member_path.parts:
                     continue
-                if member_path.suffix == ".a":
-                    if dep.install_libs is None or member_path.name in (
-                        dep.install_libs
-                    ):
-                        rel = _relative_to_segment(member_path, "lib")
-                        dest = sysroot() / "lib" / rel
-                        dest.parent.mkdir(parents=True, exist_ok=True)
-                        with zf.open(info) as src, dest.open("wb") as dst:
-                            shutil.copyfileobj(src, dst)
-                elif member_path.suffix == ".h":
-                    if dep.install_headers is None or member_path.name in (
-                        dep.install_headers
-                    ):
-                        rel = _relative_to_segment(member_path, "include")
-                        dest = sysroot() / "include" / rel
-                        dest.parent.mkdir(parents=True, exist_ok=True)
-                        with zf.open(info) as src, dest.open("wb") as dst:
-                            shutil.copyfileobj(src, dst)
+                target = _member_target(member_path, dep)
+                if target is None:
+                    continue
+                anchor, rel = target
+                dest = sysroot() / anchor / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info) as src, dest.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
 
     def install_local_nanvix(
         self,
@@ -421,52 +422,40 @@ class Buildroot:
         self,
         dep: Dependency,
         manifest_path: Path,
-        *,
-        host: str,
-        target: str,
-        machine: str,
-        deployment_mode: str,
-        memory_size: str,
     ) -> None:
-        """Install a dependency from a sibling consumer's dev archive.
+        """Install a dependency from a sibling consumer's staged dev tree.
 
-        Looks for the pre-built dev archive under
-        ``<manifest_path>/../out/dist/`` matching the current build
-        parameters, then extracts it into the sysroot via the same
-        routine used by :meth:`install_dep`.
+        Walks ``<manifest_path>/../out/staging/dev/`` — the tree the
+        sibling's ``release`` step packs into the dev archive,
+        byte-identical to the archive contents — and copies matching
+        files into the sysroot, applying the same routing and filter
+        rules used when extracting the released archive.
 
-        Fatal (``EXIT_MISSING_DEP``) if the archive is not present;
+        Fatal (``EXIT_MISSING_DEP``) if the staging tree is absent;
         callers should run ``./z build`` against *manifest_path* first.
         """
-        asset_name = dep.artifact_pattern.format(
-            name=dep.name,
-            host=host,
-            arch=target,
-            machine=machine,
-            mode=deployment_mode,
-            mem=memory_size,
-        )
-        dist_dir = manifest_path.parent / "out" / "dist"
-        # Match the online path's extension preference (github.py).
-        asset_path: Path | None = None
-        for ext in (".tar.bz2", ".tar.gz", ".zip"):
-            candidate = dist_dir / f"{asset_name}{ext}"
-            if candidate.is_file():
-                asset_path = candidate
-                break
-        if asset_path is None:
+        dev_dir = manifest_path.parent / "out" / "staging" / "dev"
+        if not dev_dir.is_dir():
             log.fatal(
-                f"local dep '{dep.name}': no archive matching"
-                f" {asset_name}.(tar.bz2|tar.gz|zip) in {dist_dir}",
+                f"local dep '{dep.name}': no staged dev tree at {dev_dir}",
                 code=EXIT_MISSING_DEP,
                 hint=f"Run `./z build` for {manifest_path} first.",
             )
-        log.info(f"Extracting local dep {dep.name} from {asset_path}...")
-        if zipfile.is_zipfile(asset_path):
-            self._extract_dep_zip(asset_path, dep)
-        else:
-            self._extract_dep_tar(asset_path, dep)
-        log.success(f"Installed {dep.name} from local manifest: {manifest_path}")
+
+        copied = 0
+        for src in dev_dir.rglob("*"):
+            if not src.is_file():
+                continue
+            target = _member_target(src.relative_to(dev_dir), dep)
+            if target is None:
+                continue
+            anchor, rel = target
+            dest = sysroot() / anchor / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            copied += 1
+
+        log.success(f"Copied {copied} file(s) for {dep.name} from {dev_dir}")
 
     # ------------------------------------------------------------------
     # Verification

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -417,6 +417,57 @@ class Buildroot:
             log.info(f"Installed {dep.name} from local path: {dep_dir}")
         return installed
 
+    def install_local_archive(
+        self,
+        dep: Dependency,
+        manifest_path: Path,
+        *,
+        host: str,
+        target: str,
+        machine: str,
+        deployment_mode: str,
+        memory_size: str,
+    ) -> None:
+        """Install a dependency from a sibling consumer's dev archive.
+
+        Looks for the pre-built dev archive under
+        ``<manifest_path>/../out/dist/`` matching the current build
+        parameters, then extracts it into the sysroot via the same
+        routine used by :meth:`install_dep`.
+
+        Fatal (``EXIT_MISSING_DEP``) if the archive is not present;
+        callers should run ``./z build`` against *manifest_path* first.
+        """
+        asset_name = dep.artifact_pattern.format(
+            name=dep.name,
+            host=host,
+            arch=target,
+            machine=machine,
+            mode=deployment_mode,
+            mem=memory_size,
+        )
+        dist_dir = manifest_path.parent / "out" / "dist"
+        # Match the online path's extension preference (github.py).
+        asset_path: Path | None = None
+        for ext in (".tar.bz2", ".tar.gz", ".zip"):
+            candidate = dist_dir / f"{asset_name}{ext}"
+            if candidate.is_file():
+                asset_path = candidate
+                break
+        if asset_path is None:
+            log.fatal(
+                f"local dep '{dep.name}': no archive matching"
+                f" {asset_name}.(tar.bz2|tar.gz|zip) in {dist_dir}",
+                code=EXIT_MISSING_DEP,
+                hint=f"Run `./z build` for {manifest_path} first.",
+            )
+        log.info(f"Extracting local dep {dep.name} from {asset_path}...")
+        if zipfile.is_zipfile(asset_path):
+            self._extract_dep_zip(asset_path, dep)
+        else:
+            self._extract_dep_tar(asset_path, dep)
+        log.success(f"Installed {dep.name} from local manifest: {manifest_path}")
+
     # ------------------------------------------------------------------
     # Verification
     # ------------------------------------------------------------------

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -45,6 +45,55 @@ def _abs_dir(raw: str) -> str:
     return str(resolved)
 
 
+def _abs_file(raw: str) -> str:
+    """argparse ``type=`` callable: resolve ``raw`` to an absolute file.
+
+    Expands ``~``, resolves symlinks, and requires the target to exist
+    and be a regular file.
+    """
+    if not raw:
+        raise argparse.ArgumentTypeError("path is empty")
+    p = Path(raw).expanduser()
+    try:
+        resolved = p.resolve(strict=True)
+    except (OSError, RuntimeError) as e:
+        raise argparse.ArgumentTypeError(
+            f"path does not exist: {raw}",
+        ) from e
+    if not resolved.is_file():
+        raise argparse.ArgumentTypeError(
+            f"path is not a file: {raw}",
+        )
+    return str(resolved)
+
+
+def _dep_map(raw: str) -> dict[str, str]:
+    """argparse ``type=`` callable: parse ``name=path,name=path`` into a dict.
+
+    Each path is expanded (``~``) and canonicalised via :func:`_abs_file`.
+    Paths must point at a sibling consumer's manifest file (typically
+    ``.nanvix/nanvix.toml``).  Empty entries, missing ``=``, empty
+    names, and empty paths are errors.
+    """
+    if not raw:
+        raise argparse.ArgumentTypeError("--with-deps value is empty")
+    out: dict[str, str] = {}
+    for entry in raw.split(","):
+        if "=" not in entry:
+            raise argparse.ArgumentTypeError(
+                f"expected 'name=path', got {entry!r}",
+            )
+        name, _, path = entry.partition("=")
+        name = name.strip()
+        path = path.strip()
+        if not name:
+            raise argparse.ArgumentTypeError(f"empty dep name in {entry!r}")
+        if not path:
+            raise argparse.ArgumentTypeError(f"empty path for dep {name!r}")
+        out[name] = _abs_file(path)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Parser factory
 # ---------------------------------------------------------------------------
@@ -188,6 +237,18 @@ def build_parser(
                 " deps/<name>/{lib,include}/ artifacts."
                 " Relative paths and ~ are accepted; the path is"
                 " canonicalised to an absolute directory.",
+            )
+            sub.add_argument(
+                "--with-deps",
+                type=_dep_map,
+                metavar="NAME=PATH,...",
+                dest="with_deps",
+                help="Comma-separated map of local dep overrides. Each"
+                " PATH is a sibling consumer's manifest file (typically"
+                " .nanvix/nanvix.toml); its pre-built dev archive under"
+                " <PATH>/../out/dist/ is installed in place of the"
+                " released dep. One-time; pass again on each setup to"
+                " reapply.",
             )
         if name == "install":
             sub.add_argument(

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -245,10 +245,10 @@ def build_parser(
                 dest="with_deps",
                 help="Comma-separated map of local dep overrides. Each"
                 " PATH is a sibling consumer's manifest file (typically"
-                " .nanvix/nanvix.toml); its pre-built dev archive under"
-                " <PATH>/../out/dist/ is installed in place of the"
-                " released dep. One-time; pass again on each setup to"
-                " reapply.",
+                " .nanvix/nanvix.toml); its staged dev tree under"
+                " <PATH>/../out/staging/dev/ is copied into the sysroot"
+                " in place of the released dep. One-time; pass again on"
+                " each setup to reapply.",
             )
         if name == "install":
             sub.add_argument(

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -314,25 +314,19 @@ class ZScript:
         if nanvix_local:
             self.sysroot.overlay_local_nanvix(Path(nanvix_local))
 
-        # Resolve --with-deps overrides. Names not in the manifest are
-        # warned about and ignored — we cannot compute the archive name
-        # without a Dependency entry.
+        # Snapshot --with-deps overrides. Names not present in the
+        # resolved tree (below) are warned about and ignored.
         local_deps = dict(self._with_deps)
-        if local_deps:
-            manifest_names = {d.name for d in self.manifest.dependencies}
-            unknown = sorted(set(local_deps) - manifest_names)
-            for name in unknown:
-                log.warning(
-                    f"--with-deps: ignoring '{name}' — not in"
-                    f" nanvix.toml [[dependencies]]"
-                )
-                del local_deps[name]
         if local_deps:
             log.info(f"Using {len(local_deps)} local dep override(s).")
 
         self.sysroot.verify(self.sysroot_required_files())
 
         deps: list[Dependency] = list(self.manifest.dependencies)
+        # ``known`` is the set of names we understand at install time.
+        # In offline mode this is just the manifest's direct deps;
+        # online mode extends it with SDK-resolved transitives below.
+        known: set[str] = {dep.name for dep in deps}
 
         sdk_releases: dict[str, dict[str, object]] = {}
         if not self._offline:
@@ -370,6 +364,47 @@ class ZScript:
                     )
                 selected.append(name)
                 pending.extend(package.dependencies)
+            known.update(selected)
+
+            # Forward diamond check: any released package that transitively
+            # depends on a --with-deps override must itself be overridden.
+            # A released ``.a`` embeds calls against the pre-override version
+            # of its transitives; mixing it with a local override at link
+            # time silently drifts ABI.
+            if local_deps:
+                mismatches: list[tuple[str, str]] = []
+                for name in selected:
+                    if name in local_deps:
+                        continue
+                    stack = list(packages[name].dependencies)
+                    seen: set[str] = set()
+                    while stack:
+                        n = stack.pop()
+                        if n in seen:
+                            continue
+                        seen.add(n)
+                        if n in local_deps:
+                            mismatches.append((name, n))
+                        pkg = packages.get(n)
+                        if pkg is not None:
+                            stack.extend(pkg.dependencies)
+                if mismatches:
+                    lines = "\n".join(
+                        f"  - '{parent}' (released) transitively depends on"
+                        f" '{child}' (locally overridden)"
+                        for parent, child in sorted(set(mismatches))
+                    )
+                    log.fatal(
+                        "Inconsistent --with-deps overrides:\n" + lines,
+                        code=EXIT_MISSING_DEP,
+                        hint=(
+                            "Released packages built against the original"
+                            " version of an overridden dep will silently"
+                            " mismatch at link time. Either override the"
+                            " parent(s) too via --with-deps, or drop the"
+                            " leaf override."
+                        ),
+                    )
             direct = {dep.name for dep in deps}
             for name in selected:
                 package = packages[name]
@@ -394,6 +429,20 @@ class ZScript:
                             ref=package.ref,
                         )
                     )
+
+        # Warn+drop --with-deps overrides that are not part of the
+        # known dep set.  Deferred until after SDK resolution so that
+        # overriding a valid transitive dep (present in the SDK lock
+        # but not in the manifest's direct [[dependencies]]) is not
+        # spuriously rejected.
+        if local_deps:
+            unknown = sorted(set(local_deps) - known)
+            for name in unknown:
+                log.warning(
+                    f"--with-deps: ignoring '{name}' \u2014 not in the"
+                    f" resolved dep tree"
+                )
+                del local_deps[name]
 
         if deps:
             self.buildroot = Buildroot.create()

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -398,16 +398,11 @@ class ZScript:
         if deps:
             self.buildroot = Buildroot.create()
             for dep in deps:
-                # --with-deps: install from a sibling consumer's dev archive.
+                # --with-deps: copy from a sibling consumer's staged dev tree.
                 if dep.name in local_deps:
                     self.buildroot.install_local_archive(
                         dep,
                         Path(local_deps[dep.name]),
-                        host=self.config.host,
-                        target=self.config.target,
-                        machine=self.config.machine,
-                        deployment_mode=self.config.deployment_mode,
-                        memory_size=self.config.memory_size,
                     )
                     continue
                 # When --with-nanvix is active, try local artifacts first.

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -39,7 +39,12 @@ from nanvix_zutil.buildroot import (
     RefKind,
 )
 from nanvix_zutil.cli import build_parser
-from nanvix_zutil.config import CFG_DOCKER_IMAGE, CFG_GH_TOKEN, CFG_SYSROOT, Config
+from nanvix_zutil.config import (
+    CFG_DOCKER_IMAGE,
+    CFG_GH_TOKEN,
+    CFG_SYSROOT,
+    Config,
+)
 from nanvix_zutil.docker import (
     SYSROOT_CONTAINER_PATH,
     WORKSPACE_CONTAINER_PATH,
@@ -175,6 +180,7 @@ class ZScript:
         self.docker: DockerConfig | None = None
         self._offline: bool = False
         self._with_nanvix_path: str | None = None
+        self._with_deps: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Hook classification helpers
@@ -308,6 +314,22 @@ class ZScript:
         if nanvix_local:
             self.sysroot.overlay_local_nanvix(Path(nanvix_local))
 
+        # Resolve --with-deps overrides. Names not in the manifest are
+        # warned about and ignored — we cannot compute the archive name
+        # without a Dependency entry.
+        local_deps = dict(self._with_deps)
+        if local_deps:
+            manifest_names = {d.name for d in self.manifest.dependencies}
+            unknown = sorted(set(local_deps) - manifest_names)
+            for name in unknown:
+                log.warning(
+                    f"--with-deps: ignoring '{name}' — not in"
+                    f" nanvix.toml [[dependencies]]"
+                )
+                del local_deps[name]
+        if local_deps:
+            log.info(f"Using {len(local_deps)} local dep override(s).")
+
         self.sysroot.verify(self.sysroot_required_files())
 
         deps: list[Dependency] = list(self.manifest.dependencies)
@@ -337,6 +359,11 @@ class ZScript:
                     continue
                 package = packages.get(name)
                 if package is None:
+                    if name in local_deps:
+                        # Locally overridden — the user's word is final;
+                        # do not require SDK-lock presence and skip
+                        # transitive walk (unknowable without a package).
+                        continue
                     log.fatal(
                         f"Strict SDK lock has no package '{name}'",
                         code=EXIT_MISSING_DEP,
@@ -371,6 +398,18 @@ class ZScript:
         if deps:
             self.buildroot = Buildroot.create()
             for dep in deps:
+                # --with-deps: install from a sibling consumer's dev archive.
+                if dep.name in local_deps:
+                    self.buildroot.install_local_archive(
+                        dep,
+                        Path(local_deps[dep.name]),
+                        host=self.config.host,
+                        target=self.config.target,
+                        machine=self.config.machine,
+                        deployment_mode=self.config.deployment_mode,
+                        memory_size=self.config.memory_size,
+                    )
+                    continue
                 # When --with-nanvix is active, try local artifacts first.
                 # In offline mode, try for ALL deps (not just nanvix-owned).
                 # In online mode, only try for nanvix-owned deps.
@@ -602,6 +641,10 @@ class ZScript:
             instance._offline = True
         if getattr(args, "with_nanvix", None):
             instance._with_nanvix_path = args.with_nanvix
+
+        with_deps: dict[str, str] | None = getattr(args, "with_deps", None)
+        if with_deps:
+            instance._with_deps = with_deps
 
         # ------------------------------------------------------------------
         # Docker: resolve image from CLI or persisted config, then check availability.

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -371,28 +371,46 @@ class ZScript:
             # A released ``.a`` embeds calls against the pre-override version
             # of its transitives; mixing it with a local override at link
             # time silently drifts ABI.
+            #
+            # Note the interaction with the ``if name in local_deps: continue``
+            # branch above: when an override T is *in* the SDK lock, T falls
+            # through to the normal walk and its transitives are enqueued, so
+            # any released grand-descendant of T that itself depends on
+            # another override L is discovered here.  When T is *not* in the
+            # lock, T's transitives are unknowable and this check silently
+            # skips them.
             if local_deps:
+                # Memoised reachability: for each node, the set of local_dep
+                # names reachable from it in the SDK graph.  Seed each entry
+                # to an empty set before recursing so cycles terminate.
+                reachable: dict[str, set[str]] = {}
+
+                def _reach(node: str) -> set[str]:
+                    cached = reachable.get(node)
+                    if cached is not None:
+                        return cached
+                    out: set[str] = set()
+                    reachable[node] = out
+                    pkg = packages.get(node)
+                    if pkg is None:
+                        return out
+                    for d in pkg.dependencies:
+                        if d in local_deps:
+                            out.add(d)
+                        out |= _reach(d)
+                    return out
+
                 mismatches: list[tuple[str, str]] = []
                 for name in selected:
                     if name in local_deps:
                         continue
-                    stack = list(packages[name].dependencies)
-                    seen: set[str] = set()
-                    while stack:
-                        n = stack.pop()
-                        if n in seen:
-                            continue
-                        seen.add(n)
-                        if n in local_deps:
-                            mismatches.append((name, n))
-                        pkg = packages.get(n)
-                        if pkg is not None:
-                            stack.extend(pkg.dependencies)
+                    for child in sorted(_reach(name)):
+                        mismatches.append((name, child))
                 if mismatches:
                     lines = "\n".join(
                         f"  - '{parent}' (released) transitively depends on"
                         f" '{child}' (locally overridden)"
-                        for parent, child in sorted(set(mismatches))
+                        for parent, child in mismatches
                     )
                     log.fatal(
                         "Inconsistent --with-deps overrides:\n" + lines,
@@ -439,8 +457,7 @@ class ZScript:
             unknown = sorted(set(local_deps) - known)
             for name in unknown:
                 log.warning(
-                    f"--with-deps: ignoring '{name}' \u2014 not in the"
-                    f" resolved dep tree"
+                    f"--with-deps: ignoring '{name}' — not in the resolved dep tree"
                 )
                 del local_deps[name]
 

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -430,6 +430,66 @@ class TestBuildrootInstallDep(unittest.TestCase):
         self.assertTrue((sysroot() / "include" / "zlib.h").exists())
 
 
+class TestInstallLocalArchive(unittest.TestCase):
+    """Buildroot.install_local_archive() reads a sibling's dev tarball."""
+
+    def _dep(self) -> Dependency:
+        return Dependency(
+            name="zlib",
+            repo="nanvix/zlib",
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+        )
+
+    def _params(self) -> dict[str, str]:
+        return dict(
+            host="linux",
+            target="x86",
+            machine="microvm",
+            deployment_mode="standalone",
+            memory_size="256mb",
+        )
+
+    def _archive_name(self, dep: Dependency) -> str:
+        p = self._params()
+        return dep.artifact_pattern.format(
+            name=dep.name,
+            host=p["host"],
+            arch=p["target"],
+            machine=p["machine"],
+            mode=p["deployment_mode"],
+            mem=p["memory_size"],
+        )
+
+    def test_extracts_lib_and_header_from_local_archive(self) -> None:
+        br = Buildroot.create()
+        dep = self._dep()
+        manifest_path = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        dist_dir = manifest_path.parent / "out" / "dist"
+        dist_dir.mkdir(parents=True)
+        manifest_path.write_text("")
+        archive = _make_tar_bz2(
+            {
+                "sysroot/lib/libz.a": b"lib-content",
+                "sysroot/include/zlib.h": b"header-content",
+            }
+        )
+        (dist_dir / f"{self._archive_name(dep)}.tar.gz").write_bytes(archive)
+
+        br.install_local_archive(dep, manifest_path, **self._params())
+
+        self.assertTrue((sysroot() / "lib" / "libz.a").exists())
+        self.assertTrue((sysroot() / "include" / "zlib.h").exists())
+
+    def test_fatals_when_archive_missing(self) -> None:
+        br = Buildroot.create()
+        dep = self._dep()
+        manifest_path = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        manifest_path.parent.mkdir(parents=True)
+        manifest_path.write_text("")
+        with self.assertRaises(SystemExit):
+            br.install_local_archive(dep, manifest_path, **self._params())
+
+
 class TestSuffixDep(unittest.TestCase):
     """Tests for suffix_dep()."""
 

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -431,63 +431,108 @@ class TestBuildrootInstallDep(unittest.TestCase):
 
 
 class TestInstallLocalArchive(unittest.TestCase):
-    """Buildroot.install_local_archive() reads a sibling's dev tarball."""
+    """Buildroot.install_local_archive() copies a sibling's staged dev tree."""
 
-    def _dep(self) -> Dependency:
+    def _dep(self, **overrides: object) -> Dependency:
         return Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
+            name=str(overrides.pop("name", "zlib")),
+            repo=str(overrides.pop("repo", "nanvix/zlib")),
             ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+            install_libs=overrides.pop("install_libs", None),  # type: ignore[arg-type]
+            install_headers=overrides.pop("install_headers", None),  # type: ignore[arg-type]
         )
 
-    def _params(self) -> dict[str, str]:
-        return dict(
-            host="linux",
-            target="x86",
-            machine="microvm",
-            deployment_mode="standalone",
-            memory_size="256mb",
-        )
+    def _stage(self, files: dict[str, bytes]) -> Path:
+        """Write *files* under a sibling's staging tree; return its manifest path."""
+        manifest = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        dev = manifest.parent / "out" / "staging" / "dev"
+        for rel, data in files.items():
+            dst = dev / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(data)
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text("")
+        return manifest
 
-    def _archive_name(self, dep: Dependency) -> str:
-        p = self._params()
-        return dep.artifact_pattern.format(
-            name=dep.name,
-            host=p["host"],
-            arch=p["target"],
-            machine=p["machine"],
-            mode=p["deployment_mode"],
-            mem=p["memory_size"],
-        )
-
-    def test_extracts_lib_and_header_from_local_archive(self) -> None:
+    def test_copies_lib_and_header(self) -> None:
         br = Buildroot.create()
-        dep = self._dep()
-        manifest_path = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
-        dist_dir = manifest_path.parent / "out" / "dist"
-        dist_dir.mkdir(parents=True)
-        manifest_path.write_text("")
-        archive = _make_tar_bz2(
+        manifest = self._stage(
             {
-                "sysroot/lib/libz.a": b"lib-content",
-                "sysroot/include/zlib.h": b"header-content",
+                "lib/libz.a": b"lib-content",
+                "include/zlib.h": b"header-content",
             }
         )
-        (dist_dir / f"{self._archive_name(dep)}.tar.gz").write_bytes(archive)
 
-        br.install_local_archive(dep, manifest_path, **self._params())
+        br.install_local_archive(self._dep(), manifest)
 
-        self.assertTrue((sysroot() / "lib" / "libz.a").exists())
-        self.assertTrue((sysroot() / "include" / "zlib.h").exists())
+        lib = sysroot() / "lib" / "libz.a"
+        hdr = sysroot() / "include" / "zlib.h"
+        self.assertTrue(lib.is_file() and not lib.is_symlink())
+        self.assertTrue(hdr.is_file() and not hdr.is_symlink())
+        self.assertEqual(lib.read_bytes(), b"lib-content")
+        self.assertEqual(hdr.read_bytes(), b"header-content")
 
-    def test_fatals_when_archive_missing(self) -> None:
+    def test_selective_libs_and_headers(self) -> None:
         br = Buildroot.create()
-        dep = self._dep()
+        manifest = self._stage(
+            {
+                "lib/libz.a": b"z",
+                "lib/libextra.a": b"extra",
+                "include/zlib.h": b"wanted",
+                "include/internal.h": b"nope",
+            }
+        )
+        dep = self._dep(install_libs=["libz.a"], install_headers=["zlib.h"])
+
+        br.install_local_archive(dep, manifest)
+
+        self.assertTrue((sysroot() / "lib" / "libz.a").is_file())
+        self.assertFalse((sysroot() / "lib" / "libextra.a").exists())
+        self.assertTrue((sysroot() / "include" / "zlib.h").is_file())
+        self.assertFalse((sysroot() / "include" / "internal.h").exists())
+
+    def test_preserves_header_subdirectory(self) -> None:
+        br = Buildroot.create()
+        manifest = self._stage(
+            {
+                "include/openssl/ssl.h": b"ssl",
+                "include/openssl/crypto.h": b"crypto",
+                "lib/libssl.a": b"lib",
+            }
+        )
+
+        br.install_local_archive(
+            self._dep(name="openssl", repo="nanvix/openssl"), manifest
+        )
+
+        self.assertTrue((sysroot() / "include" / "openssl" / "ssl.h").is_file())
+        self.assertTrue((sysroot() / "include" / "openssl" / "crypto.h").is_file())
+        self.assertTrue((sysroot() / "lib" / "libssl.a").is_file())
+
+    def test_preserves_lib_subdirectory(self) -> None:
+        """Nested libs (e.g. ``lib/engines/libcapi.a``) are copied intact."""
+        br = Buildroot.create()
+        manifest = self._stage(
+            {
+                "lib/engines/libcapi.a": b"engine",
+                "lib/libssl.a": b"lib",
+            }
+        )
+
+        br.install_local_archive(
+            self._dep(name="openssl", repo="nanvix/openssl"), manifest
+        )
+
+        self.assertTrue((sysroot() / "lib" / "engines" / "libcapi.a").is_file())
+        self.assertTrue((sysroot() / "lib" / "libssl.a").is_file())
+
+    def test_fatals_when_staging_missing(self) -> None:
+        br = Buildroot.create()
         manifest_path = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
         manifest_path.parent.mkdir(parents=True)
         manifest_path.write_text("")
         with self.assertRaises(SystemExit):
-            br.install_local_archive(dep, manifest_path, **self._params())
+            br.install_local_archive(self._dep(), manifest_path)
 
 
 class TestSuffixDep(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,6 +248,118 @@ class TestWithNanvixFlag(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
+class TestWithDepsFlag(unittest.TestCase):
+    """Tests for the --with-deps flag on the setup subcommand."""
+
+    def test_single_entry(self) -> None:
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as tmp:
+            args = parser.parse_args(
+                ["setup", "--with-docker", "img:t", "--with-deps", f"foo={tmp.name}"]
+            )
+            self.assertEqual(
+                args.with_deps, {"foo": str(Path(tmp.name).resolve(strict=True))}
+            )
+
+    def test_multiple_entries(self) -> None:
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as a, tempfile.NamedTemporaryFile() as b:
+            args = parser.parse_args(
+                [
+                    "setup",
+                    "--with-docker",
+                    "img:t",
+                    "--with-deps",
+                    f"foo={a.name},bar={b.name}",
+                ]
+            )
+            self.assertEqual(
+                args.with_deps,
+                {
+                    "foo": str(Path(a.name).resolve(strict=True)),
+                    "bar": str(Path(b.name).resolve(strict=True)),
+                },
+            )
+
+    def test_path_canonicalised(self) -> None:
+        parser = build_parser()
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                Path("m.toml").write_text("")
+                args = parser.parse_args(
+                    ["setup", "--with-docker", "img:t", "--with-deps", "foo=m.toml"]
+                )
+            finally:
+                os.chdir(cwd)
+            self.assertTrue(Path(args.with_deps["foo"]).is_absolute())
+
+    def test_default_none(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["setup", "--with-docker", "img:t"])
+        self.assertIsNone(args.with_deps)
+
+    def test_rejects_missing_equals(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["setup", "--with-docker", "img:t", "--with-deps", "foo"])
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_empty_name(self) -> None:
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as tmp:
+            with self.assertRaises(SystemExit) as ctx:
+                parser.parse_args(
+                    [
+                        "setup",
+                        "--with-docker",
+                        "img:t",
+                        "--with-deps",
+                        f"={tmp.name}",
+                    ]
+                )
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_empty_path(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(
+                ["setup", "--with-docker", "img:t", "--with-deps", "foo="]
+            )
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_missing_path_dir(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(
+                [
+                    "setup",
+                    "--with-docker",
+                    "img:t",
+                    "--with-deps",
+                    "foo=/nope/xyzzy/def/not.toml",
+                ]
+            )
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_directory(self) -> None:
+        """A directory path is rejected (must be a file)."""
+        parser = build_parser()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(SystemExit) as ctx:
+                parser.parse_args(
+                    ["setup", "--with-docker", "img:t", "--with-deps", f"foo={tmp}"]
+                )
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejected_on_build(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["build", "--with-deps", "foo=/p"])
+        self.assertEqual(ctx.exception.code, 2)
+
+
 class TestInstallArtifactsSubcommand(unittest.TestCase):
     """Tests for the install subcommand."""
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1104,6 +1104,116 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         fake_sysroot.overlay_local_nanvix.assert_not_called()
 
 
+class TestZScriptSetupWithDeps(unittest.TestCase):
+    """setup() installs local dev archives for names in ``_with_deps``."""
+
+    def setUp(self) -> None:
+        write_manifest()
+        for key in (
+            "NANVIX_MACHINE",
+            "NANVIX_DEPLOYMENT_MODE",
+            "NANVIX_MEMORY_SIZE",
+        ):
+            os.environ.pop(key, None)
+
+    def test_setup_calls_install_local_archive_for_persisted_names(self) -> None:
+        """Names in ``_with_deps`` route through install_local_archive."""
+        write_manifest(MANIFEST_WITH_DEPS)
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.Buildroot.install_dep") as mock_id,
+        ):
+            script = ZScript()
+            script._offline = True  # skip resolve() network path
+            script._with_deps = {"zlib": str(local)}
+            script.setup()
+
+        mock_ila.assert_called_once()
+        called_dep = mock_ila.call_args.args[0]
+        called_path = mock_ila.call_args.args[1]
+        self.assertEqual(called_dep.name, "zlib")
+        self.assertEqual(called_path, local)
+        mock_id.assert_not_called()
+
+    def test_setup_warns_and_ignores_unknown_dep_name(self) -> None:
+        """Names not in manifest.dependencies are warned about and ignored."""
+        local = Path.cwd() / "nope_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.log.warning") as mock_warn,
+        ):
+            script = ZScript()
+            script._with_deps = {"not_a_real_dep": str(local)}
+            script.setup()  # must not raise
+
+        mock_ila.assert_not_called()
+        self.assertTrue(
+            any("not_a_real_dep" in c.args[0] for c in mock_warn.call_args_list),
+            f"expected warning mentioning 'not_a_real_dep', got {mock_warn.call_args_list!r}",
+        )
+
+    def test_setup_no_action_when_map_empty(self) -> None:
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+        ):
+            script = ZScript()
+            script.setup()
+
+        mock_ila.assert_not_called()
+
+    def test_online_override_bypasses_missing_sdk_lock_entry(self) -> None:
+        """Online mode: overridden dep absent from SDK lock is not fatal."""
+        write_manifest(MANIFEST_WITH_DEPS)
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        # Resolution returns no packages — without the override this
+        # would fatal on "Strict SDK lock has no package 'zlib'".
+        empty_lock = Lockfile(
+            LockfileMetadata("sha256:x", "0.20.0", sdk=make_sdk_provenance("0.20.0")),
+            packages=[],
+        )
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=empty_lock),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.Buildroot.install_dep") as mock_id,
+        ):
+            script = ZScript()
+            script._with_deps = {"zlib": str(local)}
+            script.setup()
+
+        mock_ila.assert_called_once()
+        mock_id.assert_not_called()
+
+
 class TestHelpersMakeInitrd(unittest.TestCase):
     """helpers.make_initrd() builds the correct mkimage command."""
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1331,6 +1331,94 @@ class TestZScriptWithDepsForwardCheck(unittest.TestCase):
         lock = self._lock(self._pkg("zlib"))
         self._run(self._manifest("zlib"), lock, {"zlib": str(local)})  # must not raise
 
+    def test_override_of_transitive_only_dep_installs(self) -> None:
+        """Overriding a name only present as a transitive (not a direct dep)
+        routes through install_local_archive; the deferred filter admits it."""
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        # cpython (direct) → sqlite (transitive) → zlib (transitive, overridden).
+        # Also override sqlite so the forward check passes.
+        local_s = Path.cwd() / "sqlite_ws" / ".nanvix" / "nanvix.toml"
+        local_s.parent.mkdir(parents=True)
+        local_s.write_text("")
+        local_c = Path.cwd() / "cpython_ws" / ".nanvix" / "nanvix.toml"
+        local_c.parent.mkdir(parents=True)
+        local_c.write_text("")
+        lock = self._lock(
+            self._pkg("zlib"),
+            self._pkg("sqlite", deps=["zlib"]),
+            self._pkg("cpython", deps=["sqlite"]),
+        )
+        write_manifest(self._manifest("cpython"))
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=lock),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.Buildroot.install_dep"),
+        ):
+            script = ZScript()
+            script._with_deps = {
+                "zlib": str(local),
+                "sqlite": str(local_s),
+                "cpython": str(local_c),
+            }
+            script.setup()
+
+        called_names = {c.args[0].name for c in mock_ila.call_args_list}
+        self.assertIn("zlib", called_names)  # transitive-only, overridden
+
+    def test_warns_and_drops_unknown_name_online(self) -> None:
+        """An override name absent from both manifest and lock is warned+dropped."""
+        local = Path.cwd() / "ghost_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        lock = self._lock(self._pkg("zlib"))
+        write_manifest(self._manifest("zlib"))
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=lock),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.Buildroot.install_dep"),
+            patch("nanvix_zutil.script.log.warning") as mock_warn,
+        ):
+            script = ZScript()
+            script._with_deps = {"ghost": str(local)}
+            script.setup()  # must not raise
+
+        mock_ila.assert_not_called()
+        self.assertTrue(
+            any("ghost" in c.args[0] for c in mock_warn.call_args_list),
+            f"expected warning mentioning 'ghost', got {mock_warn.call_args_list!r}",
+        )
+
+    def test_cycle_in_lock_does_not_infinite_loop(self) -> None:
+        """The DFS terminates even if the SDK lock has a cycle.
+
+        In practice ``resolve()`` runs ``_detect_cycles`` and would
+        fatal first, but the memoisation guard here is defensive.
+        Test by patching in a cyclic lock directly.
+        """
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        # zlib ↔ libcrc cycle, cpython pulls both.
+        lock = self._lock(
+            self._pkg("zlib", deps=["libcrc"]),
+            self._pkg("libcrc", deps=["zlib"]),
+            self._pkg("cpython", deps=["zlib"]),
+        )
+        with self.assertRaises(SystemExit):
+            # Fatals on the forward check (cpython transitively depends on
+            # overridden zlib), not on hang.
+            self._run(self._manifest("cpython"), lock, {"zlib": str(local)})
+
 
 class TestHelpersMakeInitrd(unittest.TestCase):
     """helpers.make_initrd() builds the correct mkimage command."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -39,6 +39,7 @@ from tests.testutils import (
     MANIFEST_WITH_DEPS,
     make_sdk_provenance,
     make_toml,
+    toolchain_toml,
     write_manifest,
 )
 
@@ -1212,6 +1213,123 @@ class TestZScriptSetupWithDeps(unittest.TestCase):
 
         mock_ila.assert_called_once()
         mock_id.assert_not_called()
+
+
+class TestZScriptWithDepsForwardCheck(unittest.TestCase):
+    """setup() enforces that released parents of an override are also overridden."""
+
+    def setUp(self) -> None:
+        for key in (
+            "NANVIX_MACHINE",
+            "NANVIX_DEPLOYMENT_MODE",
+            "NANVIX_MEMORY_SIZE",
+        ):
+            os.environ.pop(key, None)
+
+    @staticmethod
+    def _pkg(name: str, deps: list[str] | None = None) -> ResolvedPackage:
+        return ResolvedPackage(
+            name=name,
+            repo=f"nanvix/{name}",
+            kind="dependency",
+            ref=Ref(kind=RefKind.VERSION, value="1.0"),
+            resolved_tag="v1.0",
+            resolved_commitish="c" * 40,
+            release_id=1,
+            dependencies=deps or [],
+            assets=[
+                ResolvedAsset(
+                    name=f"{name}-microvm-standalone-256mb.tar.bz2",
+                    url=f"https://example.invalid/{name}.tar.bz2",
+                )
+            ],
+        )
+
+    def _run(self, manifest: str, lock: Lockfile, with_deps: dict[str, str]) -> None:
+        write_manifest(manifest)
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=lock),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive"),
+            patch("nanvix_zutil.script.Buildroot.install_dep"),
+        ):
+            script = ZScript()
+            script._with_deps = with_deps
+            script.setup()
+
+    def _manifest(self, *dep_names: str) -> str:
+        deps = "\n".join(f'{name} = "1.0"' for name in dep_names)
+        return (
+            "[package]\n"
+            'name = "test"\n'
+            'version = "0.1.0"\n'
+            'nanvix-version = "0.1.0"\n'
+            + toolchain_toml()
+            + "\n[dependencies]\n"
+            + deps
+            + "\n"
+        )
+
+    def _lock(self, *pkgs: ResolvedPackage) -> Lockfile:
+        return Lockfile(
+            LockfileMetadata("sha256:x", "0.20.0", sdk=make_sdk_provenance("0.20.0")),
+            packages=list(pkgs),
+        )
+
+    def test_fatals_when_released_parent_depends_on_overridden_leaf(self) -> None:
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        lock = self._lock(
+            self._pkg("zlib"),
+            self._pkg("sqlite", deps=["zlib"]),
+        )
+        with self.assertRaises(SystemExit):
+            self._run(
+                self._manifest("zlib", "sqlite"),
+                lock,
+                {"zlib": str(local)},
+            )
+
+    def test_passes_when_all_transitives_overridden(self) -> None:
+        local_z = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local_s = Path.cwd() / "sqlite_ws" / ".nanvix" / "nanvix.toml"
+        for p in (local_z, local_s):
+            p.parent.mkdir(parents=True)
+            p.write_text("")
+        lock = self._lock(
+            self._pkg("zlib"),
+            self._pkg("sqlite", deps=["zlib"]),
+        )
+        self._run(
+            self._manifest("zlib", "sqlite"),
+            lock,
+            {"zlib": str(local_z), "sqlite": str(local_s)},
+        )  # must not raise
+
+    def test_fatals_on_multi_hop_transitive(self) -> None:
+        """cpython -> sqlite -> zlib; overriding just zlib is inconsistent."""
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        lock = self._lock(
+            self._pkg("zlib"),
+            self._pkg("sqlite", deps=["zlib"]),
+            self._pkg("cpython", deps=["sqlite"]),
+        )
+        with self.assertRaises(SystemExit):
+            self._run(self._manifest("cpython"), lock, {"zlib": str(local)})
+
+    def test_passes_when_override_has_no_released_parent(self) -> None:
+        """Overriding a leaf whose only parent is also overridden is fine."""
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        lock = self._lock(self._pkg("zlib"))
+        self._run(self._manifest("zlib"), lock, {"zlib": str(local)})  # must not raise
 
 
 class TestHelpersMakeInitrd(unittest.TestCase):


### PR DESCRIPTION
Closes #257.

## Summary

Non-breaking API addition for developing against local dependency builds.

Adds `./z setup --with-deps 'name=path,name=path'`, where each `path` is a sibling consumer's manifest file. The sibling's staged dev tree at `<path>/../out/staging/dev/` is copied into the sysroot in place of the released dep.

### Examples

```sh
### simple ###
./z setup --with-deps='zlib=/path/to/zlib/.nanvix/nanvix.toml'


### many deps (trailing/adjacent commas are tolerated) ###
DEPS=""
for DEP in libxml2 libxslt lxml sqlite zlib openssl xz; do
        DEPS+="$DEP=~/repos/nanvix/$DEP/.nanvix/nanvix.toml,"
done
./z setup --with-deps="$DEPS"


### forward diamond check ###
cd /path/to/cpython
./z setup --with-deps="zlib=$ZLIB"
# error: Inconsistent --with-deps overrides:
#  - 'sqlite' (released) transitively depends on 'zlib' (locally overridden)
#  - 'libxml2' (released) transitively depends on 'zlib' (locally overridden)
#  - 'libxslt' (released) transitively depends on 'zlib' (locally overridden)
#  - 'lxml' (released) transitively depends on 'zlib' (locally overridden)
# hint: Released packages built against the original version of an overridden
#       dep will silently mismatch at link time. Either override the parent(s)
#       too via --with-deps, or drop the leaf override.


### reverse diamond check ###
# sqlite was built earlier against released zlib (no --with-deps='zlib=...').
# Now cpython overrides both sqlite and zlib:
cd /path/to/cpython
./z setup --with-deps="sqlite=$SQLITE,zlib=$ZLIB"
# error: Inconsistent local dep provenance:
#  - via 'sqlite': 'zlib' was built against 'v1.3.1-nanvix-0.21.22-sdk.2',
#                  but consumer resolves it to '/home/…/zlib/…/nanvix.toml'
# hint: Rebuild the sibling(s) with matching --with-deps overrides, or drop
#       the conflicting local override.
```

## Behavior

- Overrides are one-shot per `setup`. Pass `--with-deps` again on the next `setup` to reapply.
- Specified dependencies which are not in the resolved dependency tree are warned and ignored.
- In the case where a dependency is in the manifest but not in the lockfile
- Empty entries (leading/trailing/adjacent commas) are tolerated for easier shell composition.
- No auto-build of siblings; missing staging tree fatals with a hint to build.

### Diamond Dependencies

Suppose we have libraries A, B, C, where A depends on B and C, and B depends on C. C is called a [diamond dependency.](https://jlbp.dev/what-is-a-diamond-dependency-conflict)

Real life example: A=cpython, B=sqlite, C=cpython

Below we describe a "forward" and "reverse" diamond dependency conflict. The implementation correctly checks for and fails if either of these conditions holds true.

#### Direct

Now suppose we use a local build of C. This _requires_ that B is a local build, because it depends on C. The implementation will correctly check for this.

```mermaid
 flowchart TD
 FA["A @ 1.0.0"]
 FB["B @ 1.0.0"]
 FC_local["C @ /some/path"]
 FC_remote["C @ 1.0.0"]

 FA -->|remote| FB
 FA -->|local| FC_local
 FB -->|remote| FC_remote
 FC_local <-. MISMATCH .-> FC_remote

 style FC_local stroke:red
 style FC_remote stroke:red
```

#### Transitive

```mermaid
 flowchart TD
 RA["A @ 1.0.0"]
 RB["B @ /some/path"]
 RC_local["C @ /some/path"]
 RC_remote["C @ 1.0.0"]

 RA -->|local| RB
 RA -->|local| RC_local
 RB -->|remote| RC_remote
 RC_local <-. MISMATCH .-> RC_remote

 style RB stroke:green
 style RC_remote stroke:red
 style RC_local stroke:red
```

In order to catch transitive diamond dependency errors, every setup run `--with-deps` populates a new `.nanvix/local_deps.json`. (This file is gitignored.) recording resolved versions or override paths. Downstream consumers using `--with-deps` read each overridden sibling's copy and fatal on disagreement of any overlapping key. Local builds _without_ the local_deps.json file are treated as unbuilt.

## Implementation

- `_dep_map` argparse type parses `name=path,...`, expands `~`, canonicalises each path (must be a regular file). Skips empty entries.
- `Buildroot.install_local_archive(dep, manifest_path)` walks `<manifest>/../out/staging/dev/` and copies matching files via a new shared `_copy_local_dep_tree` helper.
- `_member_target` centralises `.a`/`.h` routing and `install_libs`/`install_headers` filtering. Now shared by `_extract_dep_tar`, `_extract_dep_zip`, and both local-copy paths (`install_local_archive` and `install_local_nanvix`).
- `install_local_nanvix` folded onto the same helper — picks up subdirectory support under `lib/` as a side effect (previously handled only for `include/`).
- Forward diamond check runs after SDK resolution: memoised reachability (`dict[str, set[str]]`) across the resolved lockfile; each node walked once regardless of how many parents share it; cycles terminate via seed-before-recurse.
- Reverse diamond check writes `.nanvix/local_deps.json` at end of setup — a flat `{name: version-or-path}` map covering `nanvix` (sysroot tag or `--with-nanvix` path) plus every resolved dep. On subsequent consumer setups, each `--with-deps` override's sibling file is read and its keys intersected with the consumer's own resolved map; any inequality fatals. The file is unlinked at the top of every setup, so a fatal partway through leaves no stale provenance behind.
- Public read-only API: `ZScript.local_deps: dict[str, str]` — consumer setup hooks can branch on `if name in self.local_deps: ...` to be override-aware.

## Testing

- CLI parser: empty entries, missing `=`, empty name/path, non-file path, directory path, use on non-setup subcommands, trailing-comma tolerance.
- Buildroot: copy from staging tree (files, headers, subdirectories, `install_libs`/`install_headers` filtering, missing tree fatals).
- Script setup: unknown-name warn+drop, empty map no-op, override bypasses missing SDK lock entry, transitive-only override installs correctly.
- Forward diamond check: single-hop mismatch fatals, all-transitives-overridden passes, multi-hop mismatch fatals, sole-leaf passes, unknown-name in online mode still warned+dropped, cyclic lock does not hang the DFS.
- Reverse diamond check: write records versions/overrides, missing sibling file fatals, provenance mismatch fatals, agreement passes, empty overlap passes, path-equality match.

## Docs

- New `docs/with-deps.md`.
- README table entry.

## Known limitations / follow-ups

- #332 — live-edit dev loop (symlink into sibling `staging/dev/`; blocked on Docker mount rework).
- Schema versioning wrapper for `local_deps.json` — currently a flat `{name: version-or-path}`; retrofitting a `{"version": N, "deps": {...}}` shape later requires two-sided ecosystem coordination.
- Offline-sibling / online-consumer asymmetry: an offline sibling's `local_deps.json` omits released transitives, so consumer verification silently underchecks. Options: refuse consumption, or record a mode sentinel.
- Cross-host / symlinked-checkout: override-path equality is byte-exact; siblings shared across hosts or symlink layouts will spuriously mismatch.
