### PR TITLE
[DOCKER-1] docker: rsync sync + CRLF normalization

### DIFF
--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -163,6 +163,9 @@ class DockerConfig:
     output_files: list[str] = field(default_factory=lambda: [])
     """Build output files to copy back from the container to the host."""
 
+    crlf_files: list[str] = field(default_factory=lambda: [])
+    """Files (relative to the build dir) to normalize from CRLF to LF after sync."""
+
     tar_excludes: list[str] = field(
         default_factory=lambda: [
             ".git",
@@ -324,11 +327,30 @@ class DockerConfig:
             f"else {tar_cmd}; fi"
         )
 
+        # Normalize CRLF -> LF on caller-supplied files after sync. Avoids
+        # autotools/shell-script breakage on Windows checkouts without
+        # core.autocrlf=input. Uses tr (POSIX \r escape); the normalized
+        # content is written back with `cat tmp > file` so the file's mode is
+        # preserved (a plain `mv` would drop the execute bit off configure).
+        crlf_cmd = ""
+        if self.crlf_files:
+            norms: list[str] = []
+            for f in self.crlf_files:
+                path = shlex.quote(f"{self.container_build_dir}/{f}")
+                tmp = shlex.quote(f"{self.container_build_dir}/{f}.crlf.tmp")
+                norms.append(
+                    f"if [ -f {path} ]; then "
+                    f"tr -d '\\r' < {path} > {tmp} && cat {tmp} > {path} "
+                    f"&& rm -f {tmp}; fi"
+                )
+            crlf_cmd = " && ".join(norms) + " && "
+
         inner_cmd = " ".join(shlex.quote(c) for c in cmd)
         shell_script = (
             f"mkdir -p {build_dir} && "
             f"{sync_cmd} && "
             f"cd {build_dir} && "
+            f"{crlf_cmd}"
             f"{inner_cmd}; rc=$?{output_script}; exit $rc"
         )
 

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -275,8 +275,10 @@ class DockerConfig:
 
         1. Uses the configured container mounts as provided, typically including
            the host workspace at ``/mnt/workspace``.
-        2. Copies sources via ``tar`` from the mounted workspace into a
-           container-local build dir.
+        2. Copies sources from the mounted workspace into a container-local
+           build dir, preferring ``rsync`` (preserves mtimes; keeps a
+           persistent build dir incremental) and falling back to ``tar``
+           when rsync is unavailable.
         3. Runs the inner command from the container-local build dir.
         4. Copies configured output files back to the mounted workspace.
 
@@ -308,11 +310,24 @@ class DockerConfig:
                 )
             output_script = "; " + "; ".join(copy_cmds)
 
+        # Prefer rsync (preserves mtimes, syncs only changed files so a
+        # persistent build dir stays incremental); fall back to tar when rsync
+        # is not present in the image. No --delete: it would wipe build
+        # artifacts and the .build-inputs-hash from a persistent volume. The
+        # excludes string is shared: rsync and tar interpret --exclude=
+        # slightly differently (rsync anchors leading-/ patterns), so keep
+        # excludes to basename patterns to stay branch-agnostic.
+        rsync_cmd = f"rsync -a {excludes} {ws_mount}/ {build_dir}/"
+        tar_cmd = f"tar -cf - -C {ws_mount} {excludes} . | tar -xf - -C {build_dir}"
+        sync_cmd = (
+            f"if command -v rsync >/dev/null 2>&1; then {rsync_cmd}; "
+            f"else {tar_cmd}; fi"
+        )
+
         inner_cmd = " ".join(shlex.quote(c) for c in cmd)
         shell_script = (
             f"mkdir -p {build_dir} && "
-            f"tar -cf - -C {ws_mount} {excludes} . "
-            f"| tar -xf - -C {build_dir} && "
+            f"{sync_cmd} && "
             f"cd {build_dir} && "
             f"{inner_cmd}; rc=$?{output_script}; exit $rc"
         )

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -358,12 +358,22 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         self.assertIn("-c", cmd)
 
     def test_contains_tar_in_shell_script(self) -> None:
