### PR TITLE
[DOCKER-2] docker: `output_files` copies directory trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,11 @@ venv/
 .nanvix/venv/
 
 # Nanvix build artifacts (downloaded sysroot, buildroot, cache, config)
-**/.nanvix/sysroot/
+# No trailing slash on sysroot: examples may symlink it, not just dir it.
+**/.nanvix/sysroot
 **/.nanvix/buildroot/
 **/.nanvix/cache/
+**/.nanvix/out/
 **/.nanvix/env.json
 logs/
 

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -17,6 +17,7 @@ Use ``--with-docker IMAGE`` during setup to specify the Docker image::
 from __future__ import annotations
 
 import os
+import posixpath
 import shlex
 import sys
 from dataclasses import dataclass, field
@@ -161,7 +162,16 @@ class DockerConfig:
     """Additional ``-e KEY=VALUE`` pairs forwarded to the container."""
 
     output_files: list[str] = field(default_factory=lambda: [])
-    """Build output files to copy back from the container to the host."""
+    """Build outputs to copy back from the container to the workspace.
+
+    Each entry is a path relative to *both* the build dir and the workspace
+    mount -- they mirror, so the source and destination share the same
+    relative path.  Directories are wiped and copied with ``cp -a`` (``cp -aL``
+    on a Windows host, to dereference symlinks); files are copied with ``cp``.
+    File-vs-directory is detected at runtime in the container.  Each path is
+    validated lexically to stay within the workspace (it must not resolve to
+    or above the workspace root).
+    """
 
     crlf_files: list[str] = field(default_factory=lambda: [])
     """Files (relative to the build dir) to normalize from CRLF to LF after sync."""
@@ -283,7 +293,10 @@ class DockerConfig:
            persistent build dir incremental) and falling back to ``tar``
            when rsync is unavailable.
         3. Runs the inner command from the container-local build dir.
-        4. Copies configured output files back to the mounted workspace.
+        4. Copies configured ``output_files`` back to the mounted workspace
+           (directories as trees, files individually).
+           Directories are wiped and copied with ``cp -a``; files are
+           copied with ``cp``.
 
         Args:
             *cmd: Inner command and arguments to wrap.
@@ -298,19 +311,64 @@ class DockerConfig:
         # Build tar exclude args.
         excludes = " ".join(f"--exclude={shlex.quote(e)}" for e in self.tar_excludes)
 
-        # Output copy-back script.
+        # Copy build outputs back to the mounted workspace. Each entry mirrors
+        # the same relative path in the build dir and the workspace mount.
+        # Directories are wiped and copied with cp -a; files are copied with
+        # cp. Joined with `;` so a missing output does not abort the others.
+        #
+        # The container runs as root (no --user), so on a real bind mount the
+        # copied-back outputs are chown'd back to uid:gid. This is skipped on a
+        # Windows host: there is no os.getuid() (uid/gid default to 0), so
+        # chowning would force root:root and lock the files away from the
+        # Windows user -- Docker Desktop maps ownership itself. Mirrors the old
+        # _restore_owner guard.
         output_script = ""
