### PR TITLE
[LOCAL-4] Transitive diamond dependency check for --with-deps

### DIFF
--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -55,6 +55,15 @@ composition.
   against the pre-override version of the transitive; mixing at link
   time drifts ABI silently.  Either add the parent to `--with-deps`
   too, or drop the leaf override.
+- Overridden sibling was itself built against a different version of a
+  shared dependency than this build resolves: fatal.  Detected by
+  reading the sibling's committed `nanvix.lock` (its build provenance)
+  and comparing shared entries against this build's resolution.
+  Rebuild the sibling against a matching SDK, or drop the override.
+  (A sibling built with its *own* `--with-deps` is not reflected in
+  its lock; that nested case is out of scope.)
+- Overridden sibling has no committed `nanvix.lock`: fatal.  Run
+  `./z lock` (or a full setup) for the sibling first.
 
 ## Public API
 

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -330,6 +330,9 @@ class ZScript:
         known: set[str] = {dep.name for dep in deps}
 
         sdk_releases: dict[str, dict[str, object]] = {}
+        # Consumer's resolved version per package name (online only), used
+        # to verify overridden siblings' build provenance below.
+        consumer_versions: dict[str, str] = {}
         if not self._offline:
             # Windows resolves the digest-bound release tuple but cannot execute the
             # Linux provider image; CI verifies that image on its Linux job.
@@ -347,6 +350,9 @@ class ZScript:
                     hint=resolution.reason,
                 )
             packages = {pkg.name: pkg for pkg in resolution.packages}
+            consumer_versions = {
+                pkg.name: pkg.resolved_tag for pkg in resolution.packages
+            }
             selected: list[str] = []
             pending = [dep.name for dep in deps]
             while pending:
@@ -404,6 +410,44 @@ class ZScript:
             # so consumer hooks reading ``self.local_deps`` never see a
             # name that was warned-and-dropped.
             self.local_deps = dict(local_deps)
+
+        # Transitive diamond check: each overridden sibling records the
+        # versions it was built against in its own committed nanvix.lock.
+        # Every dep shared with our resolution must agree, else the
+        # sibling's prebuilt ``.a`` is frozen against a different version
+        # of that dep than we will link.  (A sibling built with its own
+        # --with-deps is not reflected in its lock; that nested case is
+        # out of scope.)
+        if local_deps and consumer_versions:
+            mismatches: list[tuple[str, str, str, str]] = []
+            for name, sibling_manifest in local_deps.items():
+                sibling_lock = read_lockfile(
+                    Path(sibling_manifest).parent / "nanvix.lock"
+                )
+                sib_versions = {
+                    pkg.name: pkg.resolved_tag for pkg in sibling_lock.packages
+                }
+                for key in sorted(set(sib_versions) & set(consumer_versions)):
+                    if sib_versions[key] != consumer_versions[key]:
+                        mismatches.append(
+                            (name, key, sib_versions[key], consumer_versions[key])
+                        )
+            if mismatches:
+                lines = "\n".join(
+                    f"  - via '{via}': '{key}' was built against {sib!r},"
+                    f" but this build resolves it to {con!r}"
+                    for via, key, sib, con in mismatches
+                )
+                log.fatal(
+                    "Inconsistent local dep provenance:\n" + lines,
+                    code=EXIT_MISSING_DEP,
+                    hint=(
+                        "The sibling was built against different dependency"
+                        " versions than this build resolves. Rebuild the"
+                        " sibling against a matching SDK, or drop the"
+                        " conflicting override."
+                    ),
+                )
 
         if deps:
             self.buildroot = Buildroot.create()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -31,6 +31,7 @@ from nanvix_zutil.lockfile import (
     LockfileMetadata,
     ResolvedAsset,
     ResolvedPackage,
+    write_lockfile,
 )
 from nanvix_zutil.manifest import Manifest
 from nanvix_zutil.resolver import BlockedResolution
@@ -1259,17 +1260,17 @@ class TestZScriptWithDepsSetupRouting(unittest.TestCase):
         local = Path.cwd() / "zlib_ws" / ".nanvix" / "nanvix.toml"
         local.parent.mkdir(parents=True)
         local.write_text("")
-        (local.parent / "local_deps.json").write_text("{}")
+        write_lockfile(self._lock(), local.parent / "nanvix.lock")
         # cpython (direct) → sqlite (transitive) → zlib (transitive, overridden).
         # Also override sqlite so the direct check passes.
         local_s = Path.cwd() / "sqlite_ws" / ".nanvix" / "nanvix.toml"
         local_s.parent.mkdir(parents=True)
         local_s.write_text("")
