### PR TITLE
[MILESTONE-4] E: build owns Docker; drop ZScript.docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ Consumer repositories subclass `ZScript` in `.nanvix/z.py`:
 
 ```python
 from nanvix_zutil import ZScript
+from nanvix_zutil.docker import DockerConfig
 from nanvix_zutil.helpers import run
 
 class MyBuild(ZScript):
-    def build(self) -> None:
-        run("make", "-f", "Makefile.nanvix", "all", docker=self.docker)
+    def build(self, docker: DockerConfig) -> None:
+        run("make", "-f", "Makefile.nanvix", "all", docker=docker)
 
     def test(self) -> None:
-        run("make", "-f", "Makefile.nanvix", "test", docker=self.docker)
+        run("make", "-f", "Makefile.nanvix", "test")
 ```
 
 Then invoke via the bootstrap wrapper:

--- a/examples/bin-hello/.nanvix/z.py
+++ b/examples/bin-hello/.nanvix/z.py
@@ -14,52 +14,22 @@ Demonstrates dependency resolution with ``nanvix.toml``.  Run with
 """
 
 import dataclasses
-from pathlib import Path, PurePosixPath
 
 import _test
 
 from nanvix_zutil import (
-    CFG_SYSROOT,
+    SYSROOT_CONTAINER_PATH,
     TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
-    log,
 )
 from nanvix_zutil.buildroot import Dependency, Ref, RefKind
-from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE
-from nanvix_zutil.helpers import InitRdArgs, make_initrd, run, translate_path
+from nanvix_zutil.helpers import InitRdArgs, make_initrd, run
 from nanvix_zutil.paths import regular_out, repo_root
 
 
 class BinHello(ZScript):
     """Build script for the bin-hello binary example."""
-
-    # ------------------------------------------------------------------
-    # Docker configuration
-    # ------------------------------------------------------------------
-
-    def docker_config(self, image: str) -> DockerConfig:
-        """Add output_files so hello.elf is copied back on Windows."""
-        cfg = super().docker_config(image)
-        return dataclasses.replace(cfg, output_files=["hello.elf"])
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _sysroot(self) -> PurePosixPath | Path:
-        """Return the sysroot path, translated for Docker if active.
-
-        Sysroot also holds dependency headers and static archives.
-        """
-        sysroot_str = self.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
-            log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_BUILD_FAILURE,
-            )
-        host = Path(sysroot_str)  # type: ignore[arg-type]
-        return translate_path(self.docker.mounts, host) if self.docker else host
 
     # ------------------------------------------------------------------
     # Lifecycle hooks
@@ -85,10 +55,12 @@ class BinHello(ZScript):
         self.sysroot.verify(["lib/libhello.a", "include/hello.h"])
         return used_fallback
 
-    def build(self) -> None:
+    def build(self, docker: DockerConfig) -> None:
         """Cross-compile main.c into hello.elf for Nanvix."""
+        # output_files copies hello.elf back to the workspace on Windows.
+        docker = dataclasses.replace(docker, output_files=["hello.elf"])
         tc = TOOLCHAIN_CONTAINER_PATH
-        sysroot = self._sysroot()
+        sysroot = SYSROOT_CONTAINER_PATH
         cc = f"{tc}/bin/clang --target=i686-unknown-nanvix --sysroot={tc}"
         cflags = f"-O2 -Wall -msse2 -mfpmath=sse -I{sysroot}/include"
         libs = f"{sysroot}/lib/libhello.a"
@@ -101,7 +73,7 @@ class BinHello(ZScript):
             f"{cc} {cflags} -c -o main.o src/main.c"
             f" && {cc} {cflags} -o hello.elf main.o {libs}",
             cwd=repo_root(),
-            docker=self.docker,
+            docker=docker,
         )
 
         # For standalone deployment mode, produce an initrd image

--- a/examples/lib-hello/.nanvix/z.py
+++ b/examples/lib-hello/.nanvix/z.py
@@ -15,17 +15,15 @@ Demonstrates the full lifecycle with a real Nanvix build.  Run with
 
 import dataclasses
 import shutil
-from pathlib import Path, PurePosixPath
 
 from nanvix_zutil import (
-    CFG_SYSROOT,
     TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
     log,
 )
-from nanvix_zutil.exitcodes import EXIT_BUILD_FAILURE, EXIT_TEST_FAILURE
-from nanvix_zutil.helpers import run, translate_path
+from nanvix_zutil.exitcodes import EXIT_TEST_FAILURE
+from nanvix_zutil.helpers import run
 from nanvix_zutil.paths import dev_out, repo_root
 
 
@@ -33,35 +31,13 @@ class LibHello(ZScript):
     """Build script for the lib-hello static library example."""
 
     # ------------------------------------------------------------------
-    # Docker configuration
-    # ------------------------------------------------------------------
-
-    def docker_config(self, image: str) -> DockerConfig:
-        """Add output_files so libhello.a is copied back on Windows."""
-        cfg = super().docker_config(image)
-        return dataclasses.replace(cfg, output_files=["libhello.a"])
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _sysroot(self) -> PurePosixPath | Path:
-        """Return the sysroot path, translated for Docker if active."""
-        sysroot_str = self.config.get(CFG_SYSROOT, "")
-        if not sysroot_str:
-            log.fatal(
-                "Sysroot not configured — run 'nanvix-zutil setup' first.",
-                code=EXIT_BUILD_FAILURE,
-            )
-        host = Path(sysroot_str)  # type: ignore[arg-type]
-        return translate_path(self.docker.mounts, host) if self.docker else host
-
-    # ------------------------------------------------------------------
     # Lifecycle hooks
     # ------------------------------------------------------------------
 
-    def build(self) -> None:
+    def build(self, docker: DockerConfig) -> None:
         """Cross-compile hello.c into libhello.a for Nanvix."""
+        # output_files copies libhello.a back to the workspace on Windows.
+        docker = dataclasses.replace(docker, output_files=["libhello.a"])
         tc = TOOLCHAIN_CONTAINER_PATH
         cc = f"{tc}/bin/clang --target=i686-unknown-nanvix --sysroot={tc}"
         ar = str(tc / "bin" / "llvm-ar")
@@ -74,7 +50,7 @@ class LibHello(ZScript):
             "-c",
             f"{cc} {cflags} -c -o hello.o src/hello.c && {ar} rcs libhello.a hello.o",
             cwd=repo_root(),
-            docker=self.docker,
+            docker=docker,
         )
         # Stage artifacts into the dev tree so `release` packs a standard
         # lib/ + include/ layout.

--- a/src/nanvix_zutil/helpers.py
+++ b/src/nanvix_zutil/helpers.py
@@ -74,7 +74,7 @@ def translate_path(mounts: list[Mount], host_path: Path) -> PurePosixPath:
     paths (e.g. ``/opt/nanvix``) keep forward slashes on Windows.
 
     Args:
-        mounts: Volume mounts to scan (typically ``docker_config.mounts``).
+        mounts: Volume mounts to scan (i.e. the build ``DockerConfig.mounts``).
         host_path: An absolute host path to translate.
 
     Returns:

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -55,7 +55,13 @@ from nanvix_zutil.helpers import (
 )
 from nanvix_zutil.lockfile import get_zutil_version, read_lockfile, write_lockfile
 from nanvix_zutil.manifest import Manifest, load_manifest
-from nanvix_zutil.paths import nanvix_root, out_dir, repo_root
+from nanvix_zutil.paths import (
+    manifest_path,
+    nanvix_root,
+    out_dir,
+    repo_root,
+    z_py_path,
+)
 from nanvix_zutil.resolver import BlockedResolution, is_stale, resolve
 from nanvix_zutil.sysroot import Sysroot
 
@@ -96,8 +102,12 @@ def _build_docker_config(image: str, config: Config) -> DockerConfig:
         mounts=mounts,
         workdir=WORKSPACE_CONTAINER_PATH,
         invalidation_inputs=[
-            repo_root() / "Makefile.nanvix",
+            z_py_path(),
+            manifest_path(),
             nanvix_root() / "nanvix.lock",
+            nanvix_root() / "src",
+            repo_root() / "Makefile.nanvix",
+            nanvix_root() / "Makefile.nanvix",
         ],
     )
 
@@ -783,14 +793,16 @@ class ZScript:
         if subcommand == "build":
             # Build is the sole Docker-aware hook: resolve the persisted
             # image, ensure it is available, and construct the config here,
-            # where build is dispatched.
+            # where build is dispatched. On Windows host-native binaries are
+            # used, so Docker is never required.
             image = instance.config.get(CFG_DOCKER_IMAGE)
             if image is None:
                 log.fatal(
                     "No Docker image configured. Run setup first.",
                     code=EXIT_INVALID_ARGS,
                 )
-            check_docker(image)
+            if not is_windows():
+                check_docker(image)
             instance.build(_build_docker_config(image, instance.config))
             log.success("Build complete")
             return

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -7,11 +7,12 @@ Consumer repositories subclass :class:`ZScript`, implement the lifecycle
 hooks they need, and call ``ZScript.main()`` as the entry point::
 
     from nanvix_zutil import ZScript
+    from nanvix_zutil.docker import DockerConfig
     from nanvix_zutil.helpers import run
 
     class MyBuild(ZScript):
-        def build(self) -> None:
-            run("make", "-f", "Makefile.nanvix", "all", docker=self.docker)
+        def build(self, docker: DockerConfig) -> None:
+            run("make", "-f", "Makefile.nanvix", "all", docker=docker)
 
     if __name__ == "__main__":
         MyBuild.main()
@@ -59,6 +60,48 @@ from nanvix_zutil.resolver import BlockedResolution, is_stale, resolve
 from nanvix_zutil.sysroot import Sysroot
 
 
+def _build_docker_config(image: str, config: Config) -> DockerConfig:
+    """Build the standard :class:`~nanvix_zutil.DockerConfig` for *image*.
+
+    Mounts :func:`repo_root` at ``/mnt/workspace`` and, when configured,
+    the sysroot at ``/mnt/sysroot``.
+
+    This is a module-private function rather than a :class:`ZScript`
+    method by design: only :meth:`ZScript.main` builds it, and only for
+    the build step, so Docker never leaks into other hooks.  Consumers
+    that need extra mounts or outputs replace fields on the ``docker``
+    they receive in :meth:`ZScript.build` (e.g. via
+    :func:`dataclasses.replace`).
+    """
+    mounts: list[Mount] = [
+        Mount(
+            host_path=repo_root(),
+            container_path=WORKSPACE_CONTAINER_PATH,
+            readonly=False,
+        ),
+    ]
+
+    sysroot_str = config.get(CFG_SYSROOT)
+    if sysroot_str:
+        mounts.append(
+            Mount(
+                host_path=Path(str(sysroot_str)),
+                container_path=SYSROOT_CONTAINER_PATH,
+                readonly=False,
+            )
+        )
+
+    return DockerConfig(
+        image=image,
+        mounts=mounts,
+        workdir=WORKSPACE_CONTAINER_PATH,
+        invalidation_inputs=[
+            repo_root() / "Makefile.nanvix",
+            nanvix_root() / "nanvix.lock",
+        ],
+    )
+
+
 class ZScript:
     """Base class for consumer build scripts.
 
