### PR TITLE
[LOCAL-3] Direct diamond dependency check for --with-deps

### DIFF
--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -46,8 +46,15 @@ composition.
 
 ## Errors
 
+- Override names not in the resolved dep tree (neither a manifest
+  direct dep nor an SDK-resolved transitive) are warned and dropped.
 - Staged dev tree not present under `<path>/../out/staging/dev/`:
   fatal, with a hint to build the sibling first.
+- Released package transitively depends on an overridden dep and
+  is not itself overridden: fatal.  The released `.a` embeds calls
+  against the pre-override version of the transitive; mixing at link
+  time drifts ABI silently.  Either add the parent to `--with-deps`
+  too, or drop the leaf override.
 
 ## Public API
 

--- a/src/nanvix_zutil/resolver.py
+++ b/src/nanvix_zutil/resolver.py
@@ -202,6 +202,7 @@ def resolve(
     verified_sdk_release: SdkRelease | None = None,
     verify_sdk_image: bool = True,
     manifest_content: bytes | None = None,
+    local_overrides: dict[str, str] | None = None,
 ) -> Lockfile | BlockedResolution:
     """Resolve a manifest into a fully pinned lockfile.
 
@@ -230,13 +231,17 @@ def resolve(
             contract. Enabled by default.
         manifest_content: Candidate manifest bytes used to hash an atomic
             update before the target file is written.
+        local_overrides: Names the caller will replace with local builds
+            (``setup --with-deps``).  Resolution is unchanged, but a
+            released package that depends on an overridden name is fatal
+            (diamond hazard) unless that package is itself overridden.
 
     Returns:
         The fully resolved :class:`Lockfile`.
 
     Raises:
-        SystemExit: On cycle detection, version conflicts, or network
-            errors.
+        SystemExit: On cycle detection, version conflicts, local-override
+            diamond hazards, or network errors.
     """
     tmp_dir = (
         Path(cache_dir)
@@ -255,6 +260,7 @@ def resolve(
             verified_sdk_release=verified_sdk_release,
             verify_sdk_image=verify_sdk_image,
             manifest_content=manifest_content,
+            local_overrides=local_overrides,
         )
     finally:
         if owns_tmp and tmp_dir.exists():
@@ -270,8 +276,17 @@ def _resolve_inner(
     verified_sdk_release: SdkRelease | None,
     verify_sdk_image: bool,
     manifest_content: bytes | None,
+    local_overrides: dict[str, str] | None = None,
 ) -> Lockfile | BlockedResolution:
     """Inner resolver logic (separated for cleanup in ``resolve()``)."""
+    # Names the caller will replace with local builds (``--with-deps``).
+    # Resolution proceeds normally (every dep is pinned to its released
+    # version), but a released package that depends on an overridden name
+    # is a diamond hazard: its prebuilt ``.a`` is frozen against the
+    # released version of that dep, so swapping in a local build drifts
+    # ABI at link time.  Such an edge is fatal unless the depending
+    # package is *itself* overridden.
+    overrides: set[str] = set(local_overrides or {})
     resolved: dict[str, ResolvedPackage] = {}
     releases: dict[str, dict[str, object]] = {}
 
@@ -466,6 +481,22 @@ def _resolve_inner(
         for trans_pkg in inner_lock.packages:
             if trans_pkg.kind == "sysroot":
                 continue
+            # Diamond hazard: a released package (``dep``) depends on a
+            # locally overridden name.  Fatal unless ``dep`` is itself
+            # overridden (in which case its provenance is the caller's
+            # responsibility, verified separately).
+            if trans_pkg.name in overrides and dep.name not in overrides:
+                log.fatal(
+                    f"Local override '{trans_pkg.name}' is required by"
+                    f" released package '{dep.name}'.",
+                    code=EXIT_INVALID_ARGS,
+                    hint=(
+                        f"'{dep.name}' was built against the released"
+                        f" '{trans_pkg.name}' and will silently mismatch at"
+                        f" link time. Override '{dep.name}' too, or drop the"
+                        f" '{trans_pkg.name}' override."
+                    ),
+                )
             if trans_pkg.name not in resolved:
                 pkg.dependencies.append(trans_pkg.name)
                 queue.append(

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -324,6 +324,10 @@ class ZScript:
         self.sysroot.verify(self.sysroot_required_files())
 
         deps: list[Dependency] = list(self.manifest.dependencies)
+        # ``known`` is the set of names we understand at install time.
+        # In offline mode this is just the manifest's direct deps;
+        # online mode extends it with SDK-resolved transitives below.
+        known: set[str] = {dep.name for dep in deps}
 
         sdk_releases: dict[str, dict[str, object]] = {}
         if not self._offline:
@@ -333,6 +337,7 @@ class ZScript:
                 self.manifest,
                 gh_token=self.config.get(CFG_GH_TOKEN),
                 verify_sdk_image=not is_windows(),
+                local_overrides=local_deps,
             )
             if isinstance(resolution, BlockedResolution):
                 log.fatal(
@@ -356,6 +361,8 @@ class ZScript:
                     )
                 selected.append(name)
                 pending.extend(package.dependencies)
+            known.update(selected)
+
             direct = {dep.name for dep in deps}
             for name in selected:
                 package = packages[name]
@@ -380,6 +387,23 @@ class ZScript:
                             ref=package.ref,
                         )
                     )
