### PR TITLE
[LOCAL-2] Add --with-deps for local overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ uv run tasks.py setup
 | [Test](docs/test.md)                            | How to run tests                           |
 | [Manifest Reference](docs/manifest.md)          | `nanvix.toml` format and options           |
 | [Local Development](docs/with-nanvix.md)        | Using local Nanvix builds (`--with-nanvix`)|
+| [Local Deps](docs/with-deps.md)                 | One-shot local dep overrides (`--with-deps`)|
 | [Troubleshooting](docs/troubleshooting.md)      | Solutions to common problems               |
 | [Contributing](CONTRIBUTING.md)                 | Contribution guidelines and release process|
 

--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -1,0 +1,63 @@
+# Using `--with-deps` for Local Dep Overrides
+
+`./z setup --with-deps 'name=path,name=path'` overrides one or more
+dependencies with **manifest paths** to sibling consumers.  Each
+entry's staged dev tree is copied into the sysroot in place of the
+released archive from GitHub.
+
+The override applies to this `setup` run only — nothing is persisted
+to `.nanvix/env.json`.  Pass `--with-deps` again on the next `setup`
+to reapply, and re-run it after every sibling rebuild.
+
+## Path Semantics
+
+Each `path` points at a sibling consumer's manifest file (typically
+`.nanvix/nanvix.toml`).  Setup reads the sibling's staged dev tree:
+
+```
+<path>/../out/staging/dev/lib/*.a
+<path>/../out/staging/dev/include/**/*.h
+```
+
+This is the same tree the sibling's `release` step packs into the
+dev archive; contents are byte-identical.  Routing (`.a` → `lib/`,
+`.h` → `include/`) and `install_libs` / `install_headers` filters
+from the current manifest are applied exactly as they are during
+archive extraction.
+
+If the staging tree is missing, setup fails with a hint to run
+`./z build` against that manifest first.  There is no auto-build.
+
+## Example
+
+Build zlib once, then point sqlite at its manifest:
+
+```bash
+(cd ~/repos/nanvix/zlib/default && ./z build)
+
+cd ~/repos/nanvix/sqlite/default
+./z setup --with-deps 'zlib=~/repos/nanvix/zlib/default/.nanvix/nanvix.toml'
+./z build
+```
+
+Paths are expanded (`~`) and canonicalised at parse time.  Empty
+entries (trailing or adjacent commas) are tolerated for easier shell
+composition.
+
+## Errors
+
+- Staged dev tree not present under `<path>/../out/staging/dev/`:
+  fatal, with a hint to build the sibling first.
+
+## Public API
+
+`ZScript.local_deps: dict[str, str]` — consumer setup hooks can
+branch on `if name in self.local_deps: ...` to be override-aware.
+
+## Relationship to `--with-nanvix`
+
+`--with-nanvix PATH` overlays a Nanvix-native build's `bin/` and
+`lib/` on top of the sysroot by direct file copy.  `--with-deps`
+copies a sibling consumer's staged dev tree instead, honouring
+`install_libs` / `install_headers` filtering from the manifest.
+Both flags are one-shot.

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -411,6 +411,33 @@ class Buildroot:
             log.info(f"Installed {dep.name} from local path: {dep_dir}")
         return copied > 0
 
+    def install_local_archive(
+        self,
+        dep: Dependency,
+        manifest_path: Path,
+    ) -> None:
+        """Install a dependency from a sibling consumer's staged dev tree.
+
+        Walks ``<manifest_path>/../out/staging/dev/`` — the tree the
+        sibling's ``release`` step packs into the dev archive,
+        byte-identical to the archive contents — and copies matching
+        files into the sysroot, applying the same routing and filter
+        rules used when extracting the released archive.
+
+        Fatal (``EXIT_MISSING_DEP``) if the staging tree is absent;
+        callers should run ``./z build`` against *manifest_path* first.
+        """
+        dev_dir = manifest_path.parent / "out" / "staging" / "dev"
+        if not dev_dir.is_dir():
+            log.fatal(
+                f"local dep '{dep.name}': no staged dev tree at {dev_dir}",
+                code=EXIT_MISSING_DEP,
+                hint=f"Run `./z build` for {manifest_path} first.",
+            )
+
+        copied = _copy_local_dep_tree(dep, dev_dir)
+        log.success(f"Copied {copied} file(s) for {dep.name} from {dev_dir}")
+
     # ------------------------------------------------------------------
     # Verification
     # ------------------------------------------------------------------

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -45,6 +45,57 @@ def _abs_dir(raw: str) -> str:
     return str(resolved)
 
 
