### PR TITLE
[MILESTONE-5] config knobs via flags, not env vars

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -131,7 +131,7 @@ Bootstraps the nanvix_zutil environment by installing a python venv.
 
 #### Setup
 
-Sets up the build environment. By default, this will download the correct nanvix distribution (sourced from `nanvix.toml`) and overlay build-time dependencies into the merged `sysroot`. The particular nanvix distribution parameters (target, machine, deployment mode, and memory size) can be overridden by supplying environment variables (listed below). The settings created here are stored at `.nanvix/env.json`.
+Sets up the build environment. By default, this will download the correct nanvix distribution (sourced from `nanvix.toml`) and overlay build-time dependencies into the merged `sysroot`. The particular nanvix distribution parameters (target, machine, deployment mode, and memory size) are set with their CLI flags (`--target`, `--machine`, `--mode`, `--memory-size`). The settings created here are stored at `.nanvix/env.json`.
 
 1. Download and verify nanvix artefacts (or source locally if `--with-nanvix`)
 2. Strictly resolve and download exact SDK-revision dependency releases.
@@ -237,17 +237,17 @@ Automatically available verbs are either standalone commands
 the ``AUTO_HOOKS`` list on ``ZScript`` (``setup``); opt-in verbs are
 listed in the ``CONSUMER_HOOKS`` array.
 
-### Environment variables
+### Configuration flags
 
-In addition to flags, which modify behaviors, certain operational values can be overridden at runtime. Environment variables take precedence over `.nanvix/env.json`. If values are missing from that file, they are filled from hardcoded defaults.
+In addition to flags that modify behaviors, certain operational values are set with CLI flags (passed after the subcommand) and persisted to `.nanvix/env.json`. If values are missing from that file, they fall back to hardcoded defaults. `GH_TOKEN` is the only remaining environment variable.
 
-| Variable                 | Default      | What it does                                                                       |
-| ------------------------ | ------------ | ---------------------------------------------------------------------------------- |
-| `NANVIX_TARGET`          | `x86`        | Sets the target architecture.                                                      |
-| `NANVIX_MACHINE`         | `microvm`    | Sets the target virtual machine.                                                   |
-| `NANVIX_DEPLOYMENT_MODE` | `standalone` | Sets the deployment mode. Can be one of standalone, single-process, multi-process. |
-| `NANVIX_MEMORY_SIZE`     | `256mb`      | Sets nanvix's allocated memory. Can be one of 128mb, 256mb.                        |
-| `GH_TOKEN`               | (none)       | Used to mitigate API usage limits.                                                 |
+| Flag            | Config key               | Default      | What it does                                                                       |
+| --------------- | ------------------------ | ------------ | ---------------------------------------------------------------------------------- |
+| `--target`      | `NANVIX_TARGET`          | `x86`        | Sets the target architecture.                                                      |
+| `--machine`     | `NANVIX_MACHINE`         | `microvm`    | Sets the target virtual machine.                                                   |
+| `--mode`        | `NANVIX_DEPLOYMENT_MODE` | `standalone` | Sets the deployment mode. Can be one of standalone, single-process, multi-process. |
+| `--memory-size` | `NANVIX_MEMORY_SIZE`     | `256mb`      | Sets nanvix's allocated memory. Can be one of 128mb, 256mb.                        |
+| `GH_TOKEN` (env)| `GH_TOKEN`               | (none)       | Used to mitigate API usage limits.                                                 |
 
 ### Exit Codes
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -44,19 +44,24 @@ contains:
 | `pre-commit` | Runs `tasks.py lint` (black, shfmt, shellcheck, PSScriptAnalyzer, yamllint) + `tasks.py typecheck` (pyright) |
 | `pre-push` | Runs `tasks.py lint` + `tasks.py typecheck` (same checks as pre-commit) |
 
-## Environment Variables
+## Configuration Flags
 