-        (local_s.parent / "local_deps.json").write_text("{}")
+        write_lockfile(self._lock(), local_s.parent / "nanvix.lock")
         local_c = Path.cwd() / "cpython_ws" / ".nanvix" / "nanvix.toml"
         local_c.parent.mkdir(parents=True)
         local_c.write_text("")
-        (local_c.parent / "local_deps.json").write_text("{}")
+        write_lockfile(self._lock(), local_c.parent / "nanvix.lock")
         lock = self._lock(
             self._pkg("zlib"),
             self._pkg("sqlite", deps=["zlib"]),
@@ -1324,6 +1325,128 @@ class TestZScriptWithDepsSetupRouting(unittest.TestCase):
         )
         # Public map reflects the effective (pruned) override set.
         self.assertEqual(script.local_deps, {})
+
+
+class TestZScriptTransitiveCheck(unittest.TestCase):
+    """setup() verifies overridden siblings' build provenance (nanvix.lock).
+
+    Each override's sibling records the versions it was built against in
+    its own committed nanvix.lock; shared deps must agree with our
+    resolution.
+    """
+
+    def setUp(self) -> None:
+        for key in (
+            "NANVIX_MACHINE",
+            "NANVIX_DEPLOYMENT_MODE",
+            "NANVIX_MEMORY_SIZE",
+        ):
+            os.environ.pop(key, None)
+
+    @staticmethod
+    def _pkg(name: str, tag: str = "v1.0") -> ResolvedPackage:
+        return ResolvedPackage(
+            name=name,
+            repo=f"nanvix/{name}",
+            kind="dependency",
+            ref=Ref(kind=RefKind.VERSION, value=tag.lstrip("v")),
+            resolved_tag=tag,
+            resolved_commitish="c" * 40,
+            release_id=1,
+            assets=[
+                ResolvedAsset(
+                    name=f"{name}-microvm-standalone-256mb.tar.bz2",
+                    url=f"https://example.invalid/{name}.tar.bz2",
+                )
+            ],
+        )
+
+    def _lock(self, *pkgs: ResolvedPackage) -> Lockfile:
+        return Lockfile(
+            LockfileMetadata("sha256:x", "0.20.0", sdk=make_sdk_provenance("0.20.0")),
+            packages=list(pkgs),
+        )
+
+    def _manifest(self, *dep_names: str) -> str:
+        deps = "\n".join(f'{name} = "1.0"' for name in dep_names)
+        return (
+            "[package]\n"
+            'name = "test"\n'
+            'version = "0.1.0"\n'
+            'nanvix-version = "0.1.0"\n'
+            + toolchain_toml()
+            + "\n[dependencies]\n"
+            + deps
+            + "\n"
+        )
+
+    def _sibling(self, name: str, lock: Lockfile | None) -> str:
+        """Create a sibling worktree; optionally write its nanvix.lock."""
+        manifest = Path.cwd() / f"{name}_ws" / ".nanvix" / "nanvix.toml"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("")
+        if lock is not None:
+            write_lockfile(lock, manifest.parent / "nanvix.lock")
+        return str(manifest)
+
+    def _run(
+        self, manifest: str, resolution: Lockfile, with_deps: dict[str, str]
+    ) -> None:
+        write_manifest(manifest)
+        fake_sysroot = MagicMock()
+        fake_sysroot.path = Path("/fake/sysroot")
+        with (
+            patch("nanvix_zutil.script.Sysroot.download", return_value=fake_sysroot),
+            patch("nanvix_zutil.script.Sysroot.verify"),
+            patch("nanvix_zutil.script.resolve", return_value=resolution),
+            patch("nanvix_zutil.script.Buildroot.install_local_archive"),
+            patch("nanvix_zutil.script.Buildroot.install_dep"),
+        ):
+            script = ZScript()
+            script.local_deps = with_deps
+            script.setup()
+
+    def test_fatals_on_version_mismatch(self) -> None:
+        """Sibling built against a different shared-dep version fatals."""
+        # Consumer resolves libcrc v1.2; sibling zlib was built vs v0.9.
+        resolution = self._lock(
+            self._pkg("zlib", "v1.0"),
+            self._pkg("libcrc", "v1.2"),
+        )
+        sib = self._sibling("zlib", self._lock(self._pkg("libcrc", "v0.9")))
+        with self.assertRaises(SystemExit):
+            self._run(
+                self._manifest("zlib", "libcrc"),
+                resolution,
+                {"zlib": sib},
+            )
+
+    def test_passes_when_versions_agree(self) -> None:
+        resolution = self._lock(
+            self._pkg("zlib", "v1.0"),
+            self._pkg("libcrc", "v1.2"),
+        )
+        sib = self._sibling("zlib", self._lock(self._pkg("libcrc", "v1.2")))
+        self._run(  # must not raise
+            self._manifest("zlib", "libcrc"),
+            resolution,
+            {"zlib": sib},
+        )
+
+    def test_passes_when_no_shared_deps(self) -> None:
+        resolution = self._lock(self._pkg("zlib", "v1.0"))
+        sib = self._sibling("zlib", self._lock(self._pkg("unrelated", "v9")))
+        self._run(  # must not raise
+            self._manifest("zlib"),
+            resolution,
+            {"zlib": sib},
+        )
+
+    def test_fatals_on_missing_sibling_lock(self) -> None:
+        resolution = self._lock(self._pkg("zlib", "v1.0"))
+        sib = self._sibling("zlib", None)  # no nanvix.lock written
+        with self.assertRaises(SystemExit):
+            self._run(self._manifest("zlib"), resolution, {"zlib": sib})
 
 
 class TestHelpersMakeInitrd(unittest.TestCase):