@@ -85,8 +128,6 @@ class ZScript:
         sysroot: The :class:`~nanvix_zutil.Sysroot` downloaded by
             :meth:`setup`.  Build-time dependencies are installed into it
             via :meth:`~nanvix_zutil.Sysroot.install_dep`.
-        docker: Active :class:`~nanvix_zutil.DockerConfig`, or ``None``
-            when Docker mode is not in use.
     """
 
     SDK_RUNTIME_REQUIRED_FILES: tuple[str, ...] = (
@@ -133,9 +174,6 @@ class ZScript:
         "clean",
     )
 
-    # Subcommands that always run inside Docker.
-    DOCKER_COMMANDS: frozenset[str | None] = frozenset({"setup", "build", "clean"})
-
     def required_files_for_release(self) -> list[Path]:
         """
         Used by `package()` to verify that the release directory contains the expected files.
@@ -170,7 +208,6 @@ class ZScript:
         self.targets: list[str] = []
         self.manifest: Manifest = load_manifest()
         self.sysroot: Sysroot | None = None
-        self.docker: DockerConfig | None = None
         self._offline: bool = False
         self._with_nanvix_path: str | None = None
         self.local_deps: dict[str, str] = {}
@@ -201,60 +238,6 @@ class ZScript:
             if getattr(type(self), name) is not getattr(ZScript, name):
                 available.append(name)
         return tuple(available)
