### PR TITLE
[DOCKER-3] docker: persistent build volume + inputs invalidation

### DIFF
--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -78,6 +78,7 @@ from nanvix_zutil.docker import (
     DockerConfig,
     Mount,
     is_windows,
+    remove_build_volume,
 )
 from nanvix_zutil.exitcodes import (
     EXIT_BUILD_FAILURE,
@@ -183,6 +184,7 @@ __all__ = [
     "ToolchainKind",
     "ZScript",
     "is_windows",
+    "remove_build_volume",
     "ensure_tool_installed",
     "extract_nanvix_version",
     "extract_nanvix_version_base",

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -16,9 +16,12 @@ Use ``--with-docker IMAGE`` during setup to specify the Docker image::
 
 from __future__ import annotations
 
+import hashlib
 import os
 import posixpath
 import shlex
+import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -189,6 +192,16 @@ class DockerConfig:
     container_build_dir: str = "/tmp/build"
     """Working directory inside the container for Windows tar-copy mode."""
 
+    persistent_volume: bool | str = False
+    """Persist the build dir in a named Docker volume across ``run`` calls.
+
+    When ``True`` a deterministic volume name is derived from the workspace
+    (``<workspace-name>-build-<md5[:8]>``); a string is used verbatim as the
+    volume name.  The volume is mounted at :attr:`container_build_dir` so the
+    source sync becomes incremental instead of re-copying every call.  Only
+    affects the Windows tar-copy path (:meth:`build_windows_run_cmd`).
+    """
+
     # ------------------------------------------------------------------
     # Path translation
     # ------------------------------------------------------------------
@@ -236,6 +249,30 @@ class DockerConfig:
     # ------------------------------------------------------------------
     # Mount helpers
     # ------------------------------------------------------------------
+
+    def _workspace_host_path(self) -> Path:
+        """Return the host path mounted at the workspace, or raise."""
+        for mount in self.mounts:
+            if mount.container_path == WORKSPACE_CONTAINER_PATH:
+                return mount.host_path
+        raise ValueError("no workspace mount configured")
+
+    def volume_name(self) -> str | None:
+        """Return the persistent build volume name, or ``None`` when disabled.
+
+        A string :attr:`persistent_volume` is used verbatim.  ``True`` derives
+        a deterministic name from the workspace host path:
+        ``<workspace-name>-build-<md5[:8]>``.
+        """
+        if not self.persistent_volume:
+            return None
+        if isinstance(self.persistent_volume, str):
+            return self.persistent_volume
+        ws = self._workspace_host_path().resolve()
+        digest = hashlib.md5(ws.as_posix().encode(), usedforsecurity=False).hexdigest()[
+            :8
+        ]
+        return f"{ws.name}-build-{digest}"
 
     # ------------------------------------------------------------------
     # Command construction
@@ -421,6 +458,12 @@ class DockerConfig:
                 vol += ":ro"
             docker_cmd += ["-v", vol]
 
+        # Persist the build dir in a named volume so the source sync is
+        # incremental across calls instead of a fresh tmpdir each time.
+        vol_name = self.volume_name()
+        if vol_name:
+            docker_cmd += ["-v", f"{vol_name}:{self.container_build_dir}"]
+
         docker_cmd += ["-w", self.container_build_dir]
         docker_cmd += ["-e", "HOME=/tmp"]
 
@@ -430,3 +473,19 @@ class DockerConfig:
         docker_cmd.append(self.image)
         docker_cmd += ["sh", "-c", shell_script]
         return docker_cmd
+
+
+# ---------------------------------------------------------------------------
+# Volume lifecycle
+# ---------------------------------------------------------------------------
+
+
+def remove_build_volume(name: str) -> None:
+    """Remove a persistent Docker build volume, if Docker is available.
+
+    A no-op when the ``docker`` CLI is missing.  Uses ``--force`` so a
+    non-existent volume is not an error.
+    """
+    if shutil.which("docker") is None:
+        return
+    subprocess.run(["docker", "volume", "rm", "--force", name], check=False)

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -202,6 +202,23 @@ class DockerConfig:
     affects the Windows tar-copy path (:meth:`build_windows_run_cmd`).
     """
 
+    invalidation_inputs: list[Path] = field(default_factory=lambda: [])
+    """Host files/dirs whose content, when changed, forces a clean rebuild.
+
+    With a :attr:`persistent_volume` the build dir survives across calls, so
+    config drift (SDK, build flags, …) that the source sync would not catch
+    needs an explicit trigger.  Their combined hash is stored in the volume;
+    on mismatch :attr:`clean_cmd` runs.  Only used when both are set.
+    """
+
+    clean_cmd: str = ""
+    """Raw shell fragment run inside the container when :attr:`invalidation_inputs` change.
+
+    Interpolated unquoted (like the build command).  The stored hash is only
+    recorded when it exits successfully, so a lenient clean should use
+    ``"... || true"`` explicitly.
+    """
+
     # ------------------------------------------------------------------
     # Path translation
     # ------------------------------------------------------------------
@@ -273,6 +290,30 @@ class DockerConfig:
             :8
         ]
         return f"{ws.name}-build-{digest}"
+
+    def invalidation_hash(self) -> str:
+        """Hash :attr:`invalidation_inputs` (files and dir trees) deterministically.
+
+        Each path and content chunk is length-framed so adjacent inputs cannot
+        alias.  Missing paths are skipped so an absent optional input does not
+        error.
+        """
+        h = hashlib.sha256()
+
+        def feed(chunk: bytes) -> None:
+            h.update(len(chunk).to_bytes(8, "big"))
+            h.update(chunk)
+
+        for p in self.invalidation_inputs:
+            if p.is_dir():
+                for f in sorted(p.rglob("*")):
+                    if f.is_file():
+                        feed(f.relative_to(p).as_posix().encode())
+                        feed(f.read_bytes())
+            elif p.is_file():
+                feed(p.name.encode())
+                feed(p.read_bytes())
+        return h.hexdigest()
 
     # ------------------------------------------------------------------
     # Command construction
@@ -440,11 +481,27 @@ class DockerConfig:
                 )
             crlf_cmd = " && ".join(norms) + " && "
 
+        # Build-inputs invalidation: with a persistent volume the build dir
+        # survives, so config drift the source sync can't see must force a
+        # clean rebuild. Compare a host-computed hash against one stored in
+        # the volume; on mismatch run clean_cmd and only record the new hash
+        # if it succeeds, so a failed clean re-triggers next call.
+        invalidation_cmd = ""
+        if self.volume_name() and self.invalidation_inputs and self.clean_cmd:
+            digest = shlex.quote(self.invalidation_hash())
+            hash_file = shlex.quote(f"{self.container_build_dir}/.build-inputs-hash")
+            invalidation_cmd = (
+                f"{{ _stored=$(cat {hash_file} 2>/dev/null || true); "
+                f'if [ "$_stored" != {digest} ]; then '
+                f"{self.clean_cmd} && printf %s {digest} > {hash_file}; fi; }} && "
+            )
+
         inner_cmd = " ".join(shlex.quote(c) for c in cmd)
         shell_script = (
             f"mkdir -p {build_dir} && "
             f"{sync_cmd} && "
             f"cd {build_dir} && "
+            f"{invalidation_cmd}"
             f"{crlf_cmd}"
             f"{inner_cmd}; rc=$?{output_script}; exit $rc"
         )

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -46,6 +46,7 @@ from nanvix_zutil.docker import (
     DockerConfig,
     Mount,
     is_windows,
+    remove_build_volume,
 )
 from nanvix_zutil.exitcodes import EXIT_INVALID_ARGS, EXIT_MISSING_DEP
 from nanvix_zutil.helpers import (
@@ -610,6 +611,13 @@ class ZScript:
         invoking the build system (which would require Docker).  Override
         to customise the files cleaned.
         """
+        # Drop the persistent build volume, if one is configured.
+        if self.docker is not None:
+            volume = self.docker.volume_name()
+            if volume is not None:
+                remove_build_volume(volume)
+                log.info(f"Removed build volume {volume}")
+
         if is_windows():
             # Common artifacts that consumers may produce.
             # Subclasses can override to add project-specific files.

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -622,11 +622,14 @@ class ZScript:
         """
         # Drop the persistent build volume, if one is configured.
         if self.docker is not None:
-            volume = self.docker.volume_name()
-            if volume is not None:
-                remove_build_volume(volume)
-                log.info(f"Removed build volume {volume}")
-
+            try:
+                volume = self.docker.volume_name()
+            except ValueError as exc:
+                log.warning(f"Skipping build-volume removal: {exc}")
+            else:
+                if volume is not None:
+                    remove_build_volume(volume)
+                    log.info(f"Requested removal of build volume {volume}")
         if is_windows():
             # Common artifacts that consumers may produce.
             # Subclasses can override to add project-specific files.

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -218,6 +218,11 @@ class ZScript:
         * sysroot path from :attr:`config` → ``/mnt/sysroot`` (writable),
           if the sysroot has been configured
 
+        Default :attr:`~nanvix_zutil.DockerConfig.invalidation_inputs` cover
+        ``Makefile.nanvix`` and ``nanvix.lock`` (missing ones are skipped), so
+        a persistent-volume build is cleaned when the build recipe or resolved
+        toolchain/deps change.  Consumers only need to set ``clean_cmd``.
+
         Override in a subclass to add extra mounts or environment variables.
 
         Args:
@@ -248,6 +253,10 @@ class ZScript:
             image=image,
             mounts=mounts,
             workdir=WORKSPACE_CONTAINER_PATH,
+            invalidation_inputs=[
+                repo_root() / "Makefile.nanvix",
+                nanvix_root() / "nanvix.lock",
+            ],
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -20,6 +20,7 @@ from nanvix_zutil.docker import (
     DockerConfig,
     Mount,
     is_windows,
+    remove_build_volume,
 )
 
 
@@ -336,6 +337,7 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         self,
         output_files: list[str] | None = None,
         crlf_files: list[str] | None = None,
+        persistent_volume: bool | str = False,
     ) -> DockerConfig:
         return DockerConfig(
             image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
@@ -350,6 +352,7 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
             gid=1000,
             output_files=output_files or [],
             crlf_files=crlf_files or [],
+            persistent_volume=persistent_volume,
         )
 
     def test_tar_copy_command_structure(self) -> None:
@@ -471,6 +474,26 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
             with self.assertRaises(ValueError):
                 self._make_config(output_files=[bad]).build_windows_run_cmd("make")
 
+    def test_no_named_volume_by_default(self) -> None:
+        """Without persistent_volume, no named volume is mounted."""
+        cmd = self._make_config().build_windows_run_cmd("make")
+        vols = [cmd[i + 1] for i, a in enumerate(cmd) if a == "-v"]
+        self.assertFalse(any(v.endswith(":/tmp/build") for v in vols))
+
+    def test_persistent_volume_mounted_at_build_dir(self) -> None:
+        """An auto-named volume is mounted at the build dir."""
+        cmd = self._make_config(persistent_volume=True).build_windows_run_cmd("make")
+        vols = [cmd[i + 1] for i, a in enumerate(cmd) if a == "-v"]
+        self.assertIn(f"{self._workspace.name}-build-", " ".join(vols))
+        self.assertTrue(any(v.endswith(":/tmp/build") for v in vols))
+
+    def test_persistent_volume_string_used_verbatim(self) -> None:
+        """A string persistent_volume is used as the volume name."""
+        cmd = self._make_config(persistent_volume="my-vol").build_windows_run_cmd(
+            "make"
+        )
+        self.assertIn("my-vol:/tmp/build", cmd)
+
     def test_inner_command_in_script(self) -> None:
         """The inner command appears in the shell script."""
         cfg = self._make_config()
@@ -556,6 +579,59 @@ class TestTranslateWindowsPath(unittest.TestCase):
 
         result = _translate_windows_path(Path("ab"))
         self.assertIsInstance(result, str)
+
+
+class TestVolumeLifecycle(unittest.TestCase):
+    """Tests for persistent-volume naming and removal."""
+
+    def _config(self, host: Path, persistent_volume: bool | str) -> DockerConfig:
+        return DockerConfig(
+            image="img",
+            mounts=[Mount(host_path=host, container_path=WORKSPACE_CONTAINER_PATH)],
+            persistent_volume=persistent_volume,
+        )
+
+    def test_volume_name_none_when_disabled(self) -> None:
+        self.assertIsNone(self._config(Path("/ws"), False).volume_name())
+
+    def test_volume_name_is_deterministic(self) -> None:
+        a = self._config(Path("/repos/cpython"), True).volume_name()
+        b = self._config(Path("/repos/cpython"), True).volume_name()
+        self.assertEqual(a, b)
+        self.assertIsNotNone(a)
+        assert a is not None
+        self.assertTrue(a.startswith("cpython-build-"))
+
+    def test_volume_name_differs_per_workspace(self) -> None:
+        a = self._config(Path("/repos/cpython"), True).volume_name()
+        b = self._config(Path("/repos/sqlite"), True).volume_name()
+        self.assertNotEqual(a, b)
+
+    def test_volume_name_string_verbatim(self) -> None:
+        self.assertEqual(self._config(Path("/ws"), "pinned").volume_name(), "pinned")
+
+    def test_volume_name_requires_workspace_mount(self) -> None:
+        cfg = DockerConfig(image="img", mounts=[], persistent_volume=True)
+        with self.assertRaises(ValueError):
+            cfg.volume_name()
+
+    @patch("nanvix_zutil.docker.subprocess.run")
+    @patch("nanvix_zutil.docker.shutil.which", return_value="/usr/bin/docker")
+    def test_remove_build_volume_invokes_docker(
+        self, _which: object, mock_run: object
+    ) -> None:
+        remove_build_volume("my-vol")
+        mock_run.assert_called_once_with(  # type: ignore[attr-defined]
+            ["docker", "volume", "rm", "--force", "my-vol"], check=False
+        )
+
+    @patch("nanvix_zutil.docker.subprocess.run")
+    @patch("nanvix_zutil.docker.shutil.which", return_value=None)
+    def test_remove_build_volume_noop_without_docker(
+        self, _which: object, mock_run: object
+    ) -> None:
+        remove_build_volume("my-vol")
+        mock_run.assert_not_called()  # type: ignore[attr-defined]
 
 
 if __name__ == "__main__":

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -338,6 +338,8 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
         output_files: list[str] | None = None,
         crlf_files: list[str] | None = None,
         persistent_volume: bool | str = False,
+        invalidation_inputs: list[Path] | None = None,
+        clean_cmd: str = "",
     ) -> DockerConfig:
         return DockerConfig(
             image="ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f",
@@ -353,6 +355,8 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
             output_files=output_files or [],
             crlf_files=crlf_files or [],
             persistent_volume=persistent_volume,
+            invalidation_inputs=invalidation_inputs or [],
+            clean_cmd=clean_cmd,
         )
 
     def test_tar_copy_command_structure(self) -> None:
@@ -461,8 +465,11 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
     def test_generated_script_is_valid_shell(self) -> None:
         """The full generated script parses under POSIX sh (guards `;;` etc.)."""
         cfg = self._make_config(
+            persistent_volume=True,
             crlf_files=["configure"],
             output_files=["a.elf", ".nanvix/out/staging/x"],
+            invalidation_inputs=[self._workspace],
+            clean_cmd="make clean || true",
         )
         script = cfg.build_windows_run_cmd("sh", "-c", "make build")[-1]
         proc = subprocess.run(["sh", "-n", "-c", script], capture_output=True)
@@ -493,6 +500,90 @@ class TestDockerConfigBuildWindowsRunCmd(unittest.TestCase):
             "make"
         )
         self.assertIn("my-vol:/tmp/build", cmd)
+
+    def test_invalidation_requires_persistent_volume(self) -> None:
+        """Without a persistent volume, no invalidation block is emitted."""
+        inp = self._workspace / "cfg.json"
+        inp.write_text("a")
+        script = self._make_config(
+            invalidation_inputs=[inp], clean_cmd="make clean"
+        ).build_windows_run_cmd("make")[-1]
+        self.assertNotIn(".build-inputs-hash", script)
+
+    def test_invalidation_block_emitted(self) -> None:
+        """With volume + inputs + clean_cmd, the compare/clean/record block runs."""
+        inp = self._workspace / "cfg.json"
+        inp.write_text("a")
+        cfg = self._make_config(
+            persistent_volume=True,
+            invalidation_inputs=[inp],
+            clean_cmd="make clean || true",
+        )
+        script = cfg.build_windows_run_cmd("make")[-1]
+        digest = cfg.invalidation_hash()
+        self.assertIn("/tmp/build/.build-inputs-hash", script)
+        self.assertIn("make clean || true", script)
+        self.assertIn(digest, script)
+        # Runs after sync/cd, before the build command.
+        self.assertLess(script.index(".build-inputs-hash"), script.index("; rc=$?"))
+        # Hash recorded only on successful clean (guards stale rebuilds).
+        self.assertIn(
+            f"|| true && printf %s {digest} > /tmp/build/.build-inputs-hash", script
+        )
+
+    def test_invalidation_strict_clean_records_on_success(self) -> None:
+        """A strict clean_cmd records the hash only when it exits 0."""
+        inp = self._workspace / "cfg.json"
+        inp.write_text("a")
+        cfg = self._make_config(
+            persistent_volume=True, invalidation_inputs=[inp], clean_cmd="make clean"
+        )
+        script = cfg.build_windows_run_cmd("make")[-1]
+        self.assertIn("make clean && printf %s", script)
+
+    def test_no_invalidation_block_without_clean_cmd(self) -> None:
+        """Inputs without a clean_cmd emit no invalidation block."""
+        inp = self._workspace / "cfg.json"
+        inp.write_text("a")
+        script = self._make_config(
+            persistent_volume=True, invalidation_inputs=[inp]
+        ).build_windows_run_cmd("make")[-1]
+        self.assertNotIn(".build-inputs-hash", script)
+
+    def test_invalidation_hash_changes_with_content(self) -> None:
+        """The input hash tracks file content."""
+        inp = self._workspace / "cfg.json"
+        inp.write_text("a")
+        cfg = self._make_config(invalidation_inputs=[inp])
+        first = cfg.invalidation_hash()
+        inp.write_text("b")
+        self.assertNotEqual(first, cfg.invalidation_hash())
+
+    def test_invalidation_hash_covers_dir_trees(self) -> None:
+        """Directory inputs are hashed and track added files."""
+        tree = self._workspace / "buildroot"
+        (tree / "sub").mkdir(parents=True)
+        (tree / "sub" / "a.txt").write_text("one")
+        cfg = self._make_config(invalidation_inputs=[tree])
+        first = cfg.invalidation_hash()
+        (tree / "sub" / "b.txt").write_text("two")
+        self.assertNotEqual(first, cfg.invalidation_hash())
+
+    def test_invalidation_hash_skips_missing_and_resists_aliasing(self) -> None:
+        """Missing paths are skipped; length-framing prevents boundary aliasing."""
+        missing = self._workspace / "nope"
+        self.assertEqual(
+            self._make_config(invalidation_inputs=[missing]).invalidation_hash(),
+            self._make_config(invalidation_inputs=[]).invalidation_hash(),
+        )
+        ab = self._workspace / "ab"
+        ab.write_text("c")
+        a = self._workspace / "a"
+        a.write_text("bc")
+        self.assertNotEqual(
+            self._make_config(invalidation_inputs=[ab]).invalidation_hash(),
+            self._make_config(invalidation_inputs=[a]).invalidation_hash(),
+        )
 
     def test_inner_command_in_script(self) -> None:
         """The inner command appears in the shell script."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -967,6 +967,13 @@ class TestZScriptDockerConfig(unittest.TestCase):
         for m in cfg.mounts:
             self.assertNotEqual(str(m.container_path), "/mnt/buildroot")
 
+    def test_docker_config_default_invalidation_inputs(self) -> None:
+        """Default invalidation inputs cover Makefile.nanvix and nanvix.lock."""
+        script = self._make_script()
+        cfg = script.docker_config("test-image")
+        names = {p.name for p in cfg.invalidation_inputs}
+        self.assertEqual(names, {"Makefile.nanvix", "nanvix.lock"})
+
 
 class TestZScriptAutoDocker(unittest.TestCase):
     """Docker is always enabled for setup/build/release/clean (hard fail)."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -353,6 +353,33 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
     def test_clean_noop(self) -> None:
         self._make_script().clean()
 
+    @patch("nanvix_zutil.script.remove_build_volume")
+    def test_clean_removes_persistent_volume(self, mock_remove: MagicMock) -> None:
+        script = self._make_script()
+        script.docker = DockerConfig(
+            image="img",
+            mounts=[
+                Mount(host_path=Path("/ws"), container_path=WORKSPACE_CONTAINER_PATH)
+            ],
+            persistent_volume="pinned-vol",
+        )
+        script.clean()
+        mock_remove.assert_called_once_with("pinned-vol")
+
+    @patch("nanvix_zutil.script.remove_build_volume")
+    def test_clean_skips_volume_when_not_persistent(
+        self, mock_remove: MagicMock
+    ) -> None:
+        script = self._make_script()
+        script.docker = DockerConfig(
+            image="img",
+            mounts=[
+                Mount(host_path=Path("/ws"), container_path=WORKSPACE_CONTAINER_PATH)
+            ],
+        )
+        script.clean()
+        mock_remove.assert_not_called()
+
 
 class TestZScriptAvailableSubcommands(unittest.TestCase):
     """available_subcommands() reflects hook overrides."""


### PR DESCRIPTION
# [zutils] docker: persistent build volume + inputs invalidation

Backports the persistent named volume and build-inputs hash invalidation
from CPython `_docker.py`. Closes #325 -- §1 + §3.

**PR 3 of 3** — stacked on `feat/docker-outputs`. Non-breaking.

## Changes
- **Persistent volume** (§1): opt-in `DockerConfig.persistent_volume:
  bool | str`. When set, mount a named volume (`<workspace>-build-<md5[:8]>`,
  or a caller-given name) at the build dir so the source sync is incremental
  across calls. Adds `volume_name()` + module `remove_build_volume()`, wired
  into `ZScript.clean`.
- **Inputs invalidation** (§3): `invalidation_inputs: list[Path]` +
  `clean_cmd`. Hashes the inputs on the host; the container compares against
  a hash stored in the volume and runs `clean_cmd` on mismatch (recording the
  new hash only on success). `docker_config` defaults the inputs to
  `Makefile.nanvix` + `nanvix.lock`.

## Notes
- e2e-validated (Linux + Windows). Retires CPython's `.nanvix/src/_docker.py`
  (see the paired cpython PR).