-These are used by the library at runtime (in consumer repos), not during
-development of `nanvix-zutil` itself:
+The build configuration knobs are set with CLI flags, passed after the
+subcommand (e.g. `./z build --machine microvm`). `setup` persists them to
+`.nanvix/env.json`; other subcommands apply them in-memory for that invocation.
+Values fall back to `.nanvix/env.json` and then built-in defaults. `GH_TOKEN` is
+the only remaining environment variable.
 
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `NANVIX_TARGET` | `x86` | Target architecture |
-| `NANVIX_MACHINE` | `microvm` | Target machine |
-| `NANVIX_DEPLOYMENT_MODE` | `standalone` | Deployment mode |
-| `NANVIX_MEMORY_SIZE` | `256mb` | Memory size for artifact naming |
-| `NANVIX_SYSROOT` | *(set by setup)* | Path to runtime sysroot |
-| `GH_TOKEN` | *(none)* | GitHub token for API rate limits |
+| Flag | Config key | Default | Purpose |
+| --- | --- | --- | --- |
+| `--host` | `NANVIX_HOST` | *(platform)* | Development host |
+| `--target` | `NANVIX_TARGET` | `x86` | Target architecture |
+| `--machine` | `NANVIX_MACHINE` | `microvm` | Target machine |
+| `--mode` | `NANVIX_DEPLOYMENT_MODE` | `standalone` | Deployment mode |
+| `--memory-size` | `NANVIX_MEMORY_SIZE` | `256mb` | Memory size for artifact naming |
+
+`NANVIX_SYSROOT` is written to `.nanvix/env.json` by `setup`. `GH_TOKEN`
+(GitHub token for API rate limits) is read from the environment.
 
 ## Project Layout
 

--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -12,8 +12,17 @@ from __future__ import annotations
 
 import argparse
 import sys
+from enum import StrEnum
 from pathlib import Path
 
+from nanvix_zutil.config import (
+    CONFIG_DESCRIPTIONS,
+    DeploymentMode,
+    Host,
+    Machine,
+    MemorySize,
+    Target,
+)
 from nanvix_zutil.lockfile import get_zutil_version
 
 # ---------------------------------------------------------------------------
@@ -131,6 +140,40 @@ SUBCOMMAND_HELP: dict[str, str] = {
     "help": "Show help message",
 }
 
+#: CLI flags that override the matching ``NANVIX_*`` config key. These are the
+#: flag equivalents of the legacy config environment variables (``GH_TOKEN``
+#: stays an environment variable). ``dest`` is the config key itself so callers
+#: can copy provided values straight into the environment / config. The
+#: key->enum mapping mirrors :data:`nanvix_zutil.config._ENUMS`; keep them in
+#: sync when adding a config key (flag names are not derivable from the keys).
+_CONFIG_FLAGS: dict[str, tuple[str, type[StrEnum]]] = {
+    "--host": ("NANVIX_HOST", Host),
+    "--target": ("NANVIX_TARGET", Target),
+    "--machine": ("NANVIX_MACHINE", Machine),
+    "--mode": ("NANVIX_DEPLOYMENT_MODE", DeploymentMode),
+    "--memory-size": ("NANVIX_MEMORY_SIZE", MemorySize),
+}
+
+#: Config keys settable via :data:`_CONFIG_FLAGS`.
+CONFIG_FLAG_KEYS: tuple[str, ...] = tuple(key for key, _ in _CONFIG_FLAGS.values())
+
+
+def add_config_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the ``NANVIX_*`` config override flags on *parser*.
+
+    Each flag stores into a ``dest`` equal to its config key (e.g.
+    ``--machine`` -> ``NANVIX_MACHINE``) so callers can read the provided
+    value back by key.
+    """
+    for flag, (key, enum_cls) in _CONFIG_FLAGS.items():
+        parser.add_argument(
+            flag,
+            dest=key,
+            default=None,
+            choices=[member.value for member in enum_cls],
+            help=CONFIG_DESCRIPTIONS.get(key, ""),
+        )
+
 
 def build_parser(
     prog: str | None = None,
@@ -189,6 +232,7 @@ def build_parser(
 
     for name in cmds:
         sub = subparsers.add_parser(name, help=SUBCOMMAND_HELP[name])
+        add_config_flags(sub)
         if name == "lock":
             lock_group = sub.add_mutually_exclusive_group()
             lock_group.add_argument(

--- a/src/nanvix_zutil/config.py
+++ b/src/nanvix_zutil/config.py
@@ -3,12 +3,16 @@
 
 """Persistent key-value configuration for nanvix_zutil consumers.
 