### PR DESCRIPTION
> **Stacked on top of #337** (LOCAL-3). Review that PR first.

Closes #257 

# D: Transitive diamond dependency check (via sibling `nanvix.lock`)

**Depends on PR C** (`feat/with-deps-direct-check`).

## Summary

Adds the second correctness check for `--with-deps`: catch the case
where a locally-built sibling was itself compiled against a different
version of a shared dependency than the consumer will now link.

### Motivating example

```
1. cd sqlite/ ; ./z setup && ./z build   # sqlite baked against its resolved zlib
2. cd cpython/ ; ./z setup --with-deps 'sqlite=…'
```

Local `sqlite.a` is frozen against whatever zlib version sqlite
resolved at build time. If cpython resolves a different zlib, the
prebuilt sqlite mismatches at link time.

## Mechanism: reuse the sibling's committed `nanvix.lock`

A built sibling already commits its resolved dependency versions — its
`nanvix.lock`. That file **is** the sibling's build provenance, so no
sidecar file and no format change are needed.

- Consumer side: `{name: resolved_tag}` taken straight from this
  build's resolved lockfile (`resolution.packages`).
- Sibling side: `read_lockfile(<override>/.nanvix/nanvix.lock)` →
  `{name: resolved_tag}`.
- For each override, every dependency shared between the sibling's lock
  and this build's resolution must agree; any disagreement is fatal.
- A missing sibling `nanvix.lock` is fatal (handled by `read_lockfile`,
  exit 3) — the sibling must be resolved/built first.

This replaces the earlier prototype that wrote a gitignored
`.nanvix/local_deps.json` on every setup and read it back. That file,
its write/unlink-on-failure dance, the `_local_deps_map` helper, and
the `.gitignore` entries are all gone.

### Scope

Reading the sibling's `nanvix.lock` reflects the sibling's *clean*
resolution. If the sibling itself was built with its own `--with-deps`
overrides, its lock will not reflect those nested overrides. That
nested case is out of scope (deemed unlikely in practice); handling it
would require embedding override provenance in the lockfile, which we
explicitly avoid.

## Testing

`test_script.py::TestZScriptTransitiveCheck`:
- sibling built against a different shared-dep version → fatal
- versions agree → passes
- no shared deps → passes
- missing sibling `nanvix.lock` → fatal

## Verified end-to-end

Against real sibling repos:

- `cpython --with-deps 'sqlite=…'` where sqlite and cpython resolve the
  same zlib → transitive check passes, full setup completes (exit 0).
- Perturbing sqlite's committed `nanvix.lock` to record a different
  zlib and re-running:

  ```
  error: Inconsistent local dep provenance:
    - via 'sqlite': 'zlib' was built against '1.2.0-nanvix-0.21.22-sdk.2',
                    but this build resolves it to '1.3.1-nanvix-0.21.22-sdk.2'
  hint: The sibling was built against different dependency versions than
        this build resolves. Rebuild the sibling against a matching SDK,
        or drop the conflicting override.
  ```

## Follow-ups

- Nested overrides: a sibling built with its own `--with-deps` isn't
  reflected in its `nanvix.lock`. Correctly handling it needs override
  provenance in the lockfile (format change) — deliberately deferred.
