### PR TITLE
[MILESTONE-1] Standardized package contents

### DIFF
--- a/docs/with-deps.md
+++ b/docs/with-deps.md
@@ -15,15 +15,13 @@ Each `path` points at a sibling consumer's manifest file (typically
 `.nanvix/nanvix.toml`).  Setup reads the sibling's staged dev tree:
 
 ```
-<path>/../out/staging/dev/lib/*.a
-<path>/../out/staging/dev/include/**/*.h
+<path>/../out/staging/dev/
 ```
 
 This is the same tree the sibling's `release` step packs into the
-dev archive; contents are byte-identical.  Routing (`.a` → `lib/`,
-`.h` → `include/`) and `install_libs` / `install_headers` filters
-from the current manifest are applied exactly as they are during
-archive extraction.
+dev archive; contents are byte-identical.  The whole tree is copied
+verbatim into the sysroot, preserving its layout (`lib/`, `include/`,
+`share/`, …), exactly as it is during archive extraction.
 
 If the staging tree is missing, setup fails with a hint to run
 `./z build` against that manifest first.  There is no auto-build.
@@ -74,6 +72,5 @@ branch on `if name in self.local_deps: ...` to be override-aware.
 
 `--with-nanvix PATH` overlays a Nanvix-native build's `bin/` and
 `lib/` on top of the sysroot by direct file copy.  `--with-deps`
-copies a sibling consumer's staged dev tree instead, honouring
-`install_libs` / `install_headers` filtering from the manifest.
+copies a sibling consumer's staged dev tree verbatim instead.
 Both flags are one-shot.

--- a/examples/bin-hello/.nanvix/nanvix.toml
+++ b/examples/bin-hello/.nanvix/nanvix.toml
@@ -11,6 +11,5 @@ sdk-image = "ghcr.io/nanvix/nanvix-sdk-c-clang"
 sdk-digest = "sha256:880ed7e6a20fe9bf2536b1b3ba9bdbbd067a48f043ec9131d3dd398c65f11f35"
 
 [dependencies]
-lib-hello = "0.1.0"
-
-[system-dependencies]
+# lib-hello is manually installed in the setup() step
+# this way we can pull it as a local dep

--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -21,10 +21,12 @@ import _test
 from nanvix_zutil import (
     CFG_SYSROOT,
     TOOLCHAIN_CONTAINER_PATH,
+    Buildroot,
     DockerConfig,
     ZScript,
     log,
 )
+from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE
 from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
 from nanvix_zutil.paths import regular_out, repo_root
@@ -67,15 +69,12 @@ class BinHello(ZScript):
     def setup(self) -> bool:
         """Download the Nanvix sysroot and lib-hello dependency, then verify."""
         used_fallback = super().setup()
-        if self.buildroot is None:
-            self.log.fatal(
-                "nanvix.toml must declare lib-hello as a build-time dependency.",
-                hint=(
-                    "Add lib-hello as a dependency in nanvix.toml, then "
-                    "re-run `nanvix-zutil setup`."
-                ),
-            )
-        self.buildroot.verify(["libhello.a"])
+        self.buildroot = Buildroot.create()
+        self.buildroot.install_local_archive(
+            Dependency("lib-hello", "nanvix/zutils", Ref(RefKind.LOCAL, "lib-hello")),
+            repo_root().parent / "lib-hello" / ".nanvix" / "nanvix.toml",
+        )
+        self.buildroot.verify(["lib/libhello.a", "include/hello.h"])
         return used_fallback
 
     def build(self) -> None:

--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -67,12 +67,21 @@ class BinHello(ZScript):
     # ------------------------------------------------------------------
 
     def setup(self) -> bool:
-        """Download the Nanvix sysroot and lib-hello dependency, then verify."""
+        """Set up the sysroot, then install lib-hello from its staged dev tree.
+
+        lib-hello is not a published GitHub package, so it is pulled
+        directly from a sibling checkout's staged dev tree instead of
+        being declared in ``nanvix.toml``.  Build lib-hello first
+        (``./z build`` in ../lib-hello) so its ``out/staging/dev`` exists.
+        """
         used_fallback = super().setup()