-        if self.output_files:
-            copy_cmds: list[str] = []
-            for f in self.output_files:
-                src = shlex.quote(f"{self.container_build_dir}/{f}")
-                dst = shlex.quote(f"{WORKSPACE_CONTAINER_PATH}/{f}")
-                dst_dir = shlex.quote(
-                    str(PurePosixPath(f"{WORKSPACE_CONTAINER_PATH}/{f}").parent)
+        copy_cmds: list[str] = []
+        ws = str(WORKSPACE_CONTAINER_PATH)
+        windows_host = is_windows()
+        restore_owner = not windows_host
+        # On a Windows host, dereference symlinks when copying dir trees so the
+        # bind mount receives real files. Docker Desktop's WSL2 backend renders
+        # container symlinks as LX reparse points that native Windows tools
+        # cannot follow or unlink (WinError 1920). On Linux, preserve symlinks.
+        cp_dir = "cp -aL" if windows_host else "cp -a"
+        for f in self.output_files:
+            # Guard the path: entries are relative to the workspace/build dir
+            # (they mirror), and dir outputs are wiped with ``rm -rf``. Reject
+            # absolute paths and any value (empty, ``.``, ``..``-escaping) that
+            # resolves to or above the workspace root.
+            if posixpath.isabs(f):
+                raise ValueError(f"output path {f!r} must be relative to the workspace")
+            dst_norm = posixpath.normpath(f"{ws}/{f}")
+            if dst_norm == ws or not dst_norm.startswith(f"{ws}/"):
+                raise ValueError(
+                    f"output path {f!r} must be a non-empty path "
+                    "within the workspace"
                 )
-                copy_cmds.append(
-                    f"[ -f {src} ] && mkdir -p {dst_dir} && cp -f {src} {dst}"
-                )
+            src = shlex.quote(f"{self.container_build_dir}/{f}")
+            dst = shlex.quote(f"{WORKSPACE_CONTAINER_PATH}/{f}")
+            dst_dir = shlex.quote(
+                str(PurePosixPath(f"{WORKSPACE_CONTAINER_PATH}/{f}").parent)
+            )
+            # Restore ownership of the copied-back output (and its contents
+            # for a dir tree) to the host user.
+            chown_dir = (
+                f"chown -R {self.uid}:{self.gid} {dst} 2>/dev/null || true; "
+                if restore_owner
+                else ""
+            )
+            chown_file = (
+                f"chown {self.uid}:{self.gid} {dst} 2>/dev/null || true; "
+                if restore_owner
+                else ""
+            )
+            copy_cmds.append(
+                f"if [ -d {src} ]; then rm -rf {dst} && mkdir -p {dst} "
+                f"&& {cp_dir} {src}/. {dst}/; {chown_dir}"
+                f"elif [ -f {src} ]; then mkdir -p {dst_dir} && cp -f {src} {dst}; "
+                f"{chown_file}fi"
+            )
+        if copy_cmds:
             output_script = "; " + "; ".join(copy_cmds)
 
         # Prefer rsync (preserves mtimes, syncs only changed files so a

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path, PurePosixPath
@@ -400,15 +402,74 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         )
         self.assertLess(shell_script.index("tr -d"), shell_script.index("make"))
 
-    def test_output_files_copied_back(self) -> None:
-        """Output files are copied from container to host."""
+    def test_file_outputs_copied_back(self) -> None:
+        """File outputs are copied to the mirrored path on the host."""
         cfg = self._make_config(output_files=["build/output.elf", "result.bin"])
         cmd = cfg.build_windows_run_cmd("make", "all")
         shell_script = cmd[-1]
-        self.assertIn("build/output.elf", shell_script)
-        self.assertIn("result.bin", shell_script)
+        self.assertIn("/tmp/build/build/output.elf", shell_script)
+        self.assertIn("/mnt/workspace/build/output.elf", shell_script)
+        self.assertIn("/mnt/workspace/result.bin", shell_script)
         self.assertIn("cp -f", shell_script)
         self.assertIn("mkdir -p", shell_script)