+
+        # Warn+drop --with-deps overrides that are not part of the
+        # known dep set.  Deferred until after SDK resolution so that
+        # overriding a valid transitive dep (present in the SDK lock
+        # but not in the manifest's direct [[dependencies]]) is not
+        # spuriously rejected.
+        if local_deps:
+            unknown = sorted(set(local_deps) - known)
+            for name in unknown:
+                log.warning(
+                    f"--with-deps: ignoring '{name}' — not in the resolved dep tree"
+                )
+                del local_deps[name]
+            # Keep the public map in sync with the effective override set
+            # so consumer hooks reading ``self.local_deps`` never see a
+            # name that was warned-and-dropped.
+            self.local_deps = dict(local_deps)
 
         if deps:
             self.buildroot = Buildroot.create()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -39,6 +39,7 @@ from tests.testutils import (
     MANIFEST_WITH_DEPS,
     make_sdk_provenance,
     make_toml,
+    toolchain_toml,
     write_manifest,
 )
 
@@ -1144,6 +1145,31 @@ class TestZScriptSetupWithDeps(unittest.TestCase):
         self.assertEqual(called_path, local)
         mock_id.assert_not_called()
 
+    def test_setup_warns_and_ignores_unknown_dep_name(self) -> None:
+        """Names not in the resolved dep tree are warned about and ignored."""
+        local = Path.cwd() / "nope_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.log.warning") as mock_warn,
+        ):
+            script = ZScript()
+            script.local_deps = {"not_a_real_dep": str(local)}
+            script.setup()  # must not raise
+
+        mock_ila.assert_not_called()
+        self.assertTrue(
+            any("not_a_real_dep" in c.args[0] for c in mock_warn.call_args_list),
+            f"expected warning mentioning 'not_a_real_dep', got {mock_warn.call_args_list!r}",
+        )
+
     def test_setup_no_action_when_map_empty(self) -> None:
         fake_sysroot = MagicMock()
         fake_sysroot.path = Path("/fake/sysroot")
@@ -1157,6 +1183,147 @@ class TestZScriptSetupWithDeps(unittest.TestCase):
             script.setup()
 
         mock_ila.assert_not_called()