+        manifest = repo_root().parent / "lib-hello" / ".nanvix" / "nanvix.toml"
         self.buildroot = Buildroot.create()
         self.buildroot.install_local_archive(
-            Dependency("lib-hello", "nanvix/zutils", Ref(RefKind.LOCAL, "lib-hello")),
-            repo_root().parent / "lib-hello" / ".nanvix" / "nanvix.toml",
+            Dependency(
+                "lib-hello", "nanvix/lib-hello", Ref(RefKind.LOCAL, str(manifest))
+            ),
+            manifest,
         )
         self.buildroot.verify(["lib/libhello.a", "include/hello.h"])
         return used_fallback

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -23,11 +23,10 @@ from nanvix_zutil import (
     DockerConfig,
     ZScript,
     log,
-    paths,
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
 from nanvix_zutil.helpers import run
-from nanvix_zutil.paths import out_dir, regular_out, repo_root
+from nanvix_zutil.paths import dev_out, repo_root
 
 
 class LibHello(ZScript):
@@ -77,13 +76,14 @@ class LibHello(ZScript):
             cwd=repo_root(),
             docker=self.docker,
         )
-        out = paths.dev_out()
-        libout = out / "lib"
-        inclout = out / "include"
+        # Stage artifacts into the dev tree so `release` packs a standard
+        # lib/ + include/ layout.
+        libout = dev_out() / "lib"
+        inclout = dev_out() / "include"
         libout.mkdir(parents=True, exist_ok=True)
         inclout.mkdir(parents=True, exist_ok=True)
-        shutil.copy(paths.repo_root() / "libhello.a", libout)
-        shutil.copy(paths.repo_root() / "src" / "hello.h", inclout)
+        shutil.copy(repo_root() / "libhello.a", libout)
+        shutil.copy(repo_root() / "src" / "hello.h", inclout)
 
     def test(self) -> None:
         """Run the test suite (smoke + integration).

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -14,6 +14,7 @@ Demonstrates the full lifecycle with a real Nanvix build.  Run with
 """
 
 import dataclasses
