### PR TITLE
[MILESTONE-3] F: Move translate_path

### DIFF
--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -27,7 +27,7 @@ from nanvix_zutil import (
 )
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE
-from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
+from nanvix_zutil.helpers import InitRdArgs, make_initrd, run, translate_path
 from nanvix_zutil.paths import regular_out, repo_root
 
 
@@ -59,7 +59,7 @@ class BinHello(ZScript):
                 code=EXIT_BUILD_FAILURE,
             )
         host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.docker.translate_path(host) if self.docker else host
+        return translate_path(self.docker.mounts, host) if self.docker else host
 
     # ------------------------------------------------------------------
     # Lifecycle hooks

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -25,7 +25,7 @@ from nanvix_zutil import (
     log,
 )
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
-from nanvix_zutil.helpers import run
+from nanvix_zutil.helpers import run, translate_path
 from nanvix_zutil.paths import dev_out, repo_root
 
 
@@ -54,7 +54,7 @@ class LibHello(ZScript):
                 code=EXIT_BUILD_FAILURE,
             )
         host = Path(sysroot_str)  # type: ignore[arg-type]
-        return self.docker.translate_path(host) if self.docker else host
+        return translate_path(self.docker.mounts, host) if self.docker else host
 
     # ------------------------------------------------------------------
     # Lifecycle hooks

--- a/src/nanvix_zutil/__init__.py
+++ b/src/nanvix_zutil/__init__.py
@@ -41,6 +41,7 @@ Public re-exports:
 - :func:`~nanvix_zutil.helpers.sync_configs` — sync packaged configs into a Nanvix tree
 - :func:`~nanvix_zutil.helpers.make_initrd` — build an initrd image
 - :func:`~nanvix_zutil.helpers.run` — run a subprocess with standardized logging
+- :func:`~nanvix_zutil.helpers.translate_path` — translate a host path to its container equivalent
 """
 
 from nanvix_zutil.buildroot import (
@@ -95,6 +96,7 @@ from nanvix_zutil.helpers import (
     mkramfs,
     run,
     sync_configs,
+    translate_path,
 )
 from nanvix_zutil.lockfile import (
     Lockfile,
@@ -201,6 +203,7 @@ __all__ = [
     "suffix_dep",
     "sdk_consumer_release_tag",
     "sync_configs",
+    "translate_path",
     "write_lockfile",
     "InitRdArgs",
     "StandaloneTest",

--- a/src/nanvix_zutil/docker.py
+++ b/src/nanvix_zutil/docker.py
@@ -220,50 +220,6 @@ class DockerConfig:
     """
 
     # ------------------------------------------------------------------
-    # Path translation
-    # ------------------------------------------------------------------
-
-    def translate_path(self, host_path: Path) -> PurePosixPath:
-        """Translate a host path to its container equivalent.
-
-        Scans :attr:`mounts` and returns the container-side path for the
-        longest matching host prefix.  If no mount covers *host_path*, the
-        path is returned as a :class:`PurePosixPath` so container-internal
-        paths keep forward slashes on Windows.
-
-        Args:
-            host_path: An absolute host path to translate.
-
-        Returns:
-            Container-side :class:`~pathlib.PurePosixPath`.  When no mount
-            covers the path, the result is still a :class:`PurePosixPath`
-            so that container-internal paths (e.g. ``/opt/nanvix``) keep
-            forward slashes on Windows.
-        """
-        resolved = host_path.resolve()
-        best_mount: Mount | None = None
-        best_depth = -1
-        best_rel = Path(".")
-
-        for mount in self.mounts:
-            mount_host = mount.host_path.resolve()
-            try:
-                rel = resolved.relative_to(mount_host)
-            except ValueError:
-                continue
-            depth = len(mount_host.parts)
-            if depth > best_depth:
-                best_depth = depth
-                best_mount = mount
-                best_rel = rel
-
-        if best_mount is not None:
-            return best_mount.container_path / PurePosixPath(*best_rel.parts)
-        # No mount matched — return as PurePosixPath so container-internal
-        # paths like /opt/nanvix keep forward slashes on Windows.
-        return PurePosixPath(host_path.as_posix())
-
-    # ------------------------------------------------------------------
     # Mount helpers
     # ------------------------------------------------------------------
 

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -11,10 +11,10 @@ import sys
 import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import log
-from nanvix_zutil.docker import DockerConfig, is_windows
+from nanvix_zutil.docker import DockerConfig, Mount, is_windows
 from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_MISSING_DEP
 from nanvix_zutil.paths import nanvix_root, sysroot
 
@@ -63,6 +63,45 @@ def filter_container_env(env: dict[str, str]) -> dict[str, str]:
         if k not in _CONTAINER_ENV_BLOCKLIST
         and k.upper() not in _CONTAINER_ENV_BLOCKLIST
     }