+
+
+class TestZScriptWithDepsSetupRouting(unittest.TestCase):
+    """setup() routes overrides to install_local_archive and warns on unknowns.
+
+    The diamond-hazard check itself now lives in the resolver; see
+    ``tests/test_sdk_resolver.py::TestResolverLocalOverrides``.
+    """
+
+    def setUp(self) -> None:
+        for key in (
+            "NANVIX_MACHINE",
+            "NANVIX_DEPLOYMENT_MODE",
+            "NANVIX_MEMORY_SIZE",
+        ):
+            os.environ.pop(key, None)
+
+    @staticmethod
+    def _pkg(name: str, deps: list[str] | None = None) -> ResolvedPackage:
+        return ResolvedPackage(
+            name=name,
+            repo=f"nanvix/{name}",
+            kind="dependency",
+            ref=Ref(kind=RefKind.VERSION, value="1.0"),
+            resolved_tag="v1.0",
+            resolved_commitish="c" * 40,
+            release_id=1,
+            dependencies=deps or [],
+            assets=[
+                ResolvedAsset(
+                    name=f"{name}-microvm-standalone-256mb.tar.bz2",
+                    url=f"https://example.invalid/{name}.tar.bz2",
+                )
+            ],
+        )
+
+    def _run(self, manifest: str, lock: Lockfile, with_deps: dict[str, str]) -> None:
+        write_manifest(manifest)
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=lock),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive"),
+            patch("nanvix_zutil.script.Buildroot.install_dep"),
+        ):
+            script = ZScript()
+            script.local_deps = with_deps
+            script.setup()
+
+    def _manifest(self, *dep_names: str) -> str:
+        deps = "\n".join(f'{name} = "1.0"' for name in dep_names)
+        return (
+            "[package]\n"
+            'name = "test"\n'
+            'version = "0.1.0"\n'
+            'nanvix-version = "0.1.0"\n'
+            + toolchain_toml()
+            + "\n[dependencies]\n"
+            + deps
+            + "\n"
+        )
+
+    def _lock(self, *pkgs: ResolvedPackage) -> Lockfile:
+        return Lockfile(
+            LockfileMetadata("sha256:x", "0.20.0", sdk=make_sdk_provenance("0.20.0")),
+            packages=list(pkgs),
+        )
+
+    def test_override_of_transitive_only_dep_installs(self) -> None:
+        """Overriding a name only present as a transitive (not a direct dep)
+        routes through install_local_archive; the deferred filter admits it."""
+        local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        (local.parent / "local_deps.json").write_text("{}")
+        # cpython (direct) → sqlite (transitive) → zlib (transitive, overridden).
+        # Also override sqlite so the direct check passes.
+        local_s = Path.cwd() / "sqlite_ws" / ".nanvix" / "nanvix.toml"
+        local_s.parent.mkdir(parents=True)
+        local_s.write_text("")
+        (local_s.parent / "local_deps.json").write_text("{}")
+        local_c = Path.cwd() / "cpython_ws" / ".nanvix" / "nanvix.toml"
+        local_c.parent.mkdir(parents=True)
+        local_c.write_text("")
+        (local_c.parent / "local_deps.json").write_text("{}")
+        lock = self._lock(
+            self._pkg("zlib"),
+            self._pkg("sqlite", deps=["zlib"]),
+            self._pkg("cpython", deps=["sqlite"]),
+        )
+        write_manifest(self._manifest("cpython"))
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=lock),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.Buildroot.install_dep"),
+        ):
+            script = ZScript()
+            script.local_deps = {
+                "zlib": str(local),
+                "sqlite": str(local_s),
+                "cpython": str(local_c),
+            }
+            script.setup()
+
+        called_names = {c.args[0].name for c in mock_ila.call_args_list}
+        self.assertIn("zlib", called_names)  # transitive-only, overridden
+
+    def test_warns_and_drops_unknown_name_online(self) -> None:
+        """An override name absent from both manifest and lock is warned+dropped."""
+        local = Path.cwd() / "ghost_ws" / ".nanvix" / "nanvix.toml"
+        local.parent.mkdir(parents=True)
+        local.write_text("")
+        lock = self._lock(self._pkg("zlib"))
+        write_manifest(self._manifest("zlib"))
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=lock),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive") as mock_ila,
+            patch("nanvix_zutil.script.Buildroot.install_dep"),
+            patch("nanvix_zutil.script.log.warning") as mock_warn,
+        ):
+            script = ZScript()
+            script.local_deps = {"ghost": str(local)}
+            script.setup()  # must not raise
+
+        mock_ila.assert_not_called()
+        self.assertTrue(
+            any("ghost" in c.args[0] for c in mock_warn.call_args_list),
+            f"expected warning mentioning 'ghost', got {mock_warn.call_args_list!r}",
+        )
+        # Public map reflects the effective (pruned) override set.
+        self.assertEqual(script.local_deps, {})
 
 
 class TestHelpersMakeInitrd(unittest.TestCase):

--- a/tests/test_sdk_resolver.py
+++ b/tests/test_sdk_resolver.py
@@ -240,5 +240,170 @@ class TestStrictSdkResolver(unittest.TestCase):
         self.assertEqual(context.exception.code, 2)
 
 