-
-    # ------------------------------------------------------------------
-    # Docker hooks — override in subclass to customise
-    # ------------------------------------------------------------------
-
-    def docker_config(self, image: str) -> DockerConfig:
-        """Build the :class:`~nanvix_zutil.DockerConfig` for *image*.
-
-        Constructs a standard configuration that mounts:
-
-        * :func:`repo_root()` → ``/mnt/workspace`` (writable, workdir)
-        * sysroot path from :attr:`config` → ``/mnt/sysroot`` (writable),
-          if the sysroot has been configured
-
-        Default :attr:`~nanvix_zutil.DockerConfig.invalidation_inputs` cover
-        ``Makefile.nanvix`` and ``nanvix.lock`` (missing ones are skipped), so
-        a persistent-volume build is cleaned when the build recipe or resolved
-        toolchain/deps change.  Consumers only need to set ``clean_cmd``.
-
-        Override in a subclass to add extra mounts or environment variables.
-
-        Args:
-            image: Docker image name to use.
-
-        Returns:
-            A fully populated :class:`~nanvix_zutil.DockerConfig`.
-        """
-        mounts: list[Mount] = [
-            Mount(
-                host_path=repo_root(),
-                container_path=WORKSPACE_CONTAINER_PATH,
-                readonly=False,
-            ),
-        ]
-
-        sysroot_str = self.config.get(CFG_SYSROOT)
-        if sysroot_str:
-            mounts.append(
-                Mount(
-                    host_path=Path(sysroot_str),
-                    container_path=SYSROOT_CONTAINER_PATH,
-                    readonly=False,
-                )
-            )
-
-        return DockerConfig(
-            image=image,
-            mounts=mounts,
-            workdir=WORKSPACE_CONTAINER_PATH,
-            invalidation_inputs=[
-                repo_root() / "Makefile.nanvix",
-                nanvix_root() / "nanvix.lock",
-            ],
-        )
 
     # ------------------------------------------------------------------
     # Lifecycle hooks — auto-implemented