+
+
+def translate_path(mounts: list[Mount], host_path: Path) -> PurePosixPath:
+    """Translate a host path to its container equivalent.
+
+    Scans *mounts* and returns the container-side path for the longest
+    matching host prefix.  If no mount covers *host_path*, the path is
+    returned as a :class:`~pathlib.PurePosixPath` so container-internal
+    paths (e.g. ``/opt/nanvix``) keep forward slashes on Windows.
+
+    Args:
+        mounts: Volume mounts to scan (typically ``docker_config.mounts``).
+        host_path: An absolute host path to translate.
+
+    Returns:
+        Container-side :class:`~pathlib.PurePosixPath`.
+    """
+    resolved = host_path.resolve()
+    best_mount: Mount | None = None
+    best_depth = -1
+    best_rel = Path(".")
+
+    for mount in mounts:
+        mount_host = mount.host_path.resolve()
+        try:
+            rel = resolved.relative_to(mount_host)
+        except ValueError:
+            continue
+        depth = len(mount_host.parts)
+        if depth > best_depth:
+            best_depth = depth
+            best_mount = mount
+            best_rel = rel
+
+    if best_mount is not None:
+        return best_mount.container_path / PurePosixPath(*best_rel.parts)
+    # No mount matched -- return as PurePosixPath so container-internal
+    # paths like /opt/nanvix keep forward slashes on Windows.
+    return PurePosixPath(host_path.as_posix())
 
 
 def check_docker(image: str) -> None:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -22,6 +22,7 @@ from nanvix_zutil.docker import (
     is_windows,
     remove_build_volume,
 )
+from nanvix_zutil.helpers import translate_path
 
 
 class TestMount(unittest.TestCase):
@@ -50,8 +51,8 @@ class TestMount(unittest.TestCase):
         self.assertEqual(m.container_path, PurePosixPath("/b"))
 
 
-class TestDockerConfigTranslatePath(unittest.TestCase):
-    """Tests for DockerConfig.translate_path."""
+class TestTranslatePath(unittest.TestCase):
+    """Tests for helpers.translate_path."""
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -81,35 +82,34 @@ class TestDockerConfigTranslatePath(unittest.TestCase):
 
     def test_workspace_root(self) -> None:
         cfg = self._make_config()
-        result = cfg.translate_path(self._workspace)
+        result = translate_path(cfg.mounts, self._workspace)
         self.assertEqual(result, WORKSPACE_CONTAINER_PATH)
 
     def test_workspace_child(self) -> None:
         cfg = self._make_config()
-        result = cfg.translate_path(self._workspace / "src" / "main.c")
+        result = translate_path(cfg.mounts, self._workspace / "src" / "main.c")
         self.assertEqual(result, WORKSPACE_CONTAINER_PATH / "src" / "main.c")
 
     def test_sysroot_root(self) -> None:
         cfg = self._make_config()
-        result = cfg.translate_path(self._sysroot)
+        result = translate_path(cfg.mounts, self._sysroot)
         self.assertEqual(result, SYSROOT_CONTAINER_PATH)
 
     def test_sysroot_child(self) -> None:
         cfg = self._make_config()
-        result = cfg.translate_path(self._sysroot / "lib" / "libposix.a")
+        result = translate_path(cfg.mounts, self._sysroot / "lib" / "libposix.a")
         self.assertEqual(result, SYSROOT_CONTAINER_PATH / "lib" / "libposix.a")
 
     def test_unmatched_path_returned_as_posix(self) -> None:
         cfg = self._make_config()
         unmatched = Path("/some/other/path")
-        result = cfg.translate_path(unmatched)
+        result = translate_path(cfg.mounts, unmatched)
         self.assertEqual(result, PurePosixPath("/some/other/path"))
         self.assertIsInstance(result, PurePosixPath)
 
     def test_empty_mounts_returns_posix(self) -> None:
-        cfg = DockerConfig(image="test-image", mounts=[])
         p = Path("/foo/bar")
-        result = cfg.translate_path(p)
+        result = translate_path([], p)
         self.assertEqual(result, PurePosixPath("/foo/bar"))
         self.assertIsInstance(result, PurePosixPath)
 


### PR DESCRIPTION
Closes #260. **Stacked on #344.** **BREAKING**

`translate_path` was buried under the `DockerConfig` class. Moved it to the
`helpers` module so consumers can grab it directly:

```python
from nanvix_zutil.helpers import translate_path
docker_path = translate_path(self.docker.mounts, some_path)
```

**BREAKING:** `DockerConfig.translate_path(path)` is gone. New signature is
`translate_path(mounts, host_path)`.

## Changes

- New free function `translate_path(mounts, host_path)` in `helpers`.
- Dropped the method off `DockerConfig`.
- Re-exported via `__init__` (`__all__` + docstring).
- Retargeted tests and both example `z.py` consumers.