+def _abs_file(raw: str) -> str:
+    """argparse ``type=`` callable: resolve ``raw`` to an absolute file.
+
+    Expands ``~``, resolves symlinks, and requires the target to exist
+    and be a regular file.
+    """
+    if not raw:
+        raise argparse.ArgumentTypeError("path is empty")
+    p = Path(raw).expanduser()
+    try:
+        resolved = p.resolve(strict=True)
+    except (OSError, RuntimeError) as e:
+        raise argparse.ArgumentTypeError(
+            f"path does not exist: {raw}",
+        ) from e
+    if not resolved.is_file():
+        raise argparse.ArgumentTypeError(
+            f"path is not a file: {raw}",
+        )
+    return str(resolved)
+
+
+def _dep_map(raw: str) -> dict[str, str]:
+    """argparse ``type=`` callable: parse ``name=path,name=path`` into a dict.
+
+    Each path is expanded (``~``) and canonicalised via :func:`_abs_file`.
+    Paths must point at a sibling consumer's manifest file (typically
+    ``.nanvix/nanvix.toml``).  Empty entries (trailing/adjacent commas)
+    are skipped; missing ``=``, empty names, and empty paths are errors.
+    """
+    if not raw:
+        raise argparse.ArgumentTypeError("--with-deps value is empty")
+    out: dict[str, str] = {}
+    for entry in raw.split(","):
+        if not entry.strip():
+            continue
+        if "=" not in entry:
+            raise argparse.ArgumentTypeError(
+                f"expected 'name=path', got {entry!r}",
+            )
+        name, _, path = entry.partition("=")
+        name = name.strip()
+        path = path.strip()
+        if not name:
+            raise argparse.ArgumentTypeError(f"empty dep name in {entry!r}")
+        if not path:
+            raise argparse.ArgumentTypeError(f"empty path for dep {name!r}")
+        out[name] = _abs_file(path)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Parser factory
 # ---------------------------------------------------------------------------