-Configuration is stored at ``.nanvix/env.json`` and overridden by environment
-variables at runtime.  The precedence order (highest to lowest) is:
+Configuration is stored at ``.nanvix/env.json``.  The config knobs
+(host/target/machine/deployment-mode/memory-size) are set via CLI flags and
+persisted here; ``GH_TOKEN`` is the sole remaining environment variable.  The
+precedence order (highest to lowest) is:
 
-1. Environment variables
+1. CLI flags (applied by :meth:`ZScript.main` via :meth:`Config.set`)
 2. Persisted ``.nanvix/env.json``
 3. Built-in defaults
+
+(``GH_TOKEN`` is read from the environment on demand and never persisted.)
 """
 
 from __future__ import annotations
@@ -111,17 +115,22 @@ CFG_GH_TOKEN: str = "GH_TOKEN"
 CFG_DOCKER_IMAGE: str = "NANVIX_DOCKER_IMAGE"
 """Docker image persisted by ``setup --with-docker``."""
 
-#: Curated mapping of the most common environment variables recognised by
-#: nanvix-zutil to human-readable descriptions.  Rendered in the ``--help``
-#: epilog.  Not exhaustive — consumers and other modules may honour additional
-#: ``NANVIX_*`` variables recognised by manifest/script modules.
-ENV_VARS: dict[str, str] = {
+#: Human-readable descriptions for the ``NANVIX_*`` config knobs.  These are
+#: set via CLI flags (see :func:`nanvix_zutil.cli.add_config_flags`); the text is
+#: reused as flag help.  Rendered nowhere as environment variables — the knobs
+#: are no longer read from the environment (see #203).
+CONFIG_DESCRIPTIONS: dict[str, str] = {
     "NANVIX_HOST": f"Development host (default: {DEFAULT_HOST}; one of: {', '.join(Host)})",
     "NANVIX_TARGET": f"Target architecture (default: {DEFAULT_TARGET}; one of: {', '.join(Target)})",
     "NANVIX_MACHINE": f"Target machine (default: {DEFAULT_MACHINE}; one of: {', '.join(Machine)})",
     "NANVIX_DEPLOYMENT_MODE": f"Deployment mode (default: {DEFAULT_DEPLOYMENT_MODE}; one of: {', '.join(DeploymentMode)})",
     "NANVIX_MEMORY_SIZE": f"Memory size for artifact naming (default: {DEFAULT_MEMORY_SIZE}; one of: {', '.join(MemorySize)})",
-    "NANVIX_SYSROOT": "Path to runtime sysroot (set by setup)",
+}
+
+#: Environment variables still honoured at runtime.  The config knobs moved to
+#: CLI flags (#203); only secrets remain env-only.  Values here are read from
+#: the environment by :meth:`Config.get`.
+ENV_VARS: dict[str, str] = {
     "GH_TOKEN": "GitHub token for API rate limits",
 }
 
@@ -139,12 +148,11 @@ class Config:
     1. Seed with built-in defaults.
     2. Override with values from the persisted ``.nanvix/env.json`` file,
        if it exists.
-    3. Override with environment variables for known keys listed in
-       :data:`ENV_VARS`, which always take precedence.
 
-    Effective precedence (highest to lowest) is therefore:
+    CLI flags are applied on top by :meth:`ZScript.main` via :meth:`set`,
+    so the effective precedence (highest to lowest) is:
 
-    1. Environment variables
+    1. CLI flags
     2. Persisted ``.nanvix/env.json``
     3. Built-in defaults
 
@@ -174,20 +182,11 @@ class Config:
         # Seed with defaults.
         self._data.update(_DEFAULTS)
 
-        # Load persisted values (environment still wins below).
+        # Load persisted values.
         if self._config_path.exists():
             self.load()
             # Never persist secrets such as GH_TOKEN; strip if present.
             self._data.pop("GH_TOKEN", None)
-
-        # Apply environment variable overrides for known keys.
-        for key in ENV_VARS:
-            # Never persist secrets such as GH_TOKEN.
-            if key == CFG_GH_TOKEN:
-                continue
-            env_val = os.environ.get(key)
-            if env_val is not None:
-                self._data[key] = env_val
 
         # Validate enum-typed keys; fatal on invalid.
         for key, enum_cls in _ENUMS.items():
@@ -249,8 +248,8 @@ class Config:
     def get(self, key: str, default: str | None = None) -> str | None:
         """Retrieve a configuration value.
 