+SDK_SUFFIX = "-nanvix-0.20.0-sdk.1"
+
+
+class TestResolverLocalOverrides(unittest.TestCase):
+    """``resolve(local_overrides=...)`` fatals on diamond hazards.
+
+    A released package that depends on a locally overridden name is
+    fatal unless that package is itself overridden.
+    """
+
+    def setUp(self) -> None:
+        paths.manifest_path().write_text(
+            "[package]\n"
+            'name = "test"\n'
+            'version = "1.0.0"\n'
+            'nanvix-version = "0.20.0"\n'
+        )
+        self.contract = validate_sdk_release(make_sdk_contract())
+        self.commit_patcher = patch(
+            "nanvix_zutil.resolver.github.resolve_commit",
+            return_value="c" * 40,
+        )
+        self.commit_patcher.start()
+        self.addCleanup(self.commit_patcher.stop)
+
+    def _manifest(self, *dep_names: str) -> Manifest:
+        return Manifest(
+            name="test",
+            version="1.0.0",
+            sysroot_ref=Ref(RefKind.TAG, "0.20.0"),
+            dependencies=[
+                Dependency(
+                    n,
+                    f"nanvix/{n}",
+                    Ref(RefKind.VERSION, f"1.0.0{SDK_SUFFIX}"),
+                )
+                for n in dep_names
+            ],
+            toolchain=Toolchain(
+                ToolchainKind.SDK,
+                SdkPin(
+                    self.contract.sdk_version,
+                    self.contract.provider_id,
+                    self.contract.image.name,
+                    self.contract.image.digest,
+                ),
+            ),
+        )
+
+    def _pkg(self, name: str) -> ResolvedPackage:
+        return ResolvedPackage(
+            name=name,
+            repo=f"nanvix/{name}",
+            kind="dependency",
+            ref=Ref(RefKind.VERSION, f"1.0.0{SDK_SUFFIX}"),
+            resolved_tag=f"1.0.0{SDK_SUFFIX}",
+            resolved_commitish="e" * 40,
+            release_id=9,
+        )
+
+    def _run(
+        self,
+        manifest: Manifest,
+        graph: dict[str, list[str]],
+        overrides: dict[str, str] | None,
+    ) -> Lockfile | BlockedResolution:
+        """Resolve *manifest* with a mocked dependency *graph*.
+
+        *graph* maps each package name to the names of its transitive
+        deps (as they would appear in its shipped ``nanvix.lock``).
+        """
+
+        def fake_release(
+            repo: str, specifier: object, **_kw: object
+        ) -> dict[str, object]:
+            if repo == "nanvix/nanvix":
+                return release("v0.20.0", "c" * 40, 1)
+            return release(f"1.0.0{SDK_SUFFIX}", "e" * 40, 2)
+
+        def fake_download(
+            dep_release: object,
+            cache_dir: object,
+            *,
+            gh_token: str | None = None,
+            dep_name: str | None = None,
+        ) -> Lockfile:
+            children = graph.get(dep_name or "", [])
+            return Lockfile(
+                LockfileMetadata(
+                    manifest_hash="sha256:dep",
+                    nanvix_zutil_version="0.15.0",
+                    sdk=self.contract.provenance(),
+                    shallow=True,
+                ),
+                packages=[self._pkg(c) for c in children],
+            )
+
+        with (
+            patch(
+                "nanvix_zutil.resolver.resolve_sdk_release",
+                return_value=self.contract,
+            ),
+            patch(
+                "nanvix_zutil.resolver.github.resolve_release",
+                side_effect=fake_release,
+            ),
+            patch(
+                "nanvix_zutil.resolver.download_lockfile_asset",
+                side_effect=fake_download,
+            ),
+        ):
+            return resolve(
+                manifest,
+                cache_dir=Path.cwd() / "cache",
+                local_overrides=overrides,
+            )
+
+    def test_released_parent_of_override_fatals(self) -> None:
+        """sqlite (released) -> zlib (overridden): fatal."""
+        with self.assertRaises(SystemExit) as ctx:
+            self._run(
+                self._manifest("sqlite", "zlib"),
+                {"sqlite": ["zlib"]},
+                {"zlib": "/p/zlib"},
+            )
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_all_overridden_passes(self) -> None:
+        """Both parent and leaf overridden: no fatal."""
+        result = self._run(
+            self._manifest("sqlite", "zlib"),
+            {"sqlite": ["zlib"]},
+            {"zlib": "/p/zlib", "sqlite": "/p/sqlite"},
+        )
+        self.assertNotIsInstance(result, BlockedResolution)
+
+    def test_override_with_no_released_parent_passes(self) -> None:
+        """Overriding a leaf nothing released depends on: no fatal."""
+        result = self._run(
+            self._manifest("zlib"),
+            {},
+            {"zlib": "/p/zlib"},
+        )
+        self.assertNotIsInstance(result, BlockedResolution)
+
+    def test_multi_hop_fatals(self) -> None:
+        """cpython -> sqlite -> zlib; overriding only zlib: fatal."""
+        with self.assertRaises(SystemExit) as ctx:
+            self._run(
+                self._manifest("cpython"),
+                {"cpython": ["sqlite"], "sqlite": ["zlib"]},
+                {"zlib": "/p/zlib"},
+            )
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_no_overrides_is_noop(self) -> None:
+        """Absent overrides, resolution is unchanged."""
+        result = self._run(
+            self._manifest("sqlite", "zlib"),
+            {"sqlite": ["zlib"]},
+            None,
+        )
+        self.assertNotIsInstance(result, BlockedResolution)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> **Stacked on top of #336** (LOCAL-2). Review that PR first.