+import shutil
 from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import (
@@ -22,10 +23,11 @@ from nanvix_zutil import (
     DockerConfig,
     ZScript,
     log,
+    paths,
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
 from nanvix_zutil.helpers import run
-from nanvix_zutil.paths import repo_root
+from nanvix_zutil.paths import out_dir, regular_out, repo_root
 
 
 class LibHello(ZScript):
@@ -75,6 +77,13 @@ class LibHello(ZScript):
             cwd=repo_root(),
             docker=self.docker,
         )
+        out = paths.dev_out()
+        libout = out / "lib"
+        inclout = out / "include"
+        libout.mkdir(parents=True, exist_ok=True)
+        inclout.mkdir(parents=True, exist_ok=True)
+        shutil.copy(paths.repo_root() / "libhello.a", libout)
+        shutil.copy(paths.repo_root() / "src" / "hello.h", inclout)
 
     def test(self) -> None:
         """Run the test suite (smoke + integration).

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -11,6 +11,7 @@ describes a single library fetched from a GitHub release.
 from __future__ import annotations
 
 import shutil
+import stat
 import tarfile
 import zipfile
 from dataclasses import dataclass
@@ -29,6 +30,10 @@ from nanvix_zutil.config import (
 from nanvix_zutil.exitcodes import EXIT_MISSING_DEP
 from nanvix_zutil.paths import nanvix_root, sysroot
 from nanvix_zutil.release import DEV_ARCHIVE_SUFFIX
+
+# zipfile packs the Unix file mode into the high 16 bits of external_attr,
+# a region the zip format itself leaves undefined. Shift to read/write it.
+ZIP_MODE_SHIFT = 16
 
 # ---------------------------------------------------------------------------
 # Verbatim copy helper
@@ -318,7 +323,7 @@ class Buildroot:
                     shutil.copyfileobj(src, dst)
                 # zipfile does not restore Unix permission bits; carry over
                 # the stored mode (e.g. executable bin/ scripts) verbatim.
-                mode = (info.external_attr >> 16) & 0o777
+                mode = stat.S_IMODE(info.external_attr >> ZIP_MODE_SHIFT)
                 if mode:
                     dest.chmod(mode)
 
@@ -391,7 +396,13 @@ class Buildroot:
         """
         root = sysroot()
         for rel in required_files:
-            if not (root / rel).exists():
+            path = Path(rel)
+            if path.is_absolute() or ".." in path.parts:
+                log.fatal(
+                    f"Required file '{rel}' must be a sysroot-relative path",
+                    code=EXIT_MISSING_DEP,
+                )
+            if not (root / path).exists():
                 log.fatal(
                     f"Required file '{rel}' not found in sysroot at {root}",
                     code=EXIT_MISSING_DEP,

--- a/src/nanvix_zutil/buildroot.py
+++ b/src/nanvix_zutil/buildroot.py
@@ -31,73 +31,25 @@ from nanvix_zutil.paths import nanvix_root, sysroot
 from nanvix_zutil.release import DEV_ARCHIVE_SUFFIX
 
 # ---------------------------------------------------------------------------
-# Tarball path helpers
+# Verbatim copy helper
 # ---------------------------------------------------------------------------
 
 
-def _member_target(member_path: Path, dep: "Dependency") -> tuple[str, str] | None:
-    """Return ``(anchor_subdir, path_below_anchor)`` for a dep member, or ``None``.
+def _copy_local_dep_tree(source_dir: Path) -> int:
+    """Copy every file under *source_dir* verbatim into the sysroot.
 
-    Centralises the ``.a``/``.h`` routing and ``install_libs`` /
-    ``install_headers`` filtering shared by the archive-extraction
-    paths and the local-copy path.
-    """
-    if member_path.suffix == ".a":
-        if dep.install_libs is not None and member_path.name not in dep.install_libs:
-            return None
-        return "lib", _relative_to_segment(member_path, "lib")
-    if member_path.suffix == ".h":
-        if (
-            dep.install_headers is not None
-            and member_path.name not in dep.install_headers
-        ):
-            return None
-        return "include", _relative_to_segment(member_path, "include")
-    return None
-
-
-def _copy_local_dep_tree(dep: "Dependency", source_dir: Path) -> int:
-    """Copy ``.a``/``.h`` files from *source_dir* into the sysroot.
-
-    Files are routed via :func:`_member_target` (same rules as archive
-    extraction).  Returns the number of files copied.
+    Relative paths are preserved, so a strict ``lib/``/``include/``/``share/``
+    layout lands intact in the sysroot.  Returns the number of files copied.
     """
     copied = 0
     for src in source_dir.rglob("*"):
         if not src.is_file():
             continue
-        target = _member_target(src.relative_to(source_dir), dep)
-        if target is None:
-            continue
-        anchor, rel = target
-        dest = sysroot() / anchor / rel
+        dest = sysroot() / src.relative_to(source_dir)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dest)
         copied += 1
     return copied
-
-
-def _relative_to_segment(member_path: Path, segment: str) -> str:
-    """Return the path portion after *segment* in *member_path*.
-
-    If *segment* is not found, return the bare filename.
-
-    Args:
-        member_path: Full archive member path
-            (e.g. ``sysroot/include/openssl/ssl.h``).
-        segment: Directory segment to search for
-            (e.g. ``"include"`` or ``"lib"``).
-
-    Returns:
-        Relative path after the segment, or the bare filename as
-        fallback.
-    """
-    parts = member_path.parts
-    try:
-        idx = parts.index(segment)
-        return str(Path(*parts[idx + 1 :]))
-    except ValueError:
-        return member_path.name
 
 
 # ---------------------------------------------------------------------------
@@ -151,10 +103,6 @@ class Dependency:
             ``{machine}``, ``{mode}``, ``{mem}``.  Default targets the
             standardised ``-dev`` archive produced by
             ``nanvix-zutil release``.
-        install_libs: List of ``.a`` file names to copy into
-            ``<buildroot>/lib/``.  ``None`` copies all ``.a`` files found.
-        install_headers: List of header file names to copy into
-            ``<buildroot>/include/``.  ``None`` copies all ``.h`` files found.
     """
 
     name: str
@@ -163,8 +111,6 @@ class Dependency:
     artifact_pattern: str = (
         "{name}-{host}-{arch}-{machine}-{mode}-{mem}" + DEV_ARCHIVE_SUFFIX
     )
-    install_libs: list[str] | None = None
-    install_headers: list[str] | None = None
 
 
 def suffix_dep(dep: Dependency, version: str) -> Dependency:
@@ -295,11 +241,11 @@ class Buildroot:
         gh_token: str | None = None,
         _release: dict[str, object] | None = None,
     ) -> None:
-        """Download a dependency release and install its libraries and headers.
+        """Download a dependency release and install its contents.
 
         The release asset is downloaded into ``.nanvix/cache/`` and then
-        extracted.  Selected ``.a`` and ``.h`` files are copied into
-        ``<sysroot>/lib/`` and ``<sysroot>/include/`` respectively.
+        unpacked verbatim into the sysroot, preserving the archive's
+        directory layout (``lib/``, ``include/``, ``share/``, …).
 
         Dependencies are assumed to publish a standardised ``-dev`` archive.
         A missing archive is fatal — no fallback to the legacy
@@ -341,9 +287,9 @@ class Buildroot:
 
         log.info(f"Extracting {asset_path.name}...")
         if zipfile.is_zipfile(asset_path):
-            self._extract_dep_zip(asset_path, dep)
+            self._extract_dep_zip(asset_path)
         else:
-            self._extract_dep_tar(asset_path, dep)
+            self._extract_dep_tar(asset_path)
 
         log.success(f"Installed {dep.name} into buildroot")
 
@@ -351,21 +297,13 @@ class Buildroot:
     # Archive extraction helpers
     # ------------------------------------------------------------------
 
-    def _extract_dep_tar(self, asset_path: Path, dep: Dependency) -> None:
-        """Extract libraries and headers from a tarball."""
+    def _extract_dep_tar(self, asset_path: Path) -> None:
+        """Unpack a tarball verbatim into the sysroot."""
         with tarfile.open(asset_path, "r:*") as tf:
-            for member in tf.getmembers():
-                if not member.isfile():
-                    continue
-                target = _member_target(Path(member.name), dep)
-                if target is None:
-                    continue
-                anchor, rel = target
-                member.name = rel
-                tf.extract(member, path=sysroot() / anchor, filter="data")
+            tf.extractall(sysroot(), filter="data")
 
-    def _extract_dep_zip(self, asset_path: Path, dep: Dependency) -> None:
-        """Extract libraries and headers from a zip archive."""
+    def _extract_dep_zip(self, asset_path: Path) -> None:
+        """Unpack a zip archive verbatim into the sysroot."""
         with zipfile.ZipFile(asset_path, "r") as zf:
             for info in zf.infolist():
                 if info.is_dir():
@@ -374,14 +312,15 @@ class Buildroot:
                 # Reject absolute paths and directory traversal.
                 if member_path.is_absolute() or ".." in member_path.parts:
                     continue
-                target = _member_target(member_path, dep)
-                if target is None:
-                    continue
-                anchor, rel = target
-                dest = sysroot() / anchor / rel
+                dest = sysroot() / member_path
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(info) as src, dest.open("wb") as dst:
                     shutil.copyfileobj(src, dst)
+                # zipfile does not restore Unix permission bits; carry over
+                # the stored mode (e.g. executable bin/ scripts) verbatim.
+                mode = (info.external_attr >> 16) & 0o777
+                if mode:
+                    dest.chmod(mode)
 
     def install_local_nanvix(
         self,
@@ -390,10 +329,9 @@ class Buildroot:
     ) -> bool:
         """Install a dependency from a local Nanvix build directory.
 
-        Looks for ``<local_path>/deps/<dep.name>/`` containing ``lib/``
-        and/or ``include/`` subdirectories.  If found, copies matching
-        artifacts into the sysroot using the same routing and filter
-        rules as archive extraction.
+        Looks for ``<local_path>/deps/<dep.name>/``; if present, its entire
+        tree is copied verbatim into the sysroot (same rules as archive
+        extraction).
 
         Args:
             dep: The :class:`Dependency` descriptor.
@@ -406,7 +344,7 @@ class Buildroot:
         dep_dir = local_path / "deps" / dep.name
         if not dep_dir.is_dir():
             return False
-        copied = _copy_local_dep_tree(dep, dep_dir)
+        copied = _copy_local_dep_tree(dep_dir)
         if copied:
             log.info(f"Installed {dep.name} from local path: {dep_dir}")
         return copied > 0
@@ -418,11 +356,10 @@ class Buildroot:
     ) -> None:
         """Install a dependency from a sibling consumer's staged dev tree.
 
-        Walks ``<manifest_path>/../out/staging/dev/`` — the tree the
+        Copies ``<manifest_path>/../out/staging/dev/`` — the tree the
         sibling's ``release`` step packs into the dev archive,
-        byte-identical to the archive contents — and copies matching
-        files into the sysroot, applying the same routing and filter
-        rules used when extracting the released archive.
+        byte-identical to the archive contents — verbatim into the
+        sysroot, the same way the released archive is unpacked.
 
         Fatal (``EXIT_MISSING_DEP``) if the staging tree is absent;
         callers should run ``./z build`` against *manifest_path* first.
@@ -435,29 +372,28 @@ class Buildroot:
                 hint=f"Run `./z build` for {manifest_path} first.",
             )
 