-        Environment variables take precedence, but only for known keys
-        listed in :data:`ENV_VARS`.
+        Environment variables take precedence only for the keys in
+        :data:`ENV_VARS` (currently just ``GH_TOKEN``).
 
         Args:
             key: The configuration key.
@@ -310,7 +309,7 @@ class Config:
             persisted = cast(dict[str, object], raw)
             for k, v in persisted.items():
                 if isinstance(v, str):
-                    # Environment variables still win for known keys.
+                    # GH_TOKEN wins from the environment even if persisted.
                     if k in ENV_VARS and os.environ.get(k) is not None:
                         continue
                     self._data[k] = v

--- a/src/nanvix_zutil/script.py
+++ b/src/nanvix_zutil/script.py
@@ -27,7 +27,6 @@ Invoke via the ``nanvix-zutil`` CLI::
 from __future__ import annotations
 
 import argparse
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -38,7 +37,7 @@ from nanvix_zutil.buildroot import (
     Dependency,
     RefKind,
 )
-from nanvix_zutil.cli import build_parser
+from nanvix_zutil.cli import CONFIG_FLAG_KEYS, build_parser
 from nanvix_zutil.config import CFG_DOCKER_IMAGE, CFG_GH_TOKEN, CFG_SYSROOT, Config
 from nanvix_zutil.docker import (
     SYSROOT_CONTAINER_PATH,
@@ -656,18 +655,15 @@ class ZScript:
             framework_argv = argv
             targets = []
 
-        # Pre-parse --version and --mode before creating the instance so
-        # that --version can exit cleanly without requiring a valid manifest,
-        # and so that --mode can override NANVIX_DEPLOYMENT_MODE before
-        # Config.__init__ runs.
+        # Pre-parse --version before creating the instance so it can exit
+        # cleanly without requiring a valid manifest.
         pre_parser = argparse.ArgumentParser(add_help=False)
         pre_parser.add_argument(
             "--version",
             action="version",
             version=f"%(prog)s (nanvix-zutil {get_zutil_version()})",
         )
-        pre_parser.add_argument("--mode", default=None, dest="mode")
-        pre_args, _ = pre_parser.parse_known_args(framework_argv)
+        pre_parser.parse_known_args(framework_argv)
 
         # Detect --help/-h and the 'help' subcommand (or no subcommand at
         # all) BEFORE loading the manifest.  A missing nanvix.toml must not
@@ -685,14 +681,6 @@ class ZScript:
             build_parser().print_help()  # 'help' subcommand or no args
             return
 
-        # ------------------------------------------------------------------
-        # Handle --mode: override NANVIX_DEPLOYMENT_MODE before Config
-        # __init__ reads it during instance construction.
-        # ------------------------------------------------------------------
-        cli_mode = getattr(pre_args, "mode", None)
-        if cli_mode is not None:
-            os.environ["NANVIX_DEPLOYMENT_MODE"] = cli_mode
-
         instance = cls()
         instance.targets = targets
 
@@ -700,6 +688,16 @@ class ZScript:
         # consumer hooks only appear when the subclass overrides them.
         parser = build_parser(available=instance.available_subcommands())
         args = parser.parse_args(framework_argv)
+
+        # ------------------------------------------------------------------
+        # Apply NANVIX_* config flags (e.g. --machine, --mode) to the config.
+        # These replace the legacy environment variables; GH_TOKEN stays an
+        # environment variable.
+        # ------------------------------------------------------------------
+        for key in CONFIG_FLAG_KEYS:
+            val = getattr(args, key, None)
+            if val is not None:
+                instance.config.set(key, val)
 
         # ------------------------------------------------------------------
         # Handle --offline, --with-nanvix from CLI.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from nanvix_zutil.cli import SUBCOMMANDS, build_parser
+from nanvix_zutil.cli import SUBCOMMANDS, CONFIG_FLAG_KEYS, build_parser
 
 
 class TestBuildParser(unittest.TestCase):
@@ -47,6 +47,26 @@ class TestBuildParser(unittest.TestCase):
         parser = build_parser()
         with self.assertRaises(SystemExit):
             parser.parse_args(["distclean"])
+
+    def test_config_flags_parse_into_config_keys(self) -> None:
+        """Config flags store into their NANVIX_* dest on each subcommand."""
+        parser = build_parser(available=("build",))
+        args = parser.parse_args(
+            ["build", "--machine", "microvm", "--mode", "standalone"]
+        )
+        self.assertEqual(getattr(args, "NANVIX_MACHINE"), "microvm")
+        self.assertEqual(getattr(args, "NANVIX_DEPLOYMENT_MODE"), "standalone")
+
+    def test_config_flags_default_to_none(self) -> None:
+        parser = build_parser(available=("build",))
+        args = parser.parse_args(["build"])
+        for key in CONFIG_FLAG_KEYS:
+            self.assertIsNone(getattr(args, key))
+
+    def test_config_flag_rejects_invalid_choice(self) -> None:
+        parser = build_parser(available=("build",))
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["build", "--machine", "bogus"])
 
     def test_available_param_restricts_subcommands(self) -> None:
         """build_parser(available=...) registers only the given subcommands."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,7 +63,9 @@ class TestConfigEnums(unittest.TestCase):
         import sys
 
         other = Host.linux if sys.platform == "win32" else Host.windows
-        os.environ["NANVIX_HOST"] = other.value
+        (nanvix_root() / "env.json").write_text(
+            json.dumps({"NANVIX_HOST": other.value}), encoding="utf-8"
+        )
         cfg = Config()
         self.assertIs(cfg.host, other)
 
@@ -86,10 +88,12 @@ class TestConfigValidation(unittest.TestCase):
     def test_invalid_value_is_fatal_for_every_enum_key(self) -> None:
         for key in self._KEYS:
             with self.subTest(key=key):
-                os.environ[key] = "not-a-real-value"
+                (nanvix_root() / "env.json").write_text(
+                    json.dumps({key: "not-a-real-value"}), encoding="utf-8"
+                )
                 with self.assertRaises(SystemExit):
                     Config()
-                os.environ.pop(key, None)
+        (nanvix_root() / "env.json").unlink(missing_ok=True)
 
 
 class TestConfigDefaults(unittest.TestCase):
@@ -114,14 +118,13 @@ class TestConfigDefaults(unittest.TestCase):
         self.assertEqual(cfg.memory_size, "256mb")
 
 
-class TestConfigEnvOverride(unittest.TestCase):
-    """Environment variables override defaults and persisted values."""
+class TestConfigPersistedOverride(unittest.TestCase):
+    """Persisted env.json values override defaults."""
 
-    def tearDown(self) -> None:
-        os.environ.pop("NANVIX_MACHINE", None)
-
-    def test_env_overrides_default(self) -> None:
-        os.environ["NANVIX_MACHINE"] = "microvm"
+    def test_persisted_overrides_default(self) -> None:
+        (nanvix_root() / "env.json").write_text(
+            json.dumps({"NANVIX_MACHINE": "microvm"}), encoding="utf-8"
+        )
         cfg = Config()
         self.assertEqual(cfg.machine, "microvm")
 

--- a/tests/test_release_cmd.py
+++ b/tests/test_release_cmd.py
@@ -9,22 +9,12 @@ import sys
 import unittest
 from io import StringIO
 from pathlib import Path
-from unittest.mock import patch
 
 from nanvix_zutil import paths
 from nanvix_zutil.commands import release as release_cmd
+from nanvix_zutil.config import Config
 from nanvix_zutil.exitcodes import EXIT_GENERAL_ERROR
 from tests.testutils import write_manifest
-
-# Pin every config-level knob so archive names are deterministic
-# regardless of the developer's ambient environment.
-_PINNED_ENV = {
-    "NANVIX_HOST": "linux",
-    "NANVIX_TARGET": "x86",
-    "NANVIX_MACHINE": "microvm",
-    "NANVIX_DEPLOYMENT_MODE": "standalone",
-    "NANVIX_MEMORY_SIZE": "256mb",
-}
 
 _BASE = "test-linux-x86-microvm-standalone-256mb"
 
@@ -32,9 +22,18 @@ _BASE = "test-linux-x86-microvm-standalone-256mb"
 class _ReleaseTestBase(unittest.TestCase):
     def setUp(self) -> None:
         write_manifest()  # manifest name = "test"
-        env_patch = patch.dict("os.environ", _PINNED_ENV, clear=False)
-        env_patch.start()
-        self.addCleanup(env_patch.stop)
+        # Pin every config knob to env.json so archive names are deterministic
+        # regardless of the host platform's defaults.
+        cfg = Config()
+        for key, val in {
+            "NANVIX_HOST": "linux",
+            "NANVIX_TARGET": "x86",
+            "NANVIX_MACHINE": "microvm",
+            "NANVIX_DEPLOYMENT_MODE": "standalone",
+            "NANVIX_MEMORY_SIZE": "256mb",
+        }.items():
+            cfg.set(key, val)
+        cfg.save()
 
     def _stage(self, subdir: str) -> Path:
         d = paths.staging_dir() / subdir
@@ -92,11 +91,11 @@ class TestReleaseHostExtension(_ReleaseTestBase):
     """Extension is gated on Config.host."""
 
     def test_windows_uses_zip(self) -> None:
-        env = dict(_PINNED_ENV)
-        env["NANVIX_HOST"] = "windows"
-        with patch.dict("os.environ", env, clear=False):
-            self._stage("regular")
-            release_cmd.release()
+        cfg = Config()
+        cfg.set("NANVIX_HOST", "windows")
+        cfg.save()
+        self._stage("regular")
+        release_cmd.release()
         produced = {p.name for p in paths.dist_dir().iterdir()}
         self.assertEqual(
             produced,

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -2136,5 +2136,33 @@ class TestInstallArtifacts(unittest.TestCase):
         self.assertTrue(target.is_dir())
 
 
+class TestZScriptConfigFlags(unittest.TestCase):
+    """NANVIX_* config flags passed on the CLI reach Config."""
+
+    def setUp(self) -> None:
+        write_manifest()
+        for key in ("NANVIX_HOST", "NANVIX_MACHINE", "NANVIX_DEPLOYMENT_MODE"):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("NANVIX_HOST", None)
+
+    def test_host_flag_overrides_config(self) -> None:
+        """``--host`` overrides the platform default before Config reads it."""
+        captured: list[str] = []
+
+        class _Consumer(ZScript):
+            def test(self) -> None:
+                captured.append(str(self.config.host))
+
+        with (
+            patch("sys.argv", ["z.py", "test", "--host", "windows"]),
+            patch("nanvix_zutil.script.log"),
+        ):
+            _Consumer.main()
+
+        self.assertEqual(captured, ["windows"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# [zutils] E: config knobs via flags, not env vars

Closes #203.

The build config knobs were env-var-only, and the one flag that existed
(`--mode`) was broken (registered in a pre-parser, rejected by the real one).
Now they're proper CLI flags and the env vars are gone.

**BREAKING:** `NANVIX_HOST/TARGET/MACHINE/DEPLOYMENT_MODE/MEMORY_SIZE` are no
longer read from the environment. Use the flags instead (passed after the
subcommand, e.g. `./z build --machine microvm`). `GH_TOKEN` stays an env var.

Precedence: flags > `.nanvix/env.json` > defaults. `setup` persists; other
subcommands apply per-invocation.

## Changes

- `add_config_flags()` in cli.py registers `--host/--target/--machine/--mode/--memory-size` on every subcommand (choices from the config enums).
- `main()` applies them via `Config.set` after parse; dropped the `--mode` → `os.environ` bridge.
- `ENV_VARS` shrunk to `GH_TOKEN`; dead env-override loop removed; knob help moved to `CONFIG_DESCRIPTIONS`.
- Tests migrated off env vars; docs updated.