@@ -188,6 +239,18 @@ def build_parser(
                 " deps/<name>/{lib,include}/ artifacts."
                 " Relative paths and ~ are accepted; the path is"
                 " canonicalised to an absolute directory.",
+            )
+            sub.add_argument(
+                "--with-deps",
+                type=_dep_map,
+                metavar="NAME=PATH,...",
+                dest="with_deps",
+                help="Comma-separated map of local dep overrides. Each"
+                " PATH is a sibling consumer's manifest file (typically"
+                " .nanvix/nanvix.toml); its staged dev tree under"
+                " <PATH>/../out/staging/dev/ is copied into the sysroot"
+                " in place of the released dep. One-time; pass again on"
+                " each setup to reapply.",
             )
         if name == "install":
             sub.add_argument(

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -175,6 +175,14 @@ class ZScript:
         self.docker: DockerConfig | None = None
         self._offline: bool = False
         self._with_nanvix_path: str | None = None
+        self.local_deps: dict[str, str] = {}
+        """Map of dep name → sibling manifest path from ``--with-deps``.
+
+        Populated at CLI parse time; empty when the flag was not passed.
+        Read-only from consumer hooks (mutations after ``setup()`` returns
+        have no effect).  Consumers that want to be override-aware can
+        branch on ``if name in self.local_deps: ...``.
+        """
 
     # ------------------------------------------------------------------
     # Hook classification helpers
@@ -308,6 +316,11 @@ class ZScript:
         if nanvix_local:
             self.sysroot.overlay_local_nanvix(Path(nanvix_local))
 
+        # Snapshot --with-deps overrides for the install loop below.
+        local_deps = dict(self.local_deps)
+        if local_deps:
+            log.info(f"Using {len(local_deps)} local dep override(s).")
+
         self.sysroot.verify(self.sysroot_required_files())
 
         deps: list[Dependency] = list(self.manifest.dependencies)
@@ -371,6 +384,13 @@ class ZScript:
         if deps:
             self.buildroot = Buildroot.create()
             for dep in deps:
+                # --with-deps: copy from a sibling consumer's staged dev tree.
+                if dep.name in local_deps:
+                    self.buildroot.install_local_archive(
+                        dep,
+                        Path(local_deps[dep.name]),
+                    )
+                    continue
                 # When --with-nanvix is active, try local artifacts first.
                 # In offline mode, try for ALL deps (not just nanvix-owned).
                 # In online mode, only try for nanvix-owned deps.
@@ -602,6 +622,10 @@ class ZScript:
             instance._offline = True
         if getattr(args, "with_nanvix", None):
             instance._with_nanvix_path = args.with_nanvix
+
+        with_deps: dict[str, str] | None = getattr(args, "with_deps", None)
+        if with_deps:
+            instance.local_deps = with_deps
 
         # ------------------------------------------------------------------
         # Docker: resolve image from CLI or persisted config, then check availability.

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -430,6 +430,111 @@ class TestBuildrootInstallDep(unittest.TestCase):
         self.assertTrue((sysroot() / "include" / "zlib.h").exists())
 
 
+class TestInstallLocalArchive(unittest.TestCase):
+    """Buildroot.install_local_archive() copies a sibling's staged dev tree."""
+
+    def _dep(self, **overrides: object) -> Dependency:
+        return Dependency(
+            name=str(overrides.pop("name", "zlib")),
+            repo=str(overrides.pop("repo", "nanvix/zlib")),
+            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
+            install_libs=overrides.pop("install_libs", None),  # type: ignore[arg-type]
+            install_headers=overrides.pop("install_headers", None),  # type: ignore[arg-type]
+        )
+
+    def _stage(self, files: dict[str, bytes]) -> Path:
+        """Write *files* under a sibling's staging tree; return its manifest path."""
+        manifest = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        dev = manifest.parent / "out" / "staging" / "dev"
+        for rel, data in files.items():
+            dst = dev / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(data)
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text("")
+        return manifest
+
+    def test_copies_lib_and_header(self) -> None:
+        br = Buildroot.create()
+        manifest = self._stage(
+            {
+                "lib/libz.a": b"lib-content",
+                "include/zlib.h": b"header-content",
+            }
+        )
+
+        br.install_local_archive(self._dep(), manifest)
+
+        lib = sysroot() / "lib" / "libz.a"
+        hdr = sysroot() / "include" / "zlib.h"
+        self.assertTrue(lib.is_file() and not lib.is_symlink())
+        self.assertTrue(hdr.is_file() and not hdr.is_symlink())
+        self.assertEqual(lib.read_bytes(), b"lib-content")
+        self.assertEqual(hdr.read_bytes(), b"header-content")
+
+    def test_selective_libs_and_headers(self) -> None:
+        br = Buildroot.create()
+        manifest = self._stage(
+            {
+                "lib/libz.a": b"z",
+                "lib/libextra.a": b"extra",
+                "include/zlib.h": b"wanted",
+                "include/internal.h": b"nope",
+            }
+        )
+        dep = self._dep(install_libs=["libz.a"], install_headers=["zlib.h"])
+
+        br.install_local_archive(dep, manifest)
+
+        self.assertTrue((sysroot() / "lib" / "libz.a").is_file())
+        self.assertFalse((sysroot() / "lib" / "libextra.a").exists())
+        self.assertTrue((sysroot() / "include" / "zlib.h").is_file())
+        self.assertFalse((sysroot() / "include" / "internal.h").exists())
+
+    def test_preserves_header_subdirectory(self) -> None:
+        br = Buildroot.create()
+        manifest = self._stage(
+            {
+                "include/openssl/ssl.h": b"ssl",
+                "include/openssl/crypto.h": b"crypto",
+                "lib/libssl.a": b"lib",
+            }
+        )
+
+        br.install_local_archive(
+            self._dep(name="openssl", repo="nanvix/openssl"), manifest
+        )
+
+        self.assertTrue((sysroot() / "include" / "openssl" / "ssl.h").is_file())
+        self.assertTrue((sysroot() / "include" / "openssl" / "crypto.h").is_file())
+        self.assertTrue((sysroot() / "lib" / "libssl.a").is_file())
+
+    def test_preserves_lib_subdirectory(self) -> None:
+        """Nested libs (e.g. ``lib/engines/libcapi.a``) are copied intact."""
+        br = Buildroot.create()
+        manifest = self._stage(
+            {
+                "lib/engines/libcapi.a": b"engine",
+                "lib/libssl.a": b"lib",
+            }
+        )
+
+        br.install_local_archive(
+            self._dep(name="openssl", repo="nanvix/openssl"), manifest
+        )
+
+        self.assertTrue((sysroot() / "lib" / "engines" / "libcapi.a").is_file())
+        self.assertTrue((sysroot() / "lib" / "libssl.a").is_file())
+
+    def test_fatals_when_staging_missing(self) -> None:
+        br = Buildroot.create()
+        manifest_path = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        manifest_path.parent.mkdir(parents=True)
+        manifest_path.write_text("")
+        with self.assertRaises(SystemExit):
+            br.install_local_archive(self._dep(), manifest_path)
+
+
 class TestSuffixDep(unittest.TestCase):
     """Tests for suffix_dep()."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,6 +248,133 @@ class TestWithNanvixFlag(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
 
+class TestWithDepsFlag(unittest.TestCase):
+    """Tests for the --with-deps flag on the setup subcommand."""
+
+    def test_single_entry(self) -> None:
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as tmp:
+            args = parser.parse_args(
+                ["setup", "--with-docker", "img:t", "--with-deps", f"foo={tmp.name}"]
+            )
+            self.assertEqual(
+                args.with_deps, {"foo": str(Path(tmp.name).resolve(strict=True))}
+            )
+
+    def test_multiple_entries(self) -> None:
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as a, tempfile.NamedTemporaryFile() as b:
+            args = parser.parse_args(
+                [
+                    "setup",
+                    "--with-docker",
+                    "img:t",
+                    "--with-deps",
+                    f"foo={a.name},bar={b.name}",
+                ]
+            )
+            self.assertEqual(
+                args.with_deps,
+                {
+                    "foo": str(Path(a.name).resolve(strict=True)),
+                    "bar": str(Path(b.name).resolve(strict=True)),
+                },
+            )
+
+    def test_path_canonicalised(self) -> None:
+        parser = build_parser()
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                Path("m.toml").write_text("")
+                args = parser.parse_args(
+                    ["setup", "--with-docker", "img:t", "--with-deps", "foo=m.toml"]
+                )
+            finally:
+                os.chdir(cwd)
+            self.assertTrue(Path(args.with_deps["foo"]).is_absolute())
+
+    def test_default_none(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["setup", "--with-docker", "img:t"])
+        self.assertIsNone(args.with_deps)
+
+    def test_rejects_missing_equals(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["setup", "--with-docker", "img:t", "--with-deps", "foo"])
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_empty_name(self) -> None:
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as tmp:
+            with self.assertRaises(SystemExit) as ctx:
+                parser.parse_args(
+                    [
+                        "setup",
+                        "--with-docker",
+                        "img:t",
+                        "--with-deps",
+                        f"={tmp.name}",
+                    ]
+                )
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_empty_path(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(
+                ["setup", "--with-docker", "img:t", "--with-deps", "foo="]
+            )
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_missing_path_dir(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(
+                [
+                    "setup",
+                    "--with-docker",
+                    "img:t",
+                    "--with-deps",
+                    "foo=/nope/xyzzy/def/not.toml",
+                ]
+            )
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejects_directory(self) -> None:
+        """A directory path is rejected (must be a file)."""
+        parser = build_parser()
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(SystemExit) as ctx:
+                parser.parse_args(
+                    ["setup", "--with-docker", "img:t", "--with-deps", f"foo={tmp}"]
+                )
+            self.assertEqual(ctx.exception.code, 2)
+
+    def test_rejected_on_build(self) -> None:
+        parser = build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["build", "--with-deps", "foo=/p"])
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_skips_empty_entries(self) -> None:
+        """Empty entries (trailing/adjacent commas) are ignored."""
+        parser = build_parser()
+        with tempfile.NamedTemporaryFile() as tmp:
+            args = parser.parse_args(
+                [
+                    "setup",
+                    "--with-docker",
+                    "img:t",
+                    "--with-deps",
+                    f",foo={tmp.name},,bar={tmp.name},",
+                ]
+            )
+            self.assertEqual(set(args.with_deps), {"foo", "bar"})
+
+
 class TestInstallArtifactsSubcommand(unittest.TestCase):
     """Tests for the install subcommand."""
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1104,6 +1104,61 @@ class TestZScriptSetupWithNanvix(unittest.TestCase):
         fake_sysroot.overlay_local_nanvix.assert_not_called()
 
 
+class TestZScriptSetupWithDeps(unittest.TestCase):
+    """setup() installs local dev archives for names in ``local_deps``."""
+
+    def setUp(self) -> None:
+        write_manifest()
+        for key in (
+            "NANVIX_MACHINE",
+            "NANVIX_DEPLOYMENT_MODE",
+            "NANVIX_MEMORY_SIZE",
+        ):
+            os.environ.pop(key, None)
+
+    def test_setup_calls_install_local_archive_for_persisted_names(self) -> None:
+        """Names in ``local_deps`` route through install_local_archive."""
+        write_manifest(MANIFEST_WITH_DEPS)
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.Buildroot.install_dep") as mock_id,
+        ):
+            script = ZScript()
+            script._offline = True  # skip resolve() network path
+            script.local_deps = {"zlib": str(local)}
+            script.setup()
+
+        mock_ila.assert_called_once()
+        called_dep = mock_ila.call_args.args[0]
+        called_path = mock_ila.call_args.args[1]
+        self.assertEqual(called_dep.name, "zlib")
+        self.assertEqual(called_path, local)
+        mock_id.assert_not_called()
+
+    def test_setup_no_action_when_map_empty(self) -> None:
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+        ):
+            script = ZScript()
+            script.setup()
+
+        mock_ila.assert_not_called()
+
+
 class TestHelpersMakeInitrd(unittest.TestCase):
     """helpers.make_initrd() builds the correct mkimage command."""
 


### PR DESCRIPTION
> **Stacked on top of #335** (LOCAL-1). Review that PR first.

# B: Add `--with-deps` for local overrides

Closes #257.  **Depends on PR A** (`refactor/dep-install-helpers`).

## Summary

Non-breaking API addition for developing against local dependency builds.

Adds `./z setup --with-deps 'name=path,name=path'`, where each `path` is a
sibling consumer's manifest **file** (typically `.nanvix/nanvix.toml`).
The sibling's staged dev tree at `<path>/../out/staging/dev/` —
byte-identical to the archive its `release` step would pack — is copied
into the sysroot in place of the released dep.  No re-release needed;
sibling only needs `./z build`.

This PR ships the mechanism only — no consistency checks.  Overrides work
"at the user's risk"; the two diamond-dependency checks land in PRs C and D.

## Example

```sh
./z setup --with-deps='zlib=~/repos/nanvix/zlib/default/.nanvix/nanvix.toml'
```

Multiple entries, comma-separated:

```sh
DEPS=""
for DEP in libxml2 libxslt lxml sqlite zlib openssl; do
    DEPS+="$DEP=~/repos/nanvix/$DEP/.nanvix/nanvix.toml,"   # trailing comma OK
done
./z setup --with-deps="$DEPS"
```

## Behavior

- Overrides are one-shot per `setup` — nothing is persisted; pass
  `--with-deps` again on the next `setup` to reapply.
- No auto-build of siblings; missing staging tree fatals with a hint.
- Empty entries (leading/trailing/adjacent commas) are tolerated for
  easier shell composition.
- Names not in the manifest's `[dependencies]` are silently ignored
  (they never get reached by the install loop).  PR C tightens this to a
  visible warning.

## Implementation

- `_dep_map` argparse type parses `name=path,...`, expands `~`,
  canonicalises each path (must be a regular file), skips empty entries.
- `Buildroot.install_local_archive(dep, manifest_path)` walks
  `<manifest>/../out/staging/dev/` and copies matching files via the
  `_copy_local_dep_tree` helper introduced in PR A.
- `ZScript.local_deps: dict[str, str]` — public, read-only.  Consumer
  setup hooks can branch on `if name in self.local_deps: ...`.
- Setup's install loop short-circuits to `install_local_archive` when a
  dep name is in `local_deps` — before the `--with-nanvix` / online
  install paths.

## Testing

- CLI parser: missing `=`, empty name/path, non-file path, directory
  path, use on non-setup subcommand, trailing-comma tolerance.
- Buildroot: copy from staging tree (files, headers, subdirectories,
  `install_libs`/`install_headers` filtering, missing tree fatals).
- Script setup: override routes through `install_local_archive`; empty
  override map is a no-op.

## Docs

- New `docs/with-deps.md`.
- README table entry.