-        copied = _copy_local_dep_tree(dep, dev_dir)
+        copied = _copy_local_dep_tree(dev_dir)
         log.success(f"Copied {copied} file(s) for {dep.name} from {dev_dir}")
 
     # ------------------------------------------------------------------
     # Verification
     # ------------------------------------------------------------------
 
-    def verify(self, required_libs: list[str]) -> None:
-        """Assert that all required build-time library files are present.
+    def verify(self, required_files: list[str]) -> None:
+        """Assert that all required build-time files are present.
 
         Args:
-            required_libs: List of ``.a`` file names that must exist under
-                ``<sysroot>/lib/``.
+            required_files: Sysroot-relative paths that must exist
+                (e.g. ``"lib/libz.a"``, ``"include/zlib.h"``).
 
         Raises:
             SystemExit: With exit code ``3`` if any required file is missing.
         """
-        for lib in required_libs:
-            br = sysroot()
-            lib_path = br / "lib" / lib
-            if not lib_path.exists():
+        root = sysroot()
+        for rel in required_files:
+            if not (root / rel).exists():
                 log.fatal(
-                    f"Required library '{lib}' not found in sysroot at {br}",
+                    f"Required file '{rel}' not found in sysroot at {root}",
                     code=EXIT_MISSING_DEP,
                     hint="Run `./z setup` to download build-time dependencies.",
                 )

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -5,6 +5,7 @@
 
 import io
 import stat
+import sys
 import tarfile
 import unittest
 import zipfile
@@ -16,6 +17,7 @@ from nanvix_zutil.buildroot import (
     Dependency,
     Ref,
     RefKind,
+    ZIP_MODE_SHIFT,
     extract_nanvix_version,
     extract_nanvix_version_base,
     parse_semver_tuple,
@@ -128,6 +130,12 @@ class TestBuildrootVerify(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             br.verify(required_files=["lib/libposix.a"])
         self.assertEqual(ctx.exception.code, 3)
+
+    def test_verify_rejects_absolute_and_traversal(self) -> None:
+        br = Buildroot.create()
+        for bad in ("/etc/passwd", "../escape.a"):
+            with self.assertRaises(SystemExit):
+                br.verify(required_files=[bad])
 
     def test_verify_empty_list_passes(self) -> None:
         br = Buildroot.create()
@@ -693,13 +701,14 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         self.assertTrue((sysroot() / "include" / "openssl" / "crypto.h").exists())
         self.assertTrue((sysroot() / "lib" / "libssl.a").exists())
 
+    @unittest.skipIf(sys.platform == "win32", "no Unix mode bits on Windows")
     def test_install_dep_zip_preserves_executable_bit(self) -> None:
         """zipfile drops Unix modes on extract; install must restore them."""
         br = self._setup_buildroot()
         buf = io.BytesIO()
         with zipfile.ZipFile(buf, "w") as zf:
             info = zipfile.ZipInfo("bin/hello")
-            info.external_attr = 0o755 << 16
+            info.external_attr = 0o755 << ZIP_MODE_SHIFT
             zf.writestr(info, b"#!/bin/sh\n")
         archive_path = Path.cwd() / "tool.zip"
         archive_path.write_bytes(buf.getvalue())

--- a/tests/test_buildroot.py
+++ b/tests/test_buildroot.py
@@ -4,6 +4,7 @@
 """Tests for nanvix_zutil.buildroot."""
 
 import io
+import stat
 import tarfile
 import unittest
 import zipfile
@@ -76,18 +77,6 @@ class TestDependency(unittest.TestCase):
         expected = "{name}-{host}-{arch}-{machine}-{mode}-{mem}" + DEV_ARCHIVE_SUFFIX
         self.assertEqual(dep.artifact_pattern, expected)
 
-    def test_default_install_libs_none(self) -> None:
-        dep = Dependency(
-            name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
-        )
-        self.assertIsNone(dep.install_libs)
-
-    def test_default_install_headers_none(self) -> None:
-        dep = Dependency(
-            name="zlib", repo="nanvix/zlib", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
-        )
-        self.assertIsNone(dep.install_headers)
-
     def test_custom_artifact_pattern(self) -> None:
         dep = Dependency(
             name="foo",
@@ -120,23 +109,29 @@ class TestBuildrootCreate(unittest.TestCase):
 
 
 class TestBuildrootVerify(unittest.TestCase):
-    """Buildroot.verify() checks that required libraries exist."""
+    """Buildroot.verify() checks that required files exist."""
 
-    def test_verify_passes_when_libs_present(self) -> None:
+    def test_verify_passes_when_file_present(self) -> None:
         br = Buildroot.create()
         (sysroot() / "lib" / "libz.a").write_bytes(b"")
         # Should not raise.
-        br.verify(required_libs=["libz.a"])
+        br.verify(required_files=["lib/libz.a"])
 
-    def test_verify_exits_3_when_lib_missing(self) -> None:
+    def test_verify_passes_for_non_lib_path(self) -> None:
+        br = Buildroot.create()
+        (sysroot() / "include" / "zlib.h").parent.mkdir(parents=True, exist_ok=True)
+        (sysroot() / "include" / "zlib.h").write_bytes(b"")
+        br.verify(required_files=["include/zlib.h"])
+
+    def test_verify_exits_3_when_file_missing(self) -> None:
         br = Buildroot.create()
         with self.assertRaises(SystemExit) as ctx:
-            br.verify(required_libs=["libposix.a"])
+            br.verify(required_files=["lib/libposix.a"])
         self.assertEqual(ctx.exception.code, 3)
 
     def test_verify_empty_list_passes(self) -> None:
         br = Buildroot.create()
-        br.verify(required_libs=[])
+        br.verify(required_files=[])
 
 
 class TestBuildrootInstallDep(unittest.TestCase):
@@ -149,8 +144,8 @@ class TestBuildrootInstallDep(unittest.TestCase):
         br = self._setup_buildroot()
         archive = _make_tar_bz2(
             {
-                "sysroot/lib/libz.a": b"lib-content",
-                "sysroot/include/zlib.h": b"header-content",
+                "lib/libz.a": b"lib-content",
+                "include/zlib.h": b"header-content",
             }
         )
         dep = Dependency(
@@ -171,8 +166,8 @@ class TestBuildrootInstallDep(unittest.TestCase):
         br = self._setup_buildroot()
         archive = _make_tar_bz2(
             {
-                "sysroot/lib/libz.a": b"lib-content",
-                "sysroot/include/zlib.h": b"header-content",
+                "lib/libz.a": b"lib-content",
+                "include/zlib.h": b"header-content",
             }
         )
         dep = Dependency(
@@ -189,61 +184,9 @@ class TestBuildrootInstallDep(unittest.TestCase):
 
         self.assertTrue((sysroot() / "include" / "zlib.h").exists())
 
-    def test_install_dep_selective_libs(self) -> None:
-        br = self._setup_buildroot()
-        archive = _make_tar_bz2(
-            {
-                "sysroot/lib/libz.a": b"libz",
-                "sysroot/lib/libextra.a": b"libextra",
-            }
-        )
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-            install_libs=["libz.a"],
-        )
-        archive_path = Path.cwd() / "zlib.tar.bz2"
-        archive_path.write_bytes(archive)
-
-        with patch(
-            "nanvix_zutil.github.download_release_asset",
-            return_value=archive_path,
-        ):
-            br.install_dep(dep)
-
-        self.assertTrue((sysroot() / "lib" / "libz.a").exists())
-        self.assertFalse((sysroot() / "lib" / "libextra.a").exists())
-
-    def test_install_dep_selective_headers(self) -> None:
-        br = self._setup_buildroot()
-        archive = _make_tar_bz2(
-            {
-                "sysroot/include/zlib.h": b"wanted",
-                "sysroot/include/internal.h": b"not-wanted",
-            }
-        )
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-            install_headers=["zlib.h"],
-        )
-        archive_path = Path.cwd() / "zlib.tar.bz2"
-        archive_path.write_bytes(archive)
-
-        with patch(
-            "nanvix_zutil.github.download_release_asset",
-            return_value=archive_path,
-        ):
-            br.install_dep(dep)
-
-        self.assertTrue((sysroot() / "include" / "zlib.h").exists())
-        self.assertFalse((sysroot() / "include" / "internal.h").exists())
-
     def test_install_dep_artifact_name_interpolated(self) -> None:
         br = self._setup_buildroot()
-        archive = _make_tar_bz2({"sysroot/lib/libz.a": b""})
+        archive = _make_tar_bz2({"lib/libz.a": b""})
         archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
@@ -286,7 +229,7 @@ class TestBuildrootInstallDep(unittest.TestCase):
     def test_install_dep_custom_pattern_receives_host_and_arch(self) -> None:
         """Custom ``artifact_pattern`` still receives the new host/arch keys."""
         br = self._setup_buildroot()
-        archive = _make_tar_bz2({"sysroot/lib/libz.a": b""})
+        archive = _make_tar_bz2({"lib/libz.a": b""})
         archive_path = Path.cwd() / "zlib.tar.bz2"
         archive_path.write_bytes(archive)
 
@@ -352,9 +295,9 @@ class TestBuildrootInstallDep(unittest.TestCase):
         br = self._setup_buildroot()
         archive = _make_tar_bz2(
             {
-                "sysroot/include/openssl/ssl.h": b"ssl-header",
-                "sysroot/include/openssl/crypto.h": b"crypto-header",
-                "sysroot/lib/libssl.a": b"ssl-lib",
+                "include/openssl/ssl.h": b"ssl-header",
+                "include/openssl/crypto.h": b"crypto-header",
+                "lib/libssl.a": b"ssl-lib",
             }
         )
         dep = Dependency(
@@ -382,8 +325,8 @@ class TestBuildrootInstallDep(unittest.TestCase):
         br = self._setup_buildroot()
         archive = _make_tar_bz2(
             {
-                "sysroot/lib/engines/libcapi.a": b"engine-lib",
-                "sysroot/lib/libssl.a": b"ssl-lib",
+                "lib/engines/libcapi.a": b"engine-lib",
+                "lib/libssl.a": b"ssl-lib",
             }
         )
         dep = Dependency(
@@ -403,13 +346,16 @@ class TestBuildrootInstallDep(unittest.TestCase):
         self.assertTrue((sysroot() / "lib" / "engines" / "libcapi.a").exists())
         self.assertTrue((sysroot() / "lib" / "libssl.a").exists())
 
-    def test_install_dep_flat_tarball_without_segments(self) -> None:
-        """Tarballs with bare filenames (no include/ or lib/ segment) still work."""
+    def test_install_dep_copies_arbitrary_top_level_dirs(self) -> None:
+        """All top-level dirs (lib/, share/, bin/, …) land verbatim, any file type."""
         br = self._setup_buildroot()
         archive = _make_tar_bz2(
             {
-                "libz.a": b"lib-content",
-                "zlib.h": b"header-content",
+                "lib/libz.so": b"shared",
+                "lib/libz.a": b"static",
+                "include/zlib.h": b"header",
+                "share/man/man1/zlib.1": b"man",
+                "bin/zlib-config": b"script",
             }
         )
         dep = Dependency(
@@ -426,8 +372,13 @@ class TestBuildrootInstallDep(unittest.TestCase):
         ):
             br.install_dep(dep)
 
+        self.assertEqual((sysroot() / "lib" / "libz.so").read_bytes(), b"shared")
         self.assertTrue((sysroot() / "lib" / "libz.a").exists())
         self.assertTrue((sysroot() / "include" / "zlib.h").exists())
+        self.assertEqual(
+            (sysroot() / "share" / "man" / "man1" / "zlib.1").read_bytes(), b"man"
+        )
+        self.assertTrue((sysroot() / "bin" / "zlib-config").exists())
 
 
 class TestInstallLocalArchive(unittest.TestCase):
@@ -438,8 +389,6 @@ class TestInstallLocalArchive(unittest.TestCase):
             name=str(overrides.pop("name", "zlib")),
             repo=str(overrides.pop("repo", "nanvix/zlib")),
             ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-            install_libs=overrides.pop("install_libs", None),  # type: ignore[arg-type]
-            install_headers=overrides.pop("install_headers", None),  # type: ignore[arg-type]
         )
 
     def _stage(self, files: dict[str, bytes]) -> Path:
@@ -471,25 +420,6 @@ class TestInstallLocalArchive(unittest.TestCase):
         self.assertTrue(hdr.is_file() and not hdr.is_symlink())
         self.assertEqual(lib.read_bytes(), b"lib-content")
         self.assertEqual(hdr.read_bytes(), b"header-content")
-
-    def test_selective_libs_and_headers(self) -> None:
-        br = Buildroot.create()
-        manifest = self._stage(
-            {
-                "lib/libz.a": b"z",
-                "lib/libextra.a": b"extra",
-                "include/zlib.h": b"wanted",
-                "include/internal.h": b"nope",
-            }
-        )
-        dep = self._dep(install_libs=["libz.a"], install_headers=["zlib.h"])
-
-        br.install_local_archive(dep, manifest)
-
-        self.assertTrue((sysroot() / "lib" / "libz.a").is_file())
-        self.assertFalse((sysroot() / "lib" / "libextra.a").exists())
-        self.assertTrue((sysroot() / "include" / "zlib.h").is_file())
-        self.assertFalse((sysroot() / "include" / "internal.h").exists())
 
     def test_preserves_header_subdirectory(self) -> None:
         br = Buildroot.create()
@@ -609,8 +539,8 @@ class TestInstallDepPreResolvedRelease(unittest.TestCase):
     def _make_archive(self) -> bytes:
         return _make_tar_bz2(
             {
-                "sysroot/lib/libz.a": b"lib-content",
-                "sysroot/include/zlib.h": b"header-content",
+                "lib/libz.a": b"lib-content",
+                "include/zlib.h": b"header-content",
             }
         )
 
@@ -692,8 +622,8 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         br = self._setup_buildroot()
         archive = _make_zip(
             {
-                "sysroot/lib/libz.a": b"lib-content",
-                "sysroot/include/zlib.h": b"header-content",
+                "lib/libz.a": b"lib-content",
+                "include/zlib.h": b"header-content",
             }
         )
         dep = Dependency(
@@ -715,8 +645,8 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         br = self._setup_buildroot()
         archive = _make_zip(
             {
-                "sysroot/lib/libz.a": b"lib-content",
-                "sysroot/include/zlib.h": b"header-content",
+                "lib/libz.a": b"lib-content",
+                "include/zlib.h": b"header-content",
             }
         )
         dep = Dependency(
@@ -736,39 +666,13 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
             (sysroot() / "include" / "zlib.h").read_bytes(), b"header-content"
         )
 
-    def test_install_dep_zip_selective_libs(self) -> None:
-        br = self._setup_buildroot()
-        archive = _make_zip(
-            {
-                "sysroot/lib/libz.a": b"libz",
-                "sysroot/lib/libextra.a": b"libextra",
-            }
-        )
-        dep = Dependency(
-            name="zlib",
-            repo="nanvix/zlib",
-            ref=Ref(kind=RefKind.TAG, value="v1.0.0"),
-            install_libs=["libz.a"],
-        )
-        archive_path = Path.cwd() / "zlib.zip"
-        archive_path.write_bytes(archive)
-
-        with patch(
-            "nanvix_zutil.github.download_release_asset",
-            return_value=archive_path,
-        ):
-            br.install_dep(dep)
-
-        self.assertTrue((sysroot() / "lib" / "libz.a").exists())
-        self.assertFalse((sysroot() / "lib" / "libextra.a").exists())
-
     def test_install_dep_zip_preserves_header_subdirectory(self) -> None:
         br = self._setup_buildroot()
         archive = _make_zip(
             {
-                "sysroot/include/openssl/ssl.h": b"ssl-header",
-                "sysroot/include/openssl/crypto.h": b"crypto-header",
-                "sysroot/lib/libssl.a": b"ssl-lib",
+                "include/openssl/ssl.h": b"ssl-header",
+                "include/openssl/crypto.h": b"crypto-header",
+                "lib/libssl.a": b"ssl-lib",
             }
         )
         dep = Dependency(
@@ -788,6 +692,29 @@ class TestBuildrootInstallDepZip(unittest.TestCase):
         self.assertTrue((sysroot() / "include" / "openssl" / "ssl.h").exists())
         self.assertTrue((sysroot() / "include" / "openssl" / "crypto.h").exists())
         self.assertTrue((sysroot() / "lib" / "libssl.a").exists())
+
+    def test_install_dep_zip_preserves_executable_bit(self) -> None:
+        """zipfile drops Unix modes on extract; install must restore them."""
+        br = self._setup_buildroot()
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            info = zipfile.ZipInfo("bin/hello")
+            info.external_attr = 0o755 << 16
+            zf.writestr(info, b"#!/bin/sh\n")
+        archive_path = Path.cwd() / "tool.zip"
+        archive_path.write_bytes(buf.getvalue())
+        dep = Dependency(
+            name="tool", repo="nanvix/tool", ref=Ref(kind=RefKind.TAG, value="v1.0.0")
+        )
+
+        with patch(
+            "nanvix_zutil.github.download_release_asset",
+            return_value=archive_path,
+        ):
+            br.install_dep(dep)
+
+        mode = (sysroot() / "bin" / "hello").stat().st_mode
+        self.assertTrue(mode & stat.S_IXUSR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# [zutils] deps: install standardized package contents verbatim

Closes #326. **BREAKING.**

Deps used to ship loose `.a`/`.h` files routed by extension. Now they
ship a strict top-level layout and we copy it into the sysroot
**verbatim** — any dir, any file type (`.so`, `bin/` scripts, `share/`):

```
my_pkg-...-dev.tar.gz/
|-- lib/       # optional
|-- include/   # optional
|-- ...
```

## Changes

- Verbatim extraction (`extractall(sysroot(), filter="data")`); dropped
  extension routing and the dead `install_libs`/`install_headers`.
- Re-apply Unix mode on zip extract so `bin/` scripts stay executable.
- `verify(required_libs)` → `verify(required_files)`: sysroot-relative
  paths (`"lib/libz.a"`) instead of bare `.a` names.
- Examples: `lib-hello` stages into `dev_out()/{lib,include}`;
  `bin-hello` pulls it as a local dep in `setup()`.
- Docs + tests updated.

## Breaking

- Deps must ship top-level `lib/`/`include/`/etc, not loose files.
- `verify(["libz.a"])` → `verify(["lib/libz.a"])`.

Downstreams need a sweep.
