### PR TITLE
[zutils] Only expose flags to setup

### DIFF
--- a/src/nanvix_zutil/cli.py
+++ b/src/nanvix_zutil/cli.py
@@ -164,6 +164,10 @@ def add_config_flags(parser: argparse.ArgumentParser) -> None:
     Each flag stores into a ``dest`` equal to its config key (e.g.
     ``--machine`` -> ``NANVIX_MACHINE``) so callers can read the provided
     value back by key.
+
+    Only ever registered on the ``setup`` subcommand: values are persisted
+    to ``.nanvix/env.json`` during setup, and later subcommands read them
+    back from config without repeating the flags.
     """
     for flag, (key, enum_cls) in _CONFIG_FLAGS.items():
         parser.add_argument(
@@ -232,7 +236,8 @@ def build_parser(
 
     for name in cmds:
         sub = subparsers.add_parser(name, help=SUBCOMMAND_HELP[name])
-        add_config_flags(sub)
+        if name == "setup":
+            add_config_flags(sub)
         if name == "lock":
             lock_group = sub.add_mutually_exclusive_group()
             lock_group.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,24 +49,30 @@ class TestBuildParser(unittest.TestCase):
             parser.parse_args(["distclean"])
 
     def test_config_flags_parse_into_config_keys(self) -> None:
-        """Config flags store into their NANVIX_* dest on each subcommand."""
-        parser = build_parser(available=("build",))
+        """Config flags are setup-only: they store into their NANVIX_* dest."""
+        parser = build_parser(available=("setup",))
         args = parser.parse_args(
-            ["build", "--machine", "microvm", "--mode", "standalone"]
+            ["setup", "--machine", "microvm", "--mode", "standalone"]
         )
         self.assertEqual(getattr(args, "NANVIX_MACHINE"), "microvm")
         self.assertEqual(getattr(args, "NANVIX_DEPLOYMENT_MODE"), "standalone")
 
     def test_config_flags_default_to_none(self) -> None:
-        parser = build_parser(available=("build",))
-        args = parser.parse_args(["build"])
+        parser = build_parser(available=("setup",))
+        args = parser.parse_args(["setup"])
         for key in CONFIG_FLAG_KEYS:
             self.assertIsNone(getattr(args, key))
 
     def test_config_flag_rejects_invalid_choice(self) -> None:
+        parser = build_parser(available=("setup",))
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["setup", "--machine", "bogus"])
+
+    def test_config_flags_not_available_outside_setup(self) -> None:
+        """build/test/etc. don't accept config flags; only setup persists them."""
         parser = build_parser(available=("build",))
         with self.assertRaises(SystemExit):
-            parser.parse_args(["build", "--machine", "bogus"])
+            parser.parse_args(["build", "--machine", "microvm"])
 
     def test_available_param_restricts_subcommands(self) -> None:
         """build_parser(available=...) registers only the given subcommands."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -2147,21 +2147,19 @@ class TestZScriptConfigFlags(unittest.TestCase):
     def tearDown(self) -> None:
         os.environ.pop("NANVIX_HOST", None)
 
-    def test_host_flag_overrides_config(self) -> None:
-        """``--host`` overrides the platform default before Config reads it."""
-        captured: list[str] = []
-
-        class _Consumer(ZScript):
-            def test(self) -> None:
-                captured.append(str(self.config.host))
-
+    def test_host_flag_persists_from_setup(self) -> None:
+        """``--host`` is setup-only: it persists to .nanvix/env.json there,
+        so a later Config() (as any other subcommand would construct) sees
+        it without repeating the flag.
+        """
         with (
-            patch("sys.argv", ["z.py", "test", "--host", "windows"]),
-            patch("nanvix_zutil.script.log"),
+            patch("sys.argv", ["z.py", "setup", "--host", "windows"]),
+            patch.object(ZScript, "setup", return_value=False),
+            patch("nanvix_zutil.script.check_docker"),
         ):
-            _Consumer.main()
+            ZScript.main()
 
-        self.assertEqual(captured, ["windows"])
+        self.assertEqual(Config().host, "windows")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit fixes a bug where mode flags were exposed to all ZScript-dependent steps. Now they are only exposed to setup. All other steps expect these values to be set during setup and persisted in env.json.