-        """The shell script should include tar commands."""
+        """The shell script should include tar commands (rsync fallback)."""
         cfg = self._make_config()
         cmd = cfg.build_windows_run_cmd("make", "all")
         shell_script = cmd[-1]  # Last arg after sh -c
         self.assertIn("tar -cf", shell_script)
         self.assertIn("tar -xf", shell_script)
+
+    def test_prefers_rsync_with_tar_fallback(self) -> None:
+        """Sync prefers rsync and falls back to tar."""
+        cfg = self._make_config()
+        cmd = cfg.build_windows_run_cmd("make", "all")
+        shell_script = cmd[-1]
+        self.assertIn("command -v rsync", shell_script)
+        self.assertIn("rsync -a --exclude", shell_script)
+        self.assertNotIn("--delete", shell_script)
+        self.assertIn("else tar -cf", shell_script)
 
     def test_output_files_copied_back(self) -> None:
         """Output files are copied from container to host."""

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -333,6 +333,7 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
     def _make_config(
         self,
         output_files: list[str] | None = None,
+        crlf_files: list[str] | None = None,
     ) -> DockerConfig:
         return DockerConfig(
             image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
@@ -346,6 +347,7 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
             uid=1000,
             gid=1000,
             output_files=output_files or [],
+            crlf_files=crlf_files or [],
         )
 
     def test_tar_copy_command_structure(self) -> None:
@@ -374,6 +376,29 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         self.assertIn("rsync -a --exclude", shell_script)
         self.assertNotIn("--delete", shell_script)
         self.assertIn("else tar -cf", shell_script)
+
+    def test_no_crlf_normalization_by_default(self) -> None:
+        """Without crlf_files, no normalization is emitted."""
+        cfg = self._make_config()
+        shell_script = cfg.build_windows_run_cmd("make")[-1]
+        self.assertNotIn("tr -d", shell_script)
+
+    def test_crlf_normalization_guarded_per_file(self) -> None:
+        """Each crlf file gets a guarded, portable normalization after sync."""
+        cfg = self._make_config(crlf_files=["configure", "Makefile.in"])
+        shell_script = cfg.build_windows_run_cmd("make")[-1]
+        self.assertIn("if [ -f", shell_script)
+        self.assertIn(r"tr -d '\r'", shell_script)
+        # Written back with cat (not mv) to preserve the file's mode.
+        self.assertIn(
+            "cat /tmp/build/configure.crlf.tmp > /tmp/build/configure", shell_script
+        )
+        self.assertIn("/tmp/build/Makefile.in", shell_script)
+        # Normalization runs after cd into the build dir, before the command.
+        self.assertLess(
+            shell_script.index("cd /tmp/build"), shell_script.index("tr -d")
+        )
+        self.assertLess(shell_script.index("tr -d"), shell_script.index("make"))
 
     def test_output_files_copied_back(self) -> None:
         """Output files are copied from container to host."""


### PR DESCRIPTION
# [zutils] docker: rsync sync + CRLF normalization

Backports two of the CPython `_docker.py` sync features into
`DockerConfig.build_windows_run_cmd` (isolated tar-copy path). Part of #325.

**PR 1 of 3** — base of the stack (branches off `dev`). Non-breaking.

## Changes
- **rsync-preferred sync** (issue #325 §2): sync sources with `rsync -a`
  (preferred) and fall back to `tar` when rsync is absent. rsync preserves
  mtimes and only touches changed files, keeping a persistent build dir
  incremental. No `--delete` — it would wipe build state from a persistent
  volume.
- **CRLF normalization** (issue #325 §5): new `DockerConfig.crlf_files`;
  after sync, normalize each listed file CRLF→LF via `tr` + `cat`-back
  (preserves file mode — a plain `mv` would drop the execute bit off
  `configure`). Guarded so a missing file is a no-op.

## Notes
- Fully POSIX-portable shell (no GNU-sed dependency); `sh -n` parse test.
- e2e-validated (Linux + Windows) as part of the full stack.