+
+    def test_no_output_files_by_default(self) -> None:
+        """Without output_files, no copy-back is emitted."""
+        shell_script = self._make_config().build_windows_run_cmd("make")[-1]
+        self.assertNotIn("rm -rf", shell_script)
+        self.assertNotIn("cp -f", shell_script)
+
+    @patch("nanvix_zutil.docker.is_windows", return_value=False)
+    def test_output_dir_copied_back_with_wipe(self, _mock: object) -> None:
+        """A directory output is wiped then copied back with cp -a (Linux host)."""
+        cfg = self._make_config(output_files=["_install_staging"])
+        shell_script = cfg.build_windows_run_cmd("make")[-1]
+        self.assertIn("if [ -d /tmp/build/_install_staging ]", shell_script)
+        self.assertIn("rm -rf /mnt/workspace/_install_staging", shell_script)
+        self.assertIn("mkdir -p /mnt/workspace/_install_staging", shell_script)
+        self.assertIn(
+            "cp -a /tmp/build/_install_staging/. /mnt/workspace/_install_staging/",
+            shell_script,
+        )
+        # Same entry also handles the file case via elif.
+        self.assertIn("elif [ -f /tmp/build/_install_staging ]", shell_script)
+        # Copied-back outputs are chown'd to host uid:gid.
+        self.assertIn(
+            "chown -R 1000:1000 /mnt/workspace/_install_staging", shell_script
+        )
+
+    @patch("nanvix_zutil.docker.is_windows", return_value=True)
+    def test_no_chown_on_windows_host(self, _mock: object) -> None:
+        """On a Windows host, copy-back does not chown (would force root:root)."""
+        cfg = self._make_config(output_files=["a.elf", ".nanvix/out/x"])
+        shell_script = cfg.build_windows_run_cmd("make")[-1]
+        self.assertNotIn("chown", shell_script)
+        # Symlinks are dereferenced (cp -aL) so no Windows reparse points.
+        self.assertIn(
+            "cp -aL /tmp/build/.nanvix/out/x/. /mnt/workspace/.nanvix/out/x/",
+            shell_script,
+        )
+        # Still valid shell without the chowns.
+        if shutil.which("sh"):
+            proc = subprocess.run(["sh", "-n", "-c", shell_script], capture_output=True)
+            self.assertEqual(proc.returncode, 0, proc.stderr.decode())
+
+    @unittest.skipUnless(shutil.which("sh"), "POSIX sh not on PATH")
+    def test_generated_script_is_valid_shell(self) -> None:
+        """The full generated script parses under POSIX sh (guards `;;` etc.)."""
+        cfg = self._make_config(
+            crlf_files=["configure"],
+            output_files=["a.elf", ".nanvix/out/staging/x"],
+        )
+        script = cfg.build_windows_run_cmd("sh", "-c", "make build")[-1]
+        proc = subprocess.run(["sh", "-n", "-c", script], capture_output=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr.decode())
+
+    def test_invalid_output_path_rejected(self) -> None:
+        """Absolute paths and paths at/above the workspace root are rejected."""
+        for bad in ("", ".", "..", "../escape", "/out", "/"):
+            with self.assertRaises(ValueError):
+                self._make_config(output_files=[bad]).build_windows_run_cmd("make")
 
     def test_inner_command_in_script(self) -> None:
         """The inner command appears in the shell script."""


### PR DESCRIPTION
# [zutils] docker: `output_files` copies directory trees

Extends the existing `DockerConfig.output_files` copy-back to handle
directory trees, not just loose files. Part of #325 §4.

**PR 2 of 3** — stacked on `feat/docker-sync-crlf`. **Non-breaking**
(`output_files: list[str]` kept; entries that are files behave as before).

## Changes
- Each `output_files` entry mirrors the same relative path in the build dir
  and the workspace mount (the two are synced mirrors, so src == dst).
- File-vs-directory detected at runtime: `cp -f` for files, `cp -a` for
  trees (`cp -aL` on a Windows host to dereference symlinks — WSL2 renders
  them as unfollowable reparse points, `WinError 1920`).
- Directory destinations are wiped (`rm -rf`) before copy; a
  `posixpath.normpath` guard rejects any path resolving to/above the
  workspace root.
- Copied-back outputs are `chown`'d to the host uid:gid, **skipped on a
  Windows host** (uid=0 there → would force root:root and lock out the user;
  Docker Desktop maps ownership itself).

## Notes
- e2e-validated (Linux + Windows); `sh -n` parse test on the generated script.
- Consumers install trees straight to the mirrored destination path (no
  separate staging dir needed).