@@ -593,10 +576,13 @@ class ZScript:
     # Lifecycle hooks — override in subclass
     # ------------------------------------------------------------------
 
-    def build(self) -> None:
+    def build(self, docker: DockerConfig) -> None:
         """Build the project.
 
-        Override to invoke the project's build system.
+        Override to invoke the project's build system.  The *docker*
+        argument is the only handle to Docker in the lifecycle: pass it
+        to :func:`~nanvix_zutil.helpers.run` to wrap commands in the
+        toolchain container.
         """
 
     def test(self) -> None:
@@ -618,16 +604,20 @@ class ZScript:
         invoking the build system (which would require Docker).  Override
         to customise the files cleaned.
         """
-        # Drop the persistent build volume, if one is configured.
-        if self.docker is not None:
-            try:
-                volume = self.docker.volume_name()
-            except ValueError as exc:
-                log.warning(f"Skipping build-volume removal: {exc}")
-            else:
-                if volume is not None:
-                    remove_build_volume(volume)
-                    log.info(f"Requested removal of build volume {volume}")
+        # Drop the persistent build volume, if one is configured.  Docker is
+        # scoped to ``build``, so reconstruct the standard config to recover
+        # the deterministic volume name.
+        docker = _build_docker_config(
+            str(self.config.get(CFG_DOCKER_IMAGE) or ""), self.config
+        )
+        try:
+            volume = docker.volume_name()
+        except ValueError as exc:
+            log.warning(f"Skipping build-volume removal: {exc}")
+        else:
+            if volume is not None:
+                remove_build_volume(volume)
+                log.info(f"Requested removal of build volume {volume}")
         if is_windows():
             # Common artifacts that consumers may produce.
             # Subclasses can override to add project-specific files.
@@ -714,59 +704,37 @@ class ZScript:
             instance.local_deps = with_deps
 
         # ------------------------------------------------------------------
-        # Docker: resolve image from CLI or persisted config, then check availability.
+        # Docker image handling for ``setup``: resolve the image, persist it,
+        # and pre-pull it. ``build`` constructs its config later, where it is
+        # dispatched; no other step touches Docker.
+        #
+        # On Windows the image is still persisted, but Docker is never
+        # required to be installed (host-native binaries are used instead),
+        # so ``check_docker`` is skipped.
         # ------------------------------------------------------------------
 
-        # On Windows, setup downloads host-native binaries
-        # via the GitHub API and does not invoke Docker.  Skip Docker
-        # entirely for setup on Windows — the image is still persisted
-        # to .nanvix/env.json so that subsequent commands can use it,
-        # but we do not require Docker to be installed or the image to
-        # exist locally.
-        if args.subcommand in ZScript.DOCKER_COMMANDS:
+        if args.subcommand == "setup":
             requested_image: str | None = getattr(args, "with_docker", None)
-            persisted_image = instance.config.get(CFG_DOCKER_IMAGE)
             manifest_image = instance.manifest.toolchain.effective_build_ref
             allow_override = bool(getattr(args, "allow_local_docker_override", False))
-
-            if args.subcommand == "setup":
-                if (
-                    requested_image is not None
-                    and requested_image != manifest_image
-                    and not allow_override
-                ):
-                    log.fatal(
-                        f"--with-docker {requested_image!r} conflicts with the"
-                        f" manifest build image {manifest_image!r}",
-                        code=EXIT_INVALID_ARGS,
-                        hint="Omit --with-docker, or use"
-                        " --allow-local-docker-override for an intentional"
-                        " local-development override.",
-                    )
-                image = requested_image or manifest_image
-            else:
-                image = persisted_image
-
-            if image is None:
+            if (
+                requested_image is not None
+                and requested_image != manifest_image
+                and not allow_override
+            ):
                 log.fatal(
-                    "No Docker image configured. Run setup first.",
+                    f"--with-docker {requested_image!r} conflicts with the"
+                    f" manifest build image {manifest_image!r}",
                     code=EXIT_INVALID_ARGS,
+                    hint="Omit --with-docker, or use"
+                    " --allow-local-docker-override for an intentional"
+                    " local-development override.",
                 )
-
-            # TODO: Move into setup()
-            # https://github.com/nanvix/zutils/issues/187
-            # https://github.com/nanvix/zutils/issues/190
-            if args.subcommand == "setup":
-                instance.config.set(CFG_DOCKER_IMAGE, image)
-                instance.config.save()
-
+            image = requested_image or manifest_image
+            instance.config.set(CFG_DOCKER_IMAGE, image)
+            instance.config.save()
             if not is_windows():
-                # may exit if Docker is required but not available
                 check_docker(image)
-
-            # Persist Docker image on setup so subsequent commands
-            # automatically use the same image.
-            instance.docker = instance.docker_config(image)
 
         # ------------------------------------------------------------------
         # Dispatch to lifecycle hook
@@ -807,11 +775,25 @@ class ZScript:
 
         dispatch: dict[str, object] = {
             "setup": instance.setup,
-            "build": instance.build,
             "test": instance.test,
             "benchmark": instance.benchmark,
             "clean": instance.clean,
         }
+
+        if subcommand == "build":
+            # Build is the sole Docker-aware hook: resolve the persisted
+            # image, ensure it is available, and construct the config here,
+            # where build is dispatched.
+            image = instance.config.get(CFG_DOCKER_IMAGE)
+            if image is None:
+                log.fatal(
+                    "No Docker image configured. Run setup first.",
+                    code=EXIT_INVALID_ARGS,
+                )
+            check_docker(image)
+            instance.build(_build_docker_config(image, instance.config))
+            log.success("Build complete")
+            return
 
         handler = dispatch.get(subcommand) if subcommand is not None else None
         if callable(handler) and subcommand is not None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from nanvix_zutil import ZScript
+from nanvix_zutil.docker import DockerConfig
 from nanvix_zutil.helpers import run
 from nanvix_zutil.paths import manifest_path, nanvix_root, repo_root
 from tests.testutils import write_manifest
@@ -35,7 +36,7 @@ class _MockConsumer(ZScript):
         self.called.append("setup")
         return False
 
-    def build(self) -> None:
+    def build(self, docker: DockerConfig) -> None:
         """Record build hook invocation."""
         self.called.append("build")
 
@@ -71,9 +72,8 @@ class TestIntegrationLifecycle(unittest.TestCase):
         fake_script = str(repo_root() / ".nanvix" / "z.py")
         argv = [fake_script, subcommand] + (extra_argv or [])
 
-        # build/clean need a persisted Docker image.
-        _DOCKER_COMMANDS = {"build", "clean"}
-        if subcommand in _DOCKER_COMMANDS:
+        # build needs a persisted Docker image.
+        if subcommand == "build":
             nanvix_dir = nanvix_root()
             env_json = nanvix_dir / "env.json"
             if not env_json.exists():

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -35,7 +35,7 @@ from nanvix_zutil.lockfile import (
 )
 from nanvix_zutil.manifest import Manifest
 from nanvix_zutil.resolver import BlockedResolution
-from nanvix_zutil.script import ZScript
+from nanvix_zutil.script import ZScript, _build_docker_config
 from tests.testutils import (
     MANIFEST_WITH_DEPS,
     make_sdk_provenance,
@@ -326,7 +326,7 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
         return ZScript()
 
     def test_build_noop(self) -> None:
-        self._make_script().build()
+        self._make_script().build(DockerConfig(image="test-image"))
 
     def test_test_noop(self) -> None:
         self._make_script().test()
@@ -338,9 +338,12 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
         self._make_script().clean()
 
     @patch("nanvix_zutil.script.remove_build_volume")
-    def test_clean_removes_persistent_volume(self, mock_remove: MagicMock) -> None:
+    @patch("nanvix_zutil.script._build_docker_config")
+    def test_clean_removes_persistent_volume(
+        self, mock_config: MagicMock, mock_remove: MagicMock
+    ) -> None:
         script = self._make_script()
-        script.docker = DockerConfig(
+        mock_config.return_value = DockerConfig(
             image="img",
             mounts=[
                 Mount(host_path=Path("/ws"), container_path=WORKSPACE_CONTAINER_PATH)
@@ -351,11 +354,12 @@ class TestZScriptLifecycleHooks(unittest.TestCase):
         mock_remove.assert_called_once_with("pinned-vol")
 
     @patch("nanvix_zutil.script.remove_build_volume")
+    @patch("nanvix_zutil.script._build_docker_config")
     def test_clean_skips_volume_when_not_persistent(
-        self, mock_remove: MagicMock
+        self, mock_config: MagicMock, mock_remove: MagicMock
     ) -> None:
         script = self._make_script()
-        script.docker = DockerConfig(
+        mock_config.return_value = DockerConfig(
             image="img",
             mounts=[
                 Mount(host_path=Path("/ws"), container_path=WORKSPACE_CONTAINER_PATH)
@@ -383,7 +387,7 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
 
     def test_subclass_exposes_overridden_hooks(self) -> None:
         class _Sub(ZScript):
-            def build(self) -> None:
+            def build(self, docker: DockerConfig) -> None:
                 pass
 
             def test(self) -> None:
@@ -396,7 +400,7 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
 
     def test_subclass_hides_non_overridden_hooks(self) -> None:
         class _Sub(ZScript):
-            def build(self) -> None:
+            def build(self, docker: DockerConfig) -> None:
                 pass
 
         script = _Sub()
@@ -406,7 +410,7 @@ class TestZScriptAvailableSubcommands(unittest.TestCase):
 
     def test_all_hooks_overridden(self) -> None:
         class _FullSub(ZScript):
-            def build(self) -> None:
+            def build(self, docker: DockerConfig) -> None:
                 pass
 
             def test(self) -> None:
@@ -909,7 +913,7 @@ class TestZScriptSysrootRequiredFiles(unittest.TestCase):
 
 
 class TestZScriptDockerConfig(unittest.TestCase):
-    """Tests for ZScript.docker / ZScript.docker_config()."""
+    """Tests for the module-level _build_docker_config()."""
 
     def setUp(self) -> None:
         write_manifest()
@@ -917,19 +921,15 @@ class TestZScriptDockerConfig(unittest.TestCase):
     def _make_script(self) -> ZScript:
         return ZScript()
 
-    def test_docker_not_active_by_default(self) -> None:
-        script = self._make_script()
-        self.assertIsNone(script.docker)
-
     def test_docker_config_returns_dockerconfig(self) -> None:
         script = self._make_script()
-        cfg = script.docker_config("test-image")
+        cfg = _build_docker_config("test-image", script.config)
         self.assertIsInstance(cfg, DockerConfig)
         self.assertEqual(cfg.image, "test-image")
 
     def test_docker_config_mounts_workspace(self) -> None:
         script = self._make_script()
-        cfg = script.docker_config("test-image")
+        cfg = _build_docker_config("test-image", script.config)
         workspace_mount = next(
             (m for m in cfg.mounts if m.container_path == WORKSPACE_CONTAINER_PATH),
             None,
@@ -941,20 +941,20 @@ class TestZScriptDockerConfig(unittest.TestCase):
     def test_docker_config_no_buildroot_mount(self) -> None:
         """Buildroot mount was removed after buildroot/sysroot consolidation."""
         script = self._make_script()
-        cfg = script.docker_config("test-image")
+        cfg = _build_docker_config("test-image", script.config)
         for m in cfg.mounts:
             self.assertNotEqual(str(m.container_path), "/mnt/buildroot")
 
     def test_docker_config_default_invalidation_inputs(self) -> None:
         """Default invalidation inputs cover Makefile.nanvix and nanvix.lock."""
         script = self._make_script()
-        cfg = script.docker_config("test-image")
+        cfg = _build_docker_config("test-image", script.config)
         names = {p.name for p in cfg.invalidation_inputs}
         self.assertEqual(names, {"Makefile.nanvix", "nanvix.lock"})
 
 
 class TestZScriptAutoDocker(unittest.TestCase):
-    """Docker is always enabled for setup/build/release/clean (hard fail)."""
+    """Docker is constructed and passed only to the build step."""
 
     def setUp(self) -> None:
         write_manifest()
@@ -965,14 +965,13 @@ class TestZScriptAutoDocker(unittest.TestCase):
         """build on Windows uses the persisted Docker image."""
 
         class BuildScript(ZScript):
-            def build(self) -> None:
+            def build(self, docker: DockerConfig) -> None:
                 pass
 
-        docker_configured = False
+        received: list[DockerConfig | None] = []
 
-        def _fake_build(self_inner: ZScript) -> None:
-            nonlocal docker_configured
-            docker_configured = self_inner.docker is not None
+        def _fake_build(self_inner: ZScript, docker: DockerConfig) -> None:
+            received.append(docker)
 
         # Pre-persist Docker image so build can find it.
         nanvix_dir = paths.nanvix_root()
@@ -988,20 +987,20 @@ class TestZScriptAutoDocker(unittest.TestCase):
         ):
             BuildScript.main()
 
-        self.assertTrue(docker_configured)
+        self.assertEqual(len(received), 1)
+        self.assertIsInstance(received[0], DockerConfig)
 
     def test_build_auto_enables_docker_on_linux(self) -> None:
         """build on Linux uses the persisted Docker image."""
 
         class BuildScript(ZScript):
-            def build(self) -> None:
+            def build(self, docker: DockerConfig) -> None:
                 pass
 
-        docker_configured = False
+        received: list[DockerConfig | None] = []
 
-        def _fake_build(self_inner: ZScript) -> None:
-            nonlocal docker_configured
-            docker_configured = self_inner.docker is not None
+        def _fake_build(self_inner: ZScript, docker: DockerConfig) -> None:
+            received.append(docker)
 
         # Pre-persist Docker image so build can find it.
         nanvix_dir = paths.nanvix_root()
@@ -1022,7 +1021,8 @@ class TestZScriptAutoDocker(unittest.TestCase):
         ):
             BuildScript.main()
 
-        self.assertTrue(docker_configured)
+        self.assertEqual(len(received), 1)
+        self.assertIsInstance(received[0], DockerConfig)
 
 
 class TestZScriptCleanWindows(unittest.TestCase):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -946,11 +946,20 @@ class TestZScriptDockerConfig(unittest.TestCase):
             self.assertNotEqual(str(m.container_path), "/mnt/buildroot")
 
     def test_docker_config_default_invalidation_inputs(self) -> None:
-        """Default invalidation inputs cover Makefile.nanvix and nanvix.lock."""
+        """Default invalidation inputs are the resolved build-recipe paths."""
         script = self._make_script()
         cfg = _build_docker_config("test-image", script.config)
-        names = {p.name for p in cfg.invalidation_inputs}
-        self.assertEqual(names, {"Makefile.nanvix", "nanvix.lock"})
+        self.assertEqual(
+            set(cfg.invalidation_inputs),
+            {
+                paths.z_py_path(),
+                paths.manifest_path(),
+                paths.nanvix_root() / "nanvix.lock",
+                paths.nanvix_root() / "src",
+                paths.repo_root() / "Makefile.nanvix",
+                paths.nanvix_root() / "Makefile.nanvix",
+            },
+        )
 
 
 class TestZScriptAutoDocker(unittest.TestCase):


### PR DESCRIPTION
# [zutils] E: build owns Docker; drop `ZScript.docker`

Closes #235. Stacked on #345 **BREAKING**

Docker was reachable from anywhere via `self.docker`, and only non-`None`
outside build. Reviewers kept flagging it. Now Docker only exists where it's
used: the build step.

**BREAKING:**

- `ZScript.docker` removed.
- `ZScript.docker_config` removed. Config is now built by a module-private
  `_build_docker_config` and handed to `build`.
- `build(self)` → `build(self, docker: DockerConfig)`.
- `DOCKER_COMMANDS` removed. `setup` resolves/persists/pre-pulls the image;
  `build` builds the config where it's dispatched; nothing else touches Docker.

Downstreams that override `docker_config` (usually just for `output_files`)
move that into `build` via `dataclasses.replace(docker, ...)`. Migrated
separately.

## Changes

- Move config construction off the class into `_build_docker_config`.
- Thread `DockerConfig` into `build`; construct it at build dispatch.
- Update examples, tests, README.