# C: Direct diamond dependency check (in the resolver)

**Depends on PR B** (`feat/with-deps`).

## Summary

Adds a correctness check for the most common `--with-deps` footgun:
overriding a leaf dep without also overriding released packages that
transitively depend on it.

### Motivating example

```
cpython → sqlite (released) → zlib
cpython → zlib (overridden via --with-deps)
```

The released `libsqlite.a` was compiled against released zlib's ABI. If
you swap in a local zlib whose ABI has drifted, cpython's link mixes
sqlite's baked-in expectations against a different-shape zlib — silent
breakage. This PR fatals at `setup` before any install happens.

## Design: fold the check into the resolver

Rather than re-walking the resolved tree in `setup`, the check lives in
`resolver.resolve()`, which already performs the BFS over the dependency
graph and already detects version conflicts and cycles.

- `resolve()` gains an optional `local_overrides: dict[str, str]`.
- During transitive discovery, when a released package `dep` lists a
  dependency `X` that is in `local_overrides`, it is fatal **unless
  `dep` is itself overridden** (in which case its provenance is the
  caller's responsibility, verified separately in PR D).
- Resolution is otherwise unchanged — every dep is still pinned to its
  released version, overrides never enter the resolved tree, and the
  output lockfile is untouched (no `RefKind.LOCAL` leakage, no format
  change).

`setup` just passes `local_overrides=local_deps`; its old post-hoc
`_reach()` reachability walk is deleted. Because the resolver runs
`_detect_cycles` upstream, the earlier "does the DFS hang on a cycle?"
concern is gone for free.

### Why not seed overrides as `RefKind.LOCAL` pre-resolved entries?

That approach (let the existing version-conflict equality check fire)
breaks: the manifest still declares `zlib@VERSION`, so a seeded
`zlib@LOCAL` conflicts with the manifest's *own* direct declaration and
fatals on the legitimate override. It also trips the SDK-coordinate
guards (which reject any non-`VERSION` ref) and would leak a synthetic
`LOCAL` package into the output lockfile. A diamond override isn't
actually a *version* conflict either (everyone agrees zlib is v1.3.1 —
the problem is that you're replacing it), so the equality check is the
wrong tool. The dedicated check reuses the resolver's traversal and
`required_by` tracking without any of that fallout, and explicitly
avoids touching the manifest or lockfile format.

## Also in this PR

- The deferred "unknown override name" warn+drop: names not in the
  resolved tree are warned and dropped. This also keeps the public
  `ZScript.local_deps` map in sync with the effective (pruned) override
  set, so consumer hooks never see a name that was dropped.

## Testing

Resolver-level (`test_sdk_resolver.py::TestResolverLocalOverrides`,
exercising `resolve(local_overrides=...)` through the network-mock
harness):
- released parent of an override → fatal
- all transitives overridden → passes
- multi-hop released parent → fatal
- override with no released parent → passes
- no overrides → unchanged resolution

Setup-level (`test_script.py::TestZScriptWithDepsSetupRouting`):
- transitive-only override routes through `install_local_archive`
- unknown override name is warned, dropped, and pruned from
  `self.local_deps`

## Verified end-to-end

`cpython --with-deps 'zlib=…'` against real sibling repos:

```
error: Local override 'zlib' is required by released package 'sqlite'.
hint: 'sqlite' was built against the released 'zlib' and will silently
      mismatch at link time. Override 'sqlite' too, or drop the 'zlib'
      override.
```

## Prior art

A specialization of Bazel's [One-Version
Rule](https://bazel.build/build/one-version) — every artifact in the
build graph must agree on the version of every dep. See also [diamond
dependency conflict](https://jlbp.dev/what-is-a-diamond-dependency-conflict